### PR TITLE
Fix inbound/outbound classification 

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -29,7 +29,7 @@ union netdata_ip {
     __u8 addr8[16];
     __u16 addr16[8];
     __u32 addr32[4];
-    __u32 addr64[2];
+    __u64 addr64[2];
 };
 
 /**
@@ -53,9 +53,9 @@ typedef struct netdata_socket {
  */
 typedef struct netdata_socket_idx {
     union netdata_ip saddr;
+    __u16 sport;
     union netdata_ip daddr;
     __u16 dport;
-    __u16 sport;
 } netdata_socket_idx_t;
 
 /**
@@ -195,7 +195,6 @@ static __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *is)
     bpf_probe_read(&family, sizeof(u16), &is->sk.__sk_common.skc_family);
     // Read source and destination IPs
     if ( family == AF_INET ) { //AF_INET
-        //bpf_probe_read(&nsi->saddr.addr32[0], sizeof(u32), &is->inet_saddr);
         bpf_probe_read(&nsi->saddr.addr32[0], sizeof(u32), &is->inet_rcv_saddr);
         bpf_probe_read(&nsi->daddr.addr32[0], sizeof(u32), &is->inet_daddr);
 
@@ -221,7 +220,7 @@ static __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *is)
 
     //Read destination port
     bpf_probe_read(&nsi->dport, sizeof(u16), &is->inet_dport);
-    bpf_probe_read(&nsi->sport, sizeof(u16), &is->inet_num);
+    bpf_probe_read(&nsi->sport, sizeof(u16), &is->inet_sport);
 
     return family;
 }

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -184,11 +184,12 @@ static __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *is)
 {
     __u16 family;
 
-    //Read Family
+    // Read Family
     bpf_probe_read(&family, sizeof(u16), &is->sk.__sk_common.skc_family);
-    //Read source and destination IPs
+    // Read source and destination IPs
     if ( family == AF_INET ) { //AF_INET
-        bpf_probe_read(&nsi->saddr.addr32[0], sizeof(u32), &is->inet_saddr);
+        //bpf_probe_read(&nsi->saddr.addr32[0], sizeof(u32), &is->inet_saddr);
+        bpf_probe_read(&nsi->saddr.addr32[0], sizeof(u32), &is->inet_rcv_saddr);
         bpf_probe_read(&nsi->daddr.addr32[0], sizeof(u32), &is->inet_daddr);
 
         if (!nsi->saddr.addr32[0] || !nsi->daddr.addr32[0])
@@ -196,7 +197,7 @@ static __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *is)
     }
     // Check necessary according https://elixir.bootlin.com/linux/v5.6.14/source/include/net/sock.h#L199
 #if IS_ENABLED(CONFIG_IPV6)
-    else if ( family == AF_INET6 ){
+    else if ( family == AF_INET6 ) {
         struct in6_addr *addr6 = &is->sk.sk_v6_rcv_saddr;
         bpf_probe_read(&nsi->saddr.addr8,  sizeof(__u8)*16, &addr6->s6_addr);
 

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -328,6 +328,9 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
     netdata_update_global(NETDATA_KEY_CALLS_TCP_SENDMSG, 1);
 
     family = set_idx_value(&idx, is);
+    if (!family)
+        return 0;
+
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_SENDMSG, (__u64)sent);
@@ -346,6 +349,9 @@ int netdata_tcp_retransmit_skb(struct pt_regs* ctx)
 
     struct inet_sock *is = inet_sk((struct sock *)PT_REGS_PARM1(ctx));
     family = set_idx_value(&idx, is);
+    if (!family)
+        return 0;
+
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_TCP_RETRANSMIT, 1);
@@ -379,6 +385,9 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
     __u64 received = (__u64) PT_REGS_PARM2(ctx);
 
     family = set_idx_value(&idx, is);
+    if (!family)
+        return 0;
+
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_CLEANUP_RBUF, received);
@@ -406,6 +415,9 @@ int netdata_tcp_close(struct pt_regs* ctx)
     netdata_update_global(NETDATA_KEY_CALLS_TCP_CLOSE, 1);
 
     family =  set_idx_value(&idx, is);
+    if (!family)
+        return 0;
+
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
     val = (netdata_socket_t *) bpf_map_lookup_elem(tbl, &idx);
     if (val) {
@@ -476,6 +488,9 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
     bpf_map_delete_elem(&tbl_nv_udp_conn_stats, &pid_tgid);
 
     family =  set_idx_value(&idx, is);
+    if (!family)
+        return 0;
+
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     netdata_update_global(NETDATA_KEY_BYTES_UDP_RECVMSG, received);
@@ -517,6 +532,9 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     netdata_update_global(NETDATA_KEY_CALLS_UDP_SENDMSG, 1);
 
     family =  set_idx_value(&idx, is);
+    if (!family)
+        return 0;
+
     tbl = (family == AF_INET6)?&tbl_conn_ipv6:&tbl_conn_ipv4;
 
     update_socket_table(tbl, &idx, (__u64) sent, 0, 0, IPPROTO_UDP);


### PR DESCRIPTION
With this PR Netdata will start to monitor connections accepted for specific ports.
This PR also fixes a data overwrite that we had when we were copying retransmission data.