### PR TITLE
Change constant

### DIFF
--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -16,7 +16,7 @@ struct bpf_map_def SEC("maps") dcstat_global = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
-    .max_entries = NETDATA_CACHESTAT_END
+    .max_entries = NETDATA_DIRECTORY_CACHE_END
 };
 
 struct bpf_map_def SEC("maps") dcstat_pid = {


### PR DESCRIPTION
When we merged directory cache, thanks the fact `cachestat` and `directory cache` monitor caches, there was an inversion of constants that we did not observe, because `cachestat` monitors more data than `directory cache`, so we are allocating more memory than necessary for directory cache. This PR brings the correct value for hash table.