### PR TITLE
Add script to determine if the kernel has the needed options.

### DIFF
--- a/kernel-check.sh
+++ b/kernel-check.sh
@@ -35,8 +35,13 @@ if [ "$(parse_version "${KERNEL_VERSION}")" -lt "$(parse_version 4.14)" ] ; then
 fi
 
 CONFIG_PATH=""
+MODULE_LOADED=""
 
-if [ -r /proc/config.gz ] || modprobe configs 2> /dev/null ; then
+if modprobe configs 2> /dev/null ; then
+    MODULE_LOADED=1
+fi
+
+if [ -r /proc/config.gz ] ; then
     CONFIG_PATH="/proc/config.gz"
 elif [ -r "/lib/modules/${KERNEL_VERSION}/source/.config" ] ; then
     CONFIG_PATH="/lib/modules/${KERNEL_VERSION}/source/.config"
@@ -60,4 +65,8 @@ if [ -n "${CONFIG_PATH}" ] ; then
         echo "Required kernel config options not found."
         exit 1
     fi
+fi
+
+if [ -n "${MODULE_LOADED}" ] ; then
+    modprobe -r configs 2> /dev/null
 fi

--- a/kernel-check.sh
+++ b/kernel-check.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+if [ "$(uname -s)" != "Linux" ] ; then
+    echo "This does not appear to be a Linux system."
+    exit 1
+fi
+
+KERNEL_VERSION="$(uname -r)"
+KERNEL_VERSION_MAJOR="$(uname -r | cut -f 1 -d '.')"
+KERNEL_VERSION_MINOR="$(uname -r | cut -f 2 -d '.')"
+
+# This insane looking condition is checking the kernel version as a floating point number.
+if [ "$(echo "${KERNEL_VERSION_MAJOR}.${KERNEL_VERSION_MINOR}" 4.11 | awk '{if ($1 < $2) print $1; else print $2}')" != "4.11" ] ; then
+    echo "Your kernel appears to be older than 4.11. This may still work in some cases, but probably won't."
+fi
+
+CONFIG_PATH=""
+
+if [ -r /proc/config.gz ] || modprobe configs 2> /dev/null ; then
+    CONFIG_PATH="/proc/config.gz"
+elif [ -r "/lib/modules/${KERNEL_VERSION}/source/.config" ] ; then
+    CONFIG_PATH="/lib/modules/${KERNEL_VERSION}/source/.config"
+elif [ -n "$(find /boot -name "config-${KERNEL_VERSION}*")" ] ; then
+    CONFIG_PATH="$(find /boot -name "config-${KERNEL_VERSION}*" | head -n 1)"
+fi
+
+if [ -n "${CONFIG_PATH}" ] ; then
+    if echo "${CONFIG_PATH}" | grep -q '.gz' ; then
+        zcat "${CONFIG_PATH}" > /tmp/config
+        CONFIG_PATH=/tmp/config
+    fi
+
+    if grep -qv "CONFIG_KPROBES=y" "${CONFIG_PATH}" || \
+       grep -qv "CONFIG_KPROBES_ON_FTRACE=y" "${CONFIG_PATH}" || \
+       grep -qv "CONFIG_HAVE_KPROBES=y" "${CONFIG_PATH}" || \
+       grep -qv "CONFIG_HAVE_KPROBES_ON_FTRACE=y" "${CONFIG_PATH}" || \
+       grep -qv "CONFIG_KPROBE_EVENTS=y" "${CONFIG_PATH}"
+    then
+        echo "Required kernel config options not found."
+        exit 1
+    fi
+
+    if [ "${CONFIG_PATH}" = /tmp/config ] ; then
+        rm /tmp/config
+    fi
+fi

--- a/kernel-check.sh
+++ b/kernel-check.sh
@@ -45,22 +45,19 @@ elif [ -n "$(find /boot -name "config-${KERNEL_VERSION}*")" ] ; then
 fi
 
 if [ -n "${CONFIG_PATH}" ] ; then
+    GREP='grep'
+
     if echo "${CONFIG_PATH}" | grep -q '.gz' ; then
-        zcat "${CONFIG_PATH}" > /tmp/config
-        CONFIG_PATH=/tmp/config
+        GREP='zgrep'
     fi
 
-    if grep -qv "CONFIG_KPROBES=y" "${CONFIG_PATH}" || \
-       grep -qv "CONFIG_KPROBES_ON_FTRACE=y" "${CONFIG_PATH}" || \
-       grep -qv "CONFIG_HAVE_KPROBES=y" "${CONFIG_PATH}" || \
-       grep -qv "CONFIG_HAVE_KPROBES_ON_FTRACE=y" "${CONFIG_PATH}" || \
-       grep -qv "CONFIG_KPROBE_EVENTS=y" "${CONFIG_PATH}"
+    if "${GREP}" -qv "CONFIG_KPROBES=y" "${CONFIG_PATH}" || \
+       "${GREP}" -qv "CONFIG_KPROBES_ON_FTRACE=y" "${CONFIG_PATH}" || \
+       "${GREP}" -qv "CONFIG_HAVE_KPROBES=y" "${CONFIG_PATH}" || \
+       "${GREP}" -qv "CONFIG_HAVE_KPROBES_ON_FTRACE=y" "${CONFIG_PATH}" || \
+       "${GREP}" -qv "CONFIG_KPROBE_EVENTS=y" "${CONFIG_PATH}"
     then
         echo "Required kernel config options not found."
         exit 1
-    fi
-
-    if [ "${CONFIG_PATH}" = /tmp/config ] ; then
-        rm /tmp/config
     fi
 fi


### PR DESCRIPTION
Exits with a non-zero exit code if the system's kernel doesn't support eBPF collector requirements.

This only issues warnings if the kernel version is too old, because RHEL/CentOS are questionable and use ancient kernel version numbers even though they have very new features.

This first checks if we're running on Linux, and bails early if we aren't.

Once checking the version and possibly issuing a warning, it then looks for the configuration in the following places, using the first it finds:

* `/proc/config.gz`: This is provided by the running kernel, but requires the kernel to have been configured to provide it (it may also need a module to be loaded, which we try to do if we can't find the file).
* `/lib/modules/${KERNEL_VERSION}/sources/.config`: This is provided by locally built kernels when the source and build directory are still present on the system.
* `/boot/config-${KERNEL_VERSION}`: This is provided by the kernel packages on a number of Linux distributions.

If it can find the config, it uses grep to check for all the required options being enabled.

if it can't find the config, it assumes things will work, and exits with 0.