### PR TITLE
Sets prerelease to false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,7 @@ jobs:
           # TODO: Generate ChagneLog here for Release Description
           body: Release ${{ github.ref }}
           draft: false
-          # TODO: Set this based on tag names
-          # v0.0.0-rc => prerelease: true
-          prerelease: true  # TODO: Change this to `false` later.
+          prerelease: false
       - name: Write upload_url
         run: |
           mkdir -p upload_url


### PR DESCRIPTION
See https://developer.github.com/v3/repos/releases/#get-the-latest-release

Releaseing non-full releases isn't that useful if I want to easily get the
latest release from ghte Github API which I'll need to use from the NetData
Installer.