### PR TITLE
Fix for old kernel

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -164,6 +164,9 @@ struct bpf_map_def SEC("maps") tbl_used_ports = {
 
 /**
  * Function used to update 64 bit values and avoid overflow
+ *
+ * To keep compatibility with kernels older than 4.18, function with pointers need
+ * to be inline.
  */
 static inline void netdata_update_u64(__u64 *res, __u64 value)
 {
@@ -232,6 +235,9 @@ static __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *is)
 
 /**
  * Update time and bytes sent and received
+ *
+ * To keep compatibility with kernels older than 4.18, function with pointers need
+ * to be inline.
  */
 static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u16 retransmitted)
 {
@@ -252,6 +258,9 @@ static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 
 
 /**
  * Update the table for the index idx
+ *
+ * To keep compatibility with kernels older than 4.18, function with pointers need
+ * to be inline.
  */
 static inline void update_socket_table(struct inet_sock *is,
                                 __u64 sent,

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -165,7 +165,7 @@ struct bpf_map_def SEC("maps") tbl_used_ports = {
 /**
  * Function used to update 64 bit values and avoid overflow
  */
-static void netdata_update_u64(__u64 *res, __u64 value)
+static inline void netdata_update_u64(__u64 *res, __u64 value)
 {
     if (!value)
         return;
@@ -230,11 +230,10 @@ static __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *is)
     return family;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
 /**
  * Update time and bytes sent and received
  */
-static void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u16 retransmitted)
+static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u16 retransmitted)
 {
     ptr->ct = bpf_ktime_get_ns();
 
@@ -254,7 +253,7 @@ static void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 receive
 /**
  * Update the table for the index idx
  */
-static void update_socket_table(struct inet_sock *is,
+static inline void update_socket_table(struct inet_sock *is,
                                 __u64 sent,
                                 __u64 received,
                                 __u16 retransmitted,
@@ -286,7 +285,6 @@ static void update_socket_table(struct inet_sock *is,
         bpf_map_update_elem(tbl, &idx, &data, BPF_ANY);
     }
 }
-#endif
 
 
 /**
@@ -343,7 +341,6 @@ static void update_pid_stats(__u32 pid, __u32 tgid, __u64 sent, __u64 received, 
     }
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
 SEC("kretprobe/inet_csk_accept")
 int netdata_inet_csk_accept(struct pt_regs* ctx)
 {
@@ -363,7 +360,6 @@ int netdata_inet_csk_accept(struct pt_regs* ctx)
 
     return 0;
 }
-#endif
 
 /************************************************************************************
  *
@@ -399,10 +395,8 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
 
     netdata_update_global(NETDATA_KEY_CALLS_TCP_SENDMSG, 1);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
     struct inet_sock *is = inet_sk((struct sock *)PT_REGS_PARM1(ctx));
     update_socket_table(is,(__u64) sent, 0, 0, IPPROTO_TCP);
-#endif
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_SENDMSG, (__u64)sent);
     update_pid_stats(pid, tgid, (__u64)sent, 0, IPPROTO_TCP);
@@ -417,10 +411,8 @@ int netdata_tcp_retransmit_skb(struct pt_regs* ctx)
     __u32 pid = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
     struct inet_sock *is = inet_sk((struct sock *)PT_REGS_PARM1(ctx));
     update_socket_table(is, 0, 0, 1, IPPROTO_TCP);
-#endif
 
     netdata_update_global(NETDATA_KEY_TCP_RETRANSMIT, 1);
 
@@ -448,10 +440,8 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
 
     __u64 received = (__u64) PT_REGS_PARM2(ctx);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
     struct inet_sock *is = inet_sk((struct sock *)PT_REGS_PARM1(ctx));
     update_socket_table(is, 0, received, 0, IPPROTO_TCP);
-#endif
 
     netdata_update_global(NETDATA_KEY_BYTES_TCP_CLEANUP_RBUF, received);
     update_pid_stats(pid, tgid, 0, received, IPPROTO_TCP);
@@ -547,10 +537,8 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
     netdata_update_global(NETDATA_KEY_BYTES_UDP_RECVMSG, received);
     update_pid_stats(pid, tgid, 0, received, IPPROTO_UDP);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
     struct inet_sock *is = inet_sk((struct sock *)*skpp);
     update_socket_table(is, 0, received, 0, IPPROTO_UDP);
-#endif
 
     return 0;
 }
@@ -581,10 +569,8 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
 
     netdata_update_global(NETDATA_KEY_CALLS_UDP_SENDMSG, 1);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
     struct inet_sock *is = inet_sk((struct sock *)PT_REGS_PARM1(ctx));
     update_socket_table(is, (__u64) sent, 0, 0, IPPROTO_UDP);
-#endif
 
     update_pid_stats(pid, tgid, (__u64) sent, 0, IPPROTO_UDP);
 


### PR DESCRIPTION
Fixes #178 
Fixes #176 

I tested this PR using the PR https://github.com/netdata/netdata/pull/10360 on the following kernels and distributions:

| Distribution | Kernel version |
|-----------------|---------------------|
|Slackware current | 5.9.11 |
|Slackware current | 5.8.18|
|Slackware current | 5.5.19|
|Slackware current | 5.4.83|
|Slackware current | 4.20.17|
|Slackware current | 4.19.161|
|Debian 10 | 4.19.132|
|Ubuntu 18.04 | 4.18.20(4.18.0-25.26)|
|Slackware current | 4.17.19|
|Ubuntu 18.04 | 4.15.18(4.15.0-123)|
|Centos 7.8 | 3.10.0-1160|