### PR TITLE
Fix kernel 5 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         kernel_version:
+          - '5.11.2'
           - '5.10.3'
           - '5.4.85'
           - '4.16.18'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         kernel_version:
+          - '5.11.2'
           - '5.10.3'
           - '5.4.85'
           - '4.16.18'

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -817,10 +817,18 @@ int netdata_sys_clone(struct pt_regs *ctx)
 
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0)) 
+#if NETDATASEL < 2
+SEC("kretprobe/close_fd")
+#else
+SEC("kprobe/close_fd")
+#endif
+#else
 #if NETDATASEL < 2
 SEC("kretprobe/__close_fd")
 #else
 SEC("kprobe/__close_fd")
+#endif
 #endif
 int netdata_close(struct pt_regs* ctx)
 {


### PR DESCRIPTION
Fixes #199 

With the latest changes on Linux kernel, we need to change our internal code.

This PR was tested on `Slackware-current` running on kernel `5.11.2`.