### PR TITLE
Change default size

### DIFF
--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -24,7 +24,7 @@ struct bpf_map_def SEC("maps") cstat_pid = {
 #endif
     .key_size = sizeof(__u32),
     .value_size = sizeof(netdata_cachestat_t),
-    .max_entries = 100000
+    .max_entries = PID_MAX_DEFAULT
 };
 
 /************************************************************************************

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -1,6 +1,7 @@
 #define KBUILD_MODNAME "dc_kern"
 #include <linux/bpf.h>
 #include <linux/ptrace.h>
+#include <linux/threads.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -26,7 +27,7 @@ struct bpf_map_def SEC("maps") dcstat_pid = {
 #endif
     .key_size = sizeof(__u32),
     .value_size = sizeof(netdata_dc_stat_t),
-    .max_entries = 100000
+    .max_entries = PID_MAX_DEFAULT
 };
 
 /************************************************************************************

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -18,7 +18,7 @@ struct bpf_map_def SEC("maps") tbl_pid_stats = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(__u32),
     .value_size = sizeof(struct netdata_pid_stat_t),
-    .max_entries = 100000
+    .max_entries = PID_MAX_DEFAULT
 };
 
 struct bpf_map_def SEC("maps") tbl_total_stats = {


### PR DESCRIPTION
Fixes #210 

As described in the issue we need to reduce PID tables to reduce kernel memory usage, we will also give conditions for uses to set them according their necessity.

This simple reduction will save around 68% of memory we are using by default.