### PR TITLE
Remove kprobe and variable

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -68,7 +68,6 @@ typedef struct netdata_bandwidth {
     __u64 ct;
     __u64 sent;
     __u64 received;
-    __u8 removed;
 } netdata_bandwidth_t;
 
 /**
@@ -559,35 +558,5 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     return 0;
 }
 
-/************************************************************************************
- *
- *                                 Process Section
- *
- *      REMOVE THIS SECTION BEFORE TO CREATE A NEW RELEASE
- ***********************************************************************************/
-
-/**
- * https://elixir.bootlin.com/linux/latest/source/kernel/exit.c#L711
- */
-SEC("kprobe/do_exit")
-int netdata_sys_exit(struct pt_regs* ctx)
-{
-    netdata_bandwidth_t *b;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-
-    //Am I the child?
-    if ( pid != tgid )
-        return 0;
-
-    //Remove PID from table
-    b = (netdata_bandwidth_t *) bpf_map_lookup_elem(&tbl_bandwidth, &tgid);
-    if (b) {
-        b->removed = 1;
-    }
-
-    return 0;
-}
-
 char _license[] SEC("license") = "GPL";
+


### PR DESCRIPTION
On `netdata/netdata` we moved the process management completely for the `ebpf_process.c` file, this means that this kprobe and the variable used to remove process are not more necessary on `socket` ebpf program.

I tested this PR on `Slackware current` and `Debian 10`, I used the following kernels to test it:

- 5.9.2
- 5.8.17
- 5.5.19
- 4.19 ( this is the official  Debian release)
- 4.16.18
- 4.15.18
- 4.14.203

I used the PR https://github.com/netdata/netdata/pull/10202 to test this, and my intention is to create a new release after to merge this PR that will be associated to the referred PR at `netdata/netdata`.