### PR TITLE
Fix Network Viewer Variables

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -227,9 +227,14 @@ static void update_socket_table(struct bpf_map_def *tbl, netdata_socket_idx_t *i
     netdata_socket_t *val;
     netdata_socket_t data = { };
 
+    if (protocol != 6 && protocol != 17)
+        return;
+
     val = (netdata_socket_t *) bpf_map_lookup_elem(tbl, idx);
     if (val) {
         update_socket_stats(val, sent, received);
+        if (protocol == 17)
+            val->removeme = 1;
     } else {
         data.first = bpf_ktime_get_ns();
         data.protocol = protocol;

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -37,11 +37,12 @@ typedef struct netdata_socket {
     __u64 pid_tgid;
     __u64 first;
     __u64 ct;
-    __u16 retransmit; //It is never used with UDP
     __u64 sent;
     __u64 recv;
+    __u16 retransmit; //It is never used with UDP
     __u8 protocol; //Should this to be in the index?
     __u8 removeme;
+    __u32 reserved;
 } netdata_socket_t;
 
 /**
@@ -156,9 +157,11 @@ static void netdata_update_u64(__u64 *res, __u64 value)
         return;
 
     __sync_fetch_and_add(res, value);
+    /*
     if ( (0xFFFFFFFFFFFFFFFF - *res) <= value) {
         *res = value;
     }
+    */
 }
 
 /*

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -157,11 +157,6 @@ static void netdata_update_u64(__u64 *res, __u64 value)
         return;
 
     __sync_fetch_and_add(res, value);
-    /*
-    if ( (0xFFFFFFFFFFFFFFFF - *res) <= value) {
-        *res = value;
-    }
-    */
 }
 
 /*


### PR DESCRIPTION
Fixes #166 

This PR is bringing the basis to read socket information.
We are splitting the probes for `tcp_sendmsg`, because when we read the argument given with `kretprobe` the number read does not match the bytes transmitted for the clients.
I am also using this PR to rename few hash tables that we access on user ring, because they had a name larger than the maximum number of bytes used for the command `bpftool`, this can be confirmed running the command `bpftool map show` . Considering that we will begin to use only libbpf to work direct with the eBPF programs, I am renaming it to avoid problems for us.