### PR TITLE
eBPF sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ all: $(KERNEL_PROGRAM)
 	cp $(KERNEL_DIR)pnetwork_viewer_kern.o pnetdata_ebpf_socket.$(VER_MAJOR).$(VER_MINOR).o
 	cp $(KERNEL_DIR)rcachestat_kern.o rnetdata_ebpf_cachestat.$(VER_MAJOR).$(VER_MINOR).o
 	cp $(KERNEL_DIR)pcachestat_kern.o pnetdata_ebpf_cachestat.$(VER_MAJOR).$(VER_MINOR).o
+	cp $(KERNEL_DIR)rsync_kern.o rnetdata_ebpf_sync.$(VER_MAJOR).$(VER_MINOR).o
+	cp $(KERNEL_DIR)psync_kern.o pnetdata_ebpf_sync.$(VER_MAJOR).$(VER_MINOR).o
 	if [ -f pnetdata_ebpf_process.$(VER_MAJOR).$(VER_MINOR).o ]; then tar -cf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar [pr]netdata_ebpf_*.$(VER_MAJOR).$(VER_MINOR).o; else echo "ERROR: Cannot find BPF programs"; exit 1; fi
 	if [ "$${DEBUG:-0}" -eq 1 ]; then tar -uvf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar tools/check-kernel-config.sh; fi
 	xz artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -8,6 +8,7 @@
 #include "netdata_cache.h"
 #include "netdata_network.h"
 #include "netdata_process.h"
+#include "netdata_sync.h"
 
 struct netdata_error_report_t {
     char comm[TASK_COMM_LEN];

--- a/includes/netdata_sync.h
+++ b/includes/netdata_sync.h
@@ -3,10 +3,12 @@
 #ifndef _NETDATA_SYNC_H_
 #define _NETDATA_SYNC_H_ 1
 
+// 
 enum sync_counters {
     NETDATA_KEY_SYNC_CALL,
     NETDATA_KEY_SYNC_ERROR,
 
+    // Keep this as last and don't skip numbers as it is used as element counter
     NETDATA_SYNC_END
 };
 

--- a/includes/netdata_sync.h
+++ b/includes/netdata_sync.h
@@ -3,7 +3,7 @@
 #ifndef _NETDATA_SYNC_H_
 #define _NETDATA_SYNC_H_ 1
 
-enum cachestat_counters {
+enum sync_counters {
     NETDATA_KEY_SYNC_CALL,
     NETDATA_KEY_SYNC_ERROR,
 

--- a/includes/netdata_sync.h
+++ b/includes/netdata_sync.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_SYNC_H_
+#define _NETDATA_SYNC_H_ 1
+
+enum cachestat_counters {
+    NETDATA_KEY_SYNC_CALL,
+    NETDATA_KEY_SYNC_ERROR,
+
+    NETDATA_SYNC_END
+};
+
+#endif /* _NETDATA_SYNC_H_ */

--- a/includes/netdata_sync.h
+++ b/includes/netdata_sync.h
@@ -3,7 +3,6 @@
 #ifndef _NETDATA_SYNC_H_
 #define _NETDATA_SYNC_H_ 1
 
-// 
 enum sync_counters {
     NETDATA_KEY_SYNC_CALL,
     NETDATA_KEY_SYNC_ERROR,

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -35,8 +35,9 @@ CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATC
 process_kern.o: process_kern.c
 network_viewer_kern.o: network_viewer_kern.c
 cachestat_kern.o: cachestat_kern.c
+sync_kern.o: sync_kern.c
 
-all: process_kern.o network_viewer_kern.o cachestat_kern.o
+all: process_kern.o network_viewer_kern.o cachestat_kern.o sync_kern.o
 
 %.o: %.c
 	if [ -w /usr/src/linux/include/generated/autoconf.h ]; then  if [ "$(CURRENT_KERNEL)" -ge 328448 ]; then sed -i -e 's/\(#define CONFIG_CC_HAS_ASM_INLINE 1\)/\/\/\1/' /usr/src/linux/include/generated/autoconf.h; fi ; fi

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -1,0 +1,53 @@
+#define KBUILD_MODNAME "latency_tp_netdata"
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+
+#include "netdata_ebpf.h"
+
+/************************************************************************************
+ *     
+ *                                 MAPS
+ *     
+ ***********************************************************************************/
+
+struct bpf_map_def SEC("maps") tbl_sync = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+
+
+/************************************************************************************
+ *
+ *                               SYNC SECTION
+ *
+ ***********************************************************************************/
+
+#if NETDATASEL < 2
+SEC("kretprobe/" NETDATA_SYSCALL(sync))
+#else
+SEC("kprobe/" NETDATA_SYSCALL(sync))
+#endif
+int netdata_syscall_sync(struct pt_regs* ctx)
+{
+    netdata_update_global(NETDATA_KEY_SYNC_CALL, 1);
+#if NETDATASEL < 2
+    int ret = (ssize_t)PT_REGS_RC(ctx);
+    if (ret < 0)
+        netdata_update_global(NETDATA_KEY_SYNC_ERROR, 1);
+#endif
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                             END SYNC SECTION
+ *
+ ***********************************************************************************/
+

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -12,12 +12,8 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_sync = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
     .type = BPF_MAP_TYPE_HASH,
-#else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif
-    .key_size = sizeof(__u64),
+    .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END
 };


### PR DESCRIPTION
Fixes #201 

This PR brings a new eBPF program to Netdata. When it is allowed users will have conditions when `sync` is called.

This PR was tested on kernels `5.11.2`, `5.10.19`, `5.4.95` and `4.16.18`.