### PR TITLE
Fix socket read

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -225,9 +225,6 @@ static void update_socket_table(struct bpf_map_def *tbl, netdata_socket_idx_t *i
     netdata_socket_t *val;
     netdata_socket_t data = { };
 
-    if (protocol != 6 && protocol != 17)
-        return;
-
     val = (netdata_socket_t *) bpf_map_lookup_elem(tbl, idx);
     if (val) {
         update_socket_stats(val, sent, received);
@@ -267,30 +264,6 @@ static void update_pid_stats(__u32 pid, __u32 tgid, __u64 sent, __u64 received)
     }
 }
 
-/*
-The motive we are using different fields to read protocol
-https://github.com/iovisor/bcc/pull/1834/files
-*/
-static __u8 read_protocol_from_socket(struct sock *sk)
-{
-    __u8 protocol;
-    long sub;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__    
-    sub = 3;
-#else
-    sub = 1;
-#endif
-
-# if (LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0))    
-    bpf_probe_read(&protocol, 1, (void *)((long)&sk->sk_wmem_queued) - sub);
-# else
-    bpf_probe_read(&protocol, 1, (void *)((long)&sk->sk_gso_max_segs) - sub);
-# endif
-    
-    return protocol;
-}
-
-
 /************************************************************************************
  *     
  *                                 TCP Section
@@ -317,7 +290,6 @@ int netdata_rtcp_sendmsg(struct pt_regs* ctx)
 SEC("kprobe/tcp_sendmsg")
 int netdata_tcp_sendmsg(struct pt_regs* ctx)
 {
-    __u8 protocol;
     __u16 family;
     netdata_socket_idx_t idx = { };
     struct bpf_map_def *tbl;
@@ -335,8 +307,7 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_SENDMSG, (__u64)sent);
-    protocol = read_protocol_from_socket(&is->sk);
-    update_socket_table(tbl, &idx,(__u64) sent, 0, protocol);
+    update_socket_table(tbl, &idx,(__u64) sent, 0, 6);
     update_pid_stats(pid, tgid, (__u64)sent, 0);
 
     return 0;
@@ -348,7 +319,6 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
 SEC("kprobe/tcp_cleanup_rbuf")
 int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
 {
-    __u8 protocol;
     __u16 family;
     netdata_socket_idx_t idx = { };
     struct bpf_map_def *tbl;
@@ -371,8 +341,7 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_CLEANUP_RBUF, received);
-    protocol = read_protocol_from_socket(&is->sk);
-    update_socket_table(tbl, &idx, 0, received, protocol);
+    update_socket_table(tbl, &idx, 0, received, 6);
     update_pid_stats(pid, tgid, 0, received);
 
     return 0;
@@ -439,7 +408,6 @@ int trace_udp_recvmsg(struct pt_regs* ctx)
 SEC("kretprobe/udp_recvmsg")
 int trace_udp_ret_recvmsg(struct pt_regs* ctx)
 {
-    __u8 protocol;
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
@@ -470,8 +438,7 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_UDP_RECVMSG, received);
-    protocol = read_protocol_from_socket(&is->sk);
-    update_socket_table(tbl, &idx, 0, received, protocol);
+    update_socket_table(tbl, &idx, 0, received, 17);
 
     update_pid_stats(pid, tgid, 0, received);
 
@@ -491,7 +458,6 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
 #if NETDATASEL < 2
     int ret = (int)PT_REGS_RC(ctx);
 #endif
-    __u8 protocol;
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
@@ -512,8 +478,7 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     family =  set_idx_value(&idx, is);
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
-    protocol = read_protocol_from_socket(&is->sk);
-    update_socket_table(tbl, &idx, (__u64) sent, 0, protocol);
+    update_socket_table(tbl, &idx, (__u64) sent, 0, 17);
     update_pid_stats(pid, tgid, (__u64) sent, 0);
 
     netdata_update_global(NETDATA_KEY_BYTES_UDP_SENDMSG, (__u64) sent);

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -228,7 +228,7 @@ static void update_socket_table(struct bpf_map_def *tbl, netdata_socket_idx_t *i
     val = (netdata_socket_t *) bpf_map_lookup_elem(tbl, idx);
     if (val) {
         update_socket_stats(val, sent, received);
-        if (protocol == 17)
+        if (protocol == IPPROTO_UDP)
             val->removeme = 1;
     } else {
         data.first = bpf_ktime_get_ns();
@@ -307,7 +307,7 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_SENDMSG, (__u64)sent);
-    update_socket_table(tbl, &idx,(__u64) sent, 0, 6);
+    update_socket_table(tbl, &idx,(__u64) sent, 0, IPPROTO_TCP);
     update_pid_stats(pid, tgid, (__u64)sent, 0);
 
     return 0;
@@ -341,7 +341,7 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_CLEANUP_RBUF, received);
-    update_socket_table(tbl, &idx, 0, received, 6);
+    update_socket_table(tbl, &idx, 0, received, IPPROTO_TCP);
     update_pid_stats(pid, tgid, 0, received);
 
     return 0;
@@ -438,7 +438,7 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_UDP_RECVMSG, received);
-    update_socket_table(tbl, &idx, 0, received, 17);
+    update_socket_table(tbl, &idx, 0, received, IPPROTO_UDP);
 
     update_pid_stats(pid, tgid, 0, received);
 
@@ -478,7 +478,7 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     family =  set_idx_value(&idx, is);
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
-    update_socket_table(tbl, &idx, (__u64) sent, 0, 17);
+    update_socket_table(tbl, &idx, (__u64) sent, 0, IPPROTO_UDP);
     update_pid_stats(pid, tgid, (__u64) sent, 0);
 
     netdata_update_global(NETDATA_KEY_BYTES_UDP_SENDMSG, (__u64) sent);


### PR DESCRIPTION
I will give the suggestion for we test this PR with the latest Netdata released, for we also test `libbpf`.

1 - Do download of the files from the Action https://github.com/netdata/kernel-collector/actions/runs/174873726.
2 - Stop your Netdata.
3 - Extract them and copy all `eBPF` programs to  `/usr/libexec/netdata/plugins.d`
4 - Start Netdata again
5 - Run `bpftool map show` and see the id of the map `tbl_conn_ipv4`
6 - Confirm that data was stored inside the table running : `bpftool map dump 3`, here I am assuming the result of the previous command was `3: per_cpu_hash tbl_conn_ipv4`.

I tested these `eBPF` programs on kernels `5.7.9`, `5.4.52`, `4.19.133`, `4.16.18` and `4.14.188`. and I observed that we always had data inside the tables, previous this PR I had data only on kernel `5.4.x`.