### PR TITLE
Fix wrong variable length

### DIFF
--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -90,7 +90,7 @@ static void netdata_update_u64(u64 *res, u64 value)
 
 static void netdata_update_global(__u32 key, __u64 value)
 {
-    u32 *res;
+    u64 *res;
     res = bpf_map_lookup_elem(&tbl_total_stats, &key);
     if (res) {
         netdata_update_u64(res, value) ;


### PR DESCRIPTION
During the update of the index size, there was a variable that was not resized,
this PR fixes this