### PR TITLE
Add cachestat collector to ebpf programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ all: $(KERNEL_PROGRAM)
 	cp $(KERNEL_DIR)pprocess_kern.o pnetdata_ebpf_process.$(VER_MAJOR).$(VER_MINOR).o
 	cp $(KERNEL_DIR)rnetwork_viewer_kern.o rnetdata_ebpf_socket.$(VER_MAJOR).$(VER_MINOR).o
 	cp $(KERNEL_DIR)pnetwork_viewer_kern.o pnetdata_ebpf_socket.$(VER_MAJOR).$(VER_MINOR).o
+	cp $(KERNEL_DIR)rcachestat_kern.o rnetdata_ebpf_cachestat.$(VER_MAJOR).$(VER_MINOR).o
+	cp $(KERNEL_DIR)pcachestat_kern.o pnetdata_ebpf_cachestat.$(VER_MAJOR).$(VER_MINOR).o
 	if [ -f pnetdata_ebpf_process.$(VER_MAJOR).$(VER_MINOR).o ]; then tar -cf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar [pr]netdata_ebpf_*.$(VER_MAJOR).$(VER_MINOR).o; else echo "ERROR: Cannot find BPF programs"; exit 1; fi
 	if [ "$${DEBUG:-0}" -eq 1 ]; then tar -uvf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar tools/check-kernel-config.sh; fi
 	xz artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,8 +34,9 @@ CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATC
 
 process_kern.o: process_kern.c
 network_viewer_kern.o: network_viewer_kern.c
+cachestat_kern.o: cachestat_kern.c
 
-all: process_kern.o network_viewer_kern.o
+all: process_kern.o network_viewer_kern.o cachestat_kern.o
 
 %.o: %.c
 	if [ -w /usr/src/linux/include/generated/autoconf.h ]; then  if [ "$(CURRENT_KERNEL)" -ge 328448 ]; then sed -i -e 's/\(#define CONFIG_CC_HAS_ASM_INLINE 1\)/\/\/\1/' /usr/src/linux/include/generated/autoconf.h; fi ; fi

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -1,0 +1,137 @@
+#define KBUILD_MODNAME "process_kern"
+#include <linux/bpf.h>
+#include <linux/version.h>
+#include <linux/ptrace.h>
+
+#include <linux/threads.h>
+#include <linux/version.h>
+
+#include "bpf_helpers.h"
+#include "netdata_ebpf.h"
+
+struct bpf_map_def SEC("maps") cstat_global = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_CACHESTAT_END
+};
+
+struct bpf_map_def SEC("maps") cstat_pid = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(netdata_cachestat_t),
+    .max_entries = NETDATA_CACHESTAT_END
+};
+
+/************************************************************************************
+ *
+ *                                 COMMON Section
+ *
+ ***********************************************************************************/
+
+static inline void netdata_update_u64(__u64 *res, __u64 value)
+{
+    __sync_fetch_and_add(res, value);
+    if ( (0xFFFFFFFFFFFFFFFF - *res) <= value) {
+        *res = value;
+    }
+}
+
+static inline void netdata_update_global(__u32 key, __u64 value)
+{
+    __u64 *res;
+    res = bpf_map_lookup_elem(&cstat_global, &key);
+    if (res)
+        netdata_update_u64(res, value) ;
+    else
+        bpf_map_update_elem(&cstat_global, &key, &value, BPF_NOEXIST);
+}
+
+/************************************************************************************
+ *
+ *                                   Probe Section
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/add_to_page_cache_lru")
+int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *fill, data = {};
+    netdata_update_global(NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU, 1);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    if (fill) {
+        netdata_update_u64(&fill->add_to_page_cache_lru, 1);
+    } else {
+        data.add_to_page_cache_lru = 1;
+        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("kprobe/mark_page_accessed")
+int netdata_mark_page_accessed(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *fill, data = {};
+    netdata_update_global(NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED, 1);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    if (fill) {
+        netdata_update_u64(&fill->mark_page_accessed, 1);
+    } else {
+        data.mark_page_accessed = 1;
+        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("kprobe/account_page_dirtied")
+int netdata_account_page_dirtied(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *fill, data = {};
+    netdata_update_global(NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    if (fill) {
+        netdata_update_u64(&fill->account_page_dirtied, 1);
+    } else {
+        data.account_page_dirtied = 1;
+        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("kprobe/mark_buffer_dirty")
+int netdata_mark_buffer_dirty(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *fill, data = {};
+    netdata_update_global(NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY, 1);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    if (fill) {
+        netdata_update_u64(&fill->mark_buffer_dirty, 1);
+    } else {
+        data.mark_buffer_dirty = 1;
+        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -24,7 +24,7 @@ struct bpf_map_def SEC("maps") cstat_pid = {
 #endif
     .key_size = sizeof(__u32),
     .value_size = sizeof(netdata_cachestat_t),
-    .max_entries = NETDATA_CACHESTAT_END
+    .max_entries = 100000
 };
 
 /************************************************************************************

--- a/kernel/netdata_ebpf.h
+++ b/kernel/netdata_ebpf.h
@@ -115,4 +115,21 @@ enum socket_counters {
     NETDATA_SOCKET_COUNTER
 };
 
+// cachestat.c
+typedef struct netdata_cachestat {
+    __u64 add_to_page_cache_lru;
+    __u64 mark_page_accessed;
+    __u64 account_page_dirtied;
+    __u64 mark_buffer_dirty;
+} netdata_cachestat_t;
+
+enum cachestat_counters {
+    NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU,
+    NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED,
+    NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED,
+    NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY,
+
+    NETDATA_CACHESTAT_END
+};
+
 #endif /* _NETDATA_EBPF_PROCESS_ */


### PR DESCRIPTION
Fixes #190 

A complete explanation for the motive we are using these kprobes is given [here](http://www.brendangregg.com/blog/2014-12-31/linux-page-cache-hit-ratio.html )

This PR is bringing the necessary code to bring cache statistic to Netdata, it was tested on the following environments:

| Kernel version | distribution |
|-------------------|------------------|
| 5.10.13 | Slackware current |
| 5.9.16 | Slackware current |
| 5.7.19 | Slackware current |
| 5.4.95 | Slackware current |
| 5.4.78 | Ubuntu 20.04 |
| 5.4.78 | Ubuntu 18.04 |
| 4.20.17 | Slackware current |
| 4.19.171-2 | Debian 10.8 |
| 4.18.20 | Ubuntu 18.04 |
| 4.15.18 | Ubuntu 18.04 |
|3.10.0-1160.15.2.el7 |  CentOS 7.9.2009 | 
