### PR TITLE
Ebpf Directory Cache

### DIFF
--- a/includes/netdata_dc.h
+++ b/includes/netdata_dc.h
@@ -21,3 +21,4 @@ enum directory_cache_counters {
 };
 
 #endif /* _NETDATA_DIRECTORY_CACHE_H_ */
+

--- a/includes/netdata_dc.h
+++ b/includes/netdata_dc.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_DIRECTORY_CACHE_H_
+#define _NETDATA_DIRECTORY_CACHE_H_ 1
+
+#include <linux/sched.h>
+
+typedef struct netdata_dc_stat {
+    __u64 references;
+    __u64 slow;
+    __u64 missed;
+} netdata_dc_stat_t;
+
+enum directory_cache_counters {
+    NETDATA_KEY_DC_REFERENCE,
+    NETDATA_KEY_DC_SLOW,
+    NETDATA_KEY_DC_MISS,
+
+    // Keep this as last and don't skip numbers as it is used as element counter
+    NETDATA_DIRECTORY_CACHE_END
+};
+
+#endif /* _NETDATA_DIRECTORY_CACHE_H_ */

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -7,6 +7,7 @@
 #include <linux/version.h>
 
 #include "netdata_cache.h"
+#include "netdata_dc.h"
 #include "netdata_network.h"
 #include "netdata_process.h"
 #include "netdata_sync.h"

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -33,6 +33,7 @@ VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3)
 CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATCH) |bc)
 
 cachestat_kern.o: cachestat_kern.c
+dc_kern.o: dc_kern.c
 fdatasync_kern.o: fdatasync_kern.c
 fsync_kern.o: fsync_kern.c
 msync_kern.o: msync_kern.c
@@ -42,7 +43,7 @@ sync_kern.o: sync_kern.c
 sync_file_range_kern.o: sync_file_range_kern.c
 syncfs_kern.o: syncfs_kern.c
 
-all: process_kern.o network_viewer_kern.o cachestat_kern.o sync_kern.o syncfs_kern.o msync_kern.o fdatasync_kern.o fsync_kern.o sync_file_range_kern.o
+all: process_kern.o network_viewer_kern.o cachestat_kern.o sync_kern.o syncfs_kern.o msync_kern.o fdatasync_kern.o fsync_kern.o sync_file_range_kern.o dc_kern.o
 
 %.o: %.c
 	if [ -w /usr/src/linux/include/generated/autoconf.h ]; then  if [ "$(CURRENT_KERNEL)" -ge 328448 ]; then sed -i -e 's/\(#define CONFIG_CC_HAS_ASM_INLINE 1\)/\/\/\1/' /usr/src/linux/include/generated/autoconf.h; fi ; fi

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -1,13 +1,15 @@
-#define KBUILD_MODNAME "process_kern"
+#define KBUILD_MODNAME "dc_kern"
 #include <linux/bpf.h>
-#include <linux/version.h>
 #include <linux/ptrace.h>
-
-#include <linux/threads.h>
-#include <linux/version.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
+
+/************************************************************************************
+ *
+ *                                   Maps Section
+ *
+ ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") dcstat_global = {
     .type = BPF_MAP_TYPE_HASH,
@@ -34,7 +36,7 @@ struct bpf_map_def SEC("maps") dcstat_pid = {
  ***********************************************************************************/
 
 SEC("kprobe/lookup_fast")
-int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
+int netdata_lookup_fast(struct pt_regs* ctx)
 {
     netdata_dc_stat_t *fill, data = {};
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
@@ -53,7 +55,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
 }
 
 SEC("kretprobe/d_lookup")
-int netdata_mark_page_accessed(struct pt_regs* ctx)
+int netdata_d_lookup(struct pt_regs* ctx)
 {
     netdata_dc_stat_t *fill, data = {};
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_SLOW, 1);

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -1,0 +1,89 @@
+#define KBUILD_MODNAME "process_kern"
+#include <linux/bpf.h>
+#include <linux/version.h>
+#include <linux/ptrace.h>
+
+#include <linux/threads.h>
+#include <linux/version.h>
+
+#include "bpf_helpers.h"
+#include "netdata_ebpf.h"
+
+struct bpf_map_def SEC("maps") dcstat_global = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_CACHESTAT_END
+};
+
+struct bpf_map_def SEC("maps") dcstat_pid = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(netdata_dc_stat_t),
+    .max_entries = 100000
+};
+
+/************************************************************************************
+ *
+ *                                   Probe Section
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/lookup_fast")
+int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
+{
+    netdata_dc_stat_t *fill, data = {};
+    libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+    if (fill) {
+        libnetdata_update_u64(&fill->references, 1);
+    } else {
+        data.references = 1;
+        bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("kretprobe/d_lookup")
+int netdata_mark_page_accessed(struct pt_regs* ctx)
+{
+    netdata_dc_stat_t *fill, data = {};
+    libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_SLOW, 1);
+
+    int ret = PT_REGS_RC(ctx);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+    if (fill) {
+        libnetdata_update_u64(&fill->slow, 1);
+    } else {
+        data.slow = 1;
+        bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+    }
+
+    // file not found
+    if (ret == 0) {
+        libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
+        fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+        if (fill) {
+            libnetdata_update_u64(&fill->missed, 1);
+        } else {
+            data.missed = 1;
+            bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+        }
+    }
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/rename_binaries.sh
+++ b/rename_binaries.sh
@@ -12,6 +12,8 @@ VER_MINOR="$2"
 
 cp "${KERNEL_DIR}rcachestat_kern.o" "rnetdata_ebpf_cachestat.${VER_MAJOR}.${VER_MINOR}.o"
 cp "${KERNEL_DIR}pcachestat_kern.o" "pnetdata_ebpf_cachestat.${VER_MAJOR}.${VER_MINOR}.o"
+cp "${KERNEL_DIR}rdc_kern.o" "rnetdata_ebpf_dc.${VER_MAJOR}.${VER_MINOR}.o"
+cp "${KERNEL_DIR}pdc_kern.o" "pnetdata_ebpf_dc.${VER_MAJOR}.${VER_MINOR}.o"
 cp "${KERNEL_DIR}rfdatasync_kern.o" "rnetdata_ebpf_fdatasync.${VER_MAJOR}.${VER_MINOR}.o"
 cp "${KERNEL_DIR}pfdatasync_kern.o" "pnetdata_ebpf_fdatasync.${VER_MAJOR}.${VER_MINOR}.o"
 cp "${KERNEL_DIR}rfsync_kern.o" "rnetdata_ebpf_fsync.${VER_MAJOR}.${VER_MINOR}.o"


### PR DESCRIPTION
Fixes #189 

This PR is bringing the logic behind [dcstat](https://github.com/iovisor/bcc/blob/master/tools/dcstat.py) to eBPF plugin. It was tested on : 

| Linux Distribution  | Kernel |
| ------------------------ | --------- | 
| Slackware Current | 5.11.2 |
| Slackware Current | 5.10.25 |
| Slackware Current | 5.4.95 |
| Ubuntu 18.04 | 4.15.0-136|
| CentOS | 3.10.0 |
