### PR TITLE
Update Release workflow to accomodate new packaging format for Netdata eBPF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,10 @@
 ---
 name: CI
 on:
-  push:
-    branches:
-      - master
   pull_request:
 jobs:
-  build:
-    name: Build
+  build-artifacts:
+    name: Build Artifacts
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
     tags:
       - 'v*'
 jobs:
-  build:
-    name: Build
+  build-artifacts:
+    name: Build Artifacts
     strategy:
       matrix:
         kernel_version:
@@ -54,9 +54,9 @@ jobs:
           name: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
           path: artifacts
 
-  release:
-    name: Release
-    needs: build
+  create-release:
+    name: Create Release
+    needs: build-artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
@@ -81,9 +81,9 @@ jobs:
           name: upload_url
           path: upload_url
 
-  upload:
-    name: Upload
-    needs: release
+  package-upload:
+    name: Package & Upload
+    needs: create-release
     runs-on: ubuntu-latest
     steps:
       - name: Download upload_url
@@ -93,6 +93,9 @@ jobs:
       - name: Set upload_url
         run: |
           echo "::set-env name=UPLOAD_URL::$(cat upload_url/upload_url.txt)"
+      - name: Set release_tag
+        run: |
+          echo "::set-env name=RELEASE_TAG::${GITHUB_REF##*/}"
       - name: Download all Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -100,24 +103,44 @@ jobs:
       - name: Display Artifacts
         run: ls -R
         working-directory: artifacts
-      - name: Package Relase Assets
+      - name: Package Release Assets
         run: |
-          mkdir -p packages/netdata-kernel-collector-glibc-${GITHUB_REF##*/}
-          mkdir -p packages/netdata-kernel-collector-musl-${GITHUB_REF##*/}
+          mkdir -p packages/netdata-kernel-collector-glibc-${RELEASE_TAG}
+          mkdir -p packages/netdata-kernel-collector-musl-${RELEASE_TAG}
           for libc in glibc musl; do
             for dir in artifacts/artifacts-*-"$libc"; do
-              tar -C packages/netdata-kernel-collector-"$libc"-${GITHUB_REF##*/} -xvf "$dir"/*.tar.xz
+              tar -C packages/netdata-kernel-collector-"$libc"-${RELEASE_TAG} -xvf "$dir"/*.tar.xz
             done
+            tar -C packages/netdata-kernel-collector-"$libc"-${RELEASE_TAG} -Jcvf packages/netdata-kernel-collector-"$libc"-${RELEASE_TAG}.tar.xz ./
           done
-      - name: Display Assets
+          cd packages && sha256sum *.tar.xz > sha256sums.txt
+      - name: Display Release Assets
         run: ls -R
         working-directory: packages
-  #      - name: Upload Release Asset ${{ steps.asset-filename.outputs.name }}
-  #      uses: actions/upload-release-asset@v1
-  #      env:
-  #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #      with:
-  #        upload_url: ${{ env.UPLOAD_URL }}
-  #        asset_path: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}/${{ steps.asset-filename.outputs.name }}
-  #        asset_name: ${{ steps.asset-filename.outputs.name }}
-  #        asset_content_type: application/x-gtar
+      - name: Upload Release Assets (glibc)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: packages/netdata-kernel-collector-glibc-${{ env.RELEASE_TAG }}.tar.xz
+          asset_name: netdata-kernel-collector-glibc-${{ env.RELEASE_TAG }}.tar.xz
+          asset_content_type: application/x-gtar
+      - name: Upload Release Assets (musl)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: packages/netdata-kernel-collector-musl-${{ env.RELEASE_TAG }}.tar.xz
+          asset_name: netdata-kernel-collector-musl-${{ env.RELEASE_TAG }}.tar.xz
+          asset_content_type: application/x-gtar
+      - name: Upload Release Assets (sha256sums)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: packages/sha256sums.txt
+          asset_name: sha256sums.txt
+          asset_content_type: text/plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Set upload_url
         run: |
           echo "::set-env name=UPLOAD_URL::$(cat upload_url/upload_url.txt)"
-
       - name: Download all Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -101,7 +100,18 @@ jobs:
       - name: Display Artifacts
         run: ls -R
         working-directory: artifacts
-
+      - name: Package Relase Assets
+        run: |
+          mkdir -p packages/netdata-kernel-collector-glibc-${GITHUB_REF##*/}
+          mkdir -p packages/netdata-kernel-collector-musl-${GITHUB_REF##*/}
+          for libc in glibc musl; do
+            for dir in artifacts/artifacts-*-"$libc"; do
+              tar -C packages/netdata-kernel-collector-"$libc"-${GITHUB_REF##*/} -xvf "$dir"/*.tar.xz
+            done
+          done
+      - name: Display Assets
+        run: ls -R
+        working-directory: packages
   #      - name: Upload Release Asset ${{ steps.asset-filename.outputs.name }}
   #      uses: actions/upload-release-asset@v1
   #      env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run buil.sh
+      - name: Run build.sh
         run: |
           if [ ${{ matrix.kernel_version }} = "4.18.0" ]; then
             os=centos8
@@ -84,24 +84,6 @@ jobs:
   upload:
     name: Upload
     needs: release
-    strategy:
-      matrix:
-        kernel_version:
-          - '5.4.20'
-          - '4.20.17'
-          - '4.18.0'
-          - '4.14.171'
-          - '3.10.0'
-        libc:
-          - glibc
-          - musl
-        exclude:
-          # excludes musl on 4.18.0
-          - kernel_version: 4.18.0
-            libc: musl
-          # excludes musl on 3.10.0
-          - kernel_version: 3.10.0
-            libc: musl
     runs-on: ubuntu-latest
     steps:
       - name: Download upload_url
@@ -111,34 +93,21 @@ jobs:
       - name: Set upload_url
         run: |
           echo "::set-env name=UPLOAD_URL::$(cat upload_url/upload_url.txt)"
-      - name: Download artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
-        uses: actions/download-artifact@v1
+
+      - name: Download all Artifacts
+        uses: actions/download-artifact@v2
         with:
-          name: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
-      - name: List Artifact artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
-        run: |
-          ls -lah artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
-      - name: Compute Asset Filename
-        id: asset-filename
-        run: |
-          cd artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
-          ls netdata_ebpf-*.tar.xz
-          echo "::set-output name=name::$(ls netdata_ebpf-*.tar.xz)"
-      - name: Upload Release Asset ${{ steps.asset-filename.outputs.name }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}/${{ steps.asset-filename.outputs.name }}
-          asset_name: ${{ steps.asset-filename.outputs.name }}
-          asset_content_type: application/x-gtar
-      - name: Upload Release Asset ${{ steps.asset-filename.outputs.name }}.sha256sum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}/${{ steps.asset-filename.outputs.name }}.sha256sum
-          asset_name: ${{ steps.asset-filename.outputs.name }}.sha256sum
-          asset_content_type: application/x-gtar
+          path: artifacts
+      - name: Display Artifacts
+        run: ls -R
+        working-directory: artifacts
+
+  #      - name: Upload Release Asset ${{ steps.asset-filename.outputs.name }}
+  #      uses: actions/upload-release-asset@v1
+  #      env:
+  #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #      with:
+  #        upload_url: ${{ env.UPLOAD_URL }}
+  #        asset_path: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}/${{ steps.asset-filename.outputs.name }}
+  #        asset_name: ${{ steps.asset-filename.outputs.name }}
+  #        asset_content_type: application/x-gtar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
     needs: build-artifacts
     runs-on: ubuntu-latest
     steps:
+      - name: Set release_tag
+        run: |
+          echo "::set-env name=RELEASE_TAG::${GITHUB_REF##*/}"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -68,8 +71,15 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           # TODO: Generate ChagneLog here for Release Description
-          body: Release ${{ github.ref }}
-          draft: false
+          body: |
+            # Release ${{ env.RELEASE_TAG }}
+
+            <!--- Summary of Release -->
+
+            ## Release Notes
+
+            <!--- Release Notes -->
+          draft: true
           prerelease: false
       - name: Write upload_url
         run: |

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ After this you can start the new collector `ebpf_program.plugin`.
 
 ## Releasing
 
-To release a new version and create a Github Release; create a Git tag like so:
+To release a new version and create a Github Release:
+
+1. Create a Git tag like so:
 
 ```sh
 $ TAG="v0.0.1"; git tag -a -s -m "Release ${TAG}" "${TAG}" && git push origin "${TAG}"
@@ -167,6 +169,10 @@ here at this time so the specific tagged versions is not so important.
 This will kick off a Github Action Workflow that will Rebuild the NetData eBPF
 Kernel Collector for all Kernel and LIBC variants, create a Github Release and
 upload all assets to the release to be consumed by anyone or the NetData Installer.
+
+2. Wait for the CD pipeline to finish in the Github Actions UI.
+3. Review the Release, Updates Release Notes, etc in the Github Releases UI.
+4. Push the "Publish Release" button in the Github Releases UI.
 
 ## Contribution
 


### PR DESCRIPTION
This eepends on #135 (_and also contains its squashed commit to avoid merge conflicts_).

There is a [v0.0.7](https://github.com/prologic/netdata-kernel-collector/releases/tag/v0.0.7)
release on my [fork](https://github.com/prologic/netdata-kernel-collector)
which can be used to test/verify the changes in this PR are correct/valid.