### PR TITLE
Check before unmap

### DIFF
--- a/user/process_user.c
+++ b/user/process_user.c
@@ -75,9 +75,12 @@ static int unmap_memory() {
     int i;
     int size = (int)sysconf(_SC_PAGESIZE)*(page_cnt + 1);
     for ( i = 0 ; i < nprocs ; i++ ) {
-        if (perf_event_unmap(headers[i], size) < 0) {
-            fprintf(stderr,"[EBPF PROCESS] CANNOT unmap headers.\n");
-            return -1;
+        if(headers[i])
+        {
+            if (perf_event_unmap(headers[i], size) < 0) {
+                fprintf(stderr,"[EBPF PROCESS] CANNOT unmap headers.\n");
+                return -1;
+            }
         }
 
         close(pmu_fd[i]);


### PR DESCRIPTION
This commit brings a missing check before to unmap the memory when there is an error.