### PR TITLE
Disable dev mode

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -50,14 +50,14 @@ all: process_kern.o
 		-DNETDATASEL=0 \
 		-O2 -emit-llvm -c $<
 	$(LLC) -march=bpf -filetype=obj -o r$@ $(<:.c=.ll)
-	$(CLANG) $(EXTRA_CFLAGS) -S -nostdinc $(LINUXINCLUDE) $(LLVM_INCLUDES) \
-		-D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
-	    	-Wno-compare-distinct-pointer-types \
-	    	-Wno-gnu-variable-sized-type-not-at-end \
-	    	-Wno-tautological-compare \
-		-DNETDATASEL=1 \
-		-O2 -emit-llvm -c $<
-	$(LLC) -march=bpf -filetype=obj -o d$@ $(<:.c=.ll)
+	#$(CLANG) $(EXTRA_CFLAGS) -S -nostdinc $(LINUXINCLUDE) $(LLVM_INCLUDES) \
+	#	-D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
+	#    	-Wno-compare-distinct-pointer-types \
+	#    	-Wno-gnu-variable-sized-type-not-at-end \
+	#    	-Wno-tautological-compare \
+	#	-DNETDATASEL=1 \
+	#	-O2 -emit-llvm -c $<
+	#$(LLC) -march=bpf -filetype=obj -o d$@ $(<:.c=.ll)
 	$(CLANG) $(EXTRA_CFLAGS) -S -nostdinc $(LINUXINCLUDE) $(LLVM_INCLUDES) \
 		-D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
 	    	-Wno-compare-distinct-pointer-types \

--- a/user/Makefile
+++ b/user/Makefile
@@ -16,7 +16,7 @@ _LIBC ?= glibc
 all: $(OBJECT_LIBLOAD) $(KERNEL_PROGRAM)
 	cp $(KERNEL_DIR)rprocess_kern.o rnetdata_ebpf_process.o
 	cp $(KERNEL_DIR)pprocess_kern.o pnetdata_ebpf_process.o
-	cp $(KERNEL_DIR)dprocess_kern.o dnetdata_ebpf_process.o
+	#cp $(KERNEL_DIR)dprocess_kern.o dnetdata_ebpf_process.o
 	$(CC) -L. -I../includes/ -o process_monitor process_user.c $(LIBS)
 	if [ -f /usr/lib64/libbpf_kernel.so ]; then tar -acf ../artifacts/netdata_ebpf-$(NETDATA_KERNEL_VERSION)-$(_LIBC).tar.xz /usr/lib64/libbpf_kernel.so* libnetdata_ebpf.so *netdata_ebpf_process.o; elif [ -f /usr/lib/libbpf_kernel.so ]; then tar -acf ../artifacts/netdata_ebpf-$(NETDATA_KERNEL_VERSION)-$(_LIBC).tar.xz /usr/lib/libbpf_kernel.so* libnetdata_ebpf.so *netdata_ebpf_process.o; else echo "ERROR: Cannot find libbpf_kernel.so"; exit 1; fi
 


### PR DESCRIPTION
We won't deliver in the first version of eBPF collector the developer mode, so I am disabling its compilation. 