### PR TITLE
ext4 monitoring

### DIFF
--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -103,13 +103,6 @@ static inline void libnetdata_update_u32(u32 *res, u32 value)
     }
 }
 
-/**
- *  We are limitating to 32 bins to be sure that
- *  our dashboard will plot.
- *
- *  The algorithm was based in the link
- *  http://www.brendangregg.com/blog/2015-05-15/ebpf-one-small-step.html
- */
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))
 static __always_inline __u32 libnetdata_select_idx(__u64 val, __u32 end)
 #else

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -111,17 +111,17 @@ static inline void libnetdata_update_u32(u32 *res, u32 value)
  *  http://www.brendangregg.com/blog/2015-05-15/ebpf-one-small-step.html
  */
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))
-static __always_inline __u32 libnetdata_select_idx(__u64 val)
+static __always_inline __u32 libnetdata_select_idx(__u64 val, __u32 end)
 #else
-static inline __u32 libnetdata_select_idx(__u64 val)
+static inline __u32 libnetdata_select_idx(__u64 val, __u32 end)
 #endif
 {
     __u32 rlog;
 
     rlog = libnetdata_log2l(val);
 
-    if (rlog > NETDATA_FS_MAX_BINS_POS)
-        rlog = NETDATA_FS_MAX_BINS_POS;
+    if (rlog > end)
+        rlog = end;
 
     return rlog;
 }

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -8,6 +8,7 @@
 
 #include "netdata_cache.h"
 #include "netdata_dc.h"
+#include "netdata_fs.h"
 #include "netdata_network.h"
 #include "netdata_process.h"
 #include "netdata_sync.h"

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -103,6 +103,29 @@ static inline void libnetdata_update_u32(u32 *res, u32 value)
     }
 }
 
+/**
+ *  We are limitating to 32 bins to be sure that
+ *  our dashboard will plot.
+ *
+ *  The algorithm was based in the link
+ *  http://www.brendangregg.com/blog/2015-05-15/ebpf-one-small-step.html
+ */
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))
+static __always_inline __u32 libnetdata_select_idx(__u64 val)
+#else
+static inline __u32 libnetdata_select_idx(__u64 val)
+#endif
+{
+    __u32 rlog;
+
+    rlog = libnetdata_log2l(val);
+
+    if (rlog > NETDATA_FS_MAX_BINS_POS)
+        rlog = NETDATA_FS_MAX_BINS_POS;
+
+    return rlog;
+}
+
 // Copied from linux/samples/bpf/tracex1_kern.c
 #define _(P)                                                                   \
         ({                                                                     \

--- a/includes/netdata_fs.h
+++ b/includes/netdata_fs.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_FS_H_
+#define _NETDATA_FS_H_ 1
+
+typedef struct netdata_fs_hist {
+    u32 hist_id;
+    u32 bin;
+} netdata_fs_hist_t;
+
+enum fs_counters {
+    NETDATA_KEY_CALLS_READ,
+    NETDATA_KEY_CALLS_WRITE,
+    NETDATA_KEY_CALLS_OPEN,
+    NETDATA_KEY_CALLS_SYNC,
+
+    NETDATA_FS_END
+};
+
+#define NETDATA_FS_MAX_BINS 32UL
+#define NETDATA_FS_MAX_BINS_POS (NETDATA_FS_MAX_BINS - 1)
+#define NETDATA_FS_HISTOGRAM_LENGTH  (NETDATA_FS_MAX_BINS * NETDATA_FS_MAX_BINS)
+
+
+#endif /* _NETDATA_FS_H_ */
+

--- a/includes/netdata_fs.h
+++ b/includes/netdata_fs.h
@@ -3,11 +3,6 @@
 #ifndef _NETDATA_FS_H_
 #define _NETDATA_FS_H_ 1
 
-typedef struct netdata_fs_hist {
-    u32 hist_id;
-    u32 bin;
-} netdata_fs_hist_t;
-
 enum fs_counters {
     NETDATA_KEY_CALLS_READ,
     NETDATA_KEY_CALLS_WRITE,
@@ -20,6 +15,8 @@ enum fs_counters {
 // We are using 24 as hard limit to avoid intervals bigger than
 // 8 seconds and to keep memory aligment.
 #define NETDATA_FS_MAX_BINS 24UL
+#define NETDATA_FS_MAX_TABLES 5UL
+#define NETDATA_FS_MAX_ELEMENTS (NETDATA_FS_MAX_BINS * NETDATA_FS_MAX_TABLES)
 #define NETDATA_FS_MAX_BINS_POS (NETDATA_FS_MAX_BINS - 1)
 #define NETDATA_FS_HISTOGRAM_LENGTH  (NETDATA_FS_MAX_BINS * NETDATA_FS_MAX_BINS)
 

--- a/includes/netdata_fs.h
+++ b/includes/netdata_fs.h
@@ -17,7 +17,9 @@ enum fs_counters {
     NETDATA_FS_END
 };
 
-#define NETDATA_FS_MAX_BINS 32UL
+// We are using 24 as hard limit to avoid intervals bigger than
+// 8 seconds and to keep memory aligment.
+#define NETDATA_FS_MAX_BINS 24UL
 #define NETDATA_FS_MAX_BINS_POS (NETDATA_FS_MAX_BINS - 1)
 #define NETDATA_FS_HISTOGRAM_LENGTH  (NETDATA_FS_MAX_BINS * NETDATA_FS_MAX_BINS)
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,6 +34,7 @@ CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATC
 
 NETDATA_APPS= cachestat \
 	      dc \
+	      ext4 \
 	      fdatasync \
 	      fsync \
 	      msync \

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -82,11 +82,11 @@ int netdata_ext4_sync_file(struct pt_regs *ctx)
 static void netdata_ext4_store_bin(__u32 bin, __u32 selection)
 {
     __u64 *fill, data;
-    __u32 idx = selection*NETDATA_FS_MAX_BINS + bin;
+    __u32 idx = selection * NETDATA_FS_MAX_BINS + bin;
     if (idx >= NETDATA_FS_MAX_ELEMENTS)
         return;
 
-    fill = bpf_map_lookup_elem(&tbl_ext4 ,&idx);
+    fill = bpf_map_lookup_elem(&tbl_ext4, &idx);
     if (fill) {
         libnetdata_update_u64(fill, 1);
 		return;
@@ -103,7 +103,7 @@ int netdata_ret_ext4_ext4_file_read_iter(struct pt_regs *ctx)
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 bin, pid = (__u32)(pid_tgid >> 32);
 
-    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    fill = bpf_map_lookup_elem(&tmp_ext4, &pid);
     if (!fill)
         return 0;
 
@@ -119,7 +119,7 @@ int netdata_ret_ext4_ext4_file_read_iter(struct pt_regs *ctx)
     bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
     netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_READ);
 
-	return 0;
+    return 0;
 }
 
 SEC("kretprobe/ext4_file_write_iter")
@@ -129,7 +129,7 @@ int netdata_ret_ext4_file_write_iter(struct pt_regs *ctx)
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 bin, pid = (__u32)(pid_tgid >> 32);
 
-    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    fill = bpf_map_lookup_elem(&tmp_ext4, &pid);
     if (!fill)
         return 0;
 
@@ -145,7 +145,7 @@ int netdata_ret_ext4_file_write_iter(struct pt_regs *ctx)
     bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
     netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_WRITE);
 
-	return 0;
+    return 0;
 }
 
 SEC("kretprobe/ext4_file_open")
@@ -155,7 +155,7 @@ int netdata_ret_ext4_file_open(struct pt_regs *ctx)
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 bin, pid = (__u32)(pid_tgid >> 32);
 
-    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    fill = bpf_map_lookup_elem(&tmp_ext4, &pid);
     if (!fill)
         return 0;
 
@@ -171,7 +171,7 @@ int netdata_ret_ext4_file_open(struct pt_regs *ctx)
     bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
     netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_OPEN);
 
-	return 0;
+    return 0;
 }
 
 SEC("kretprobe/ext4_sync_file")
@@ -181,7 +181,7 @@ int netdata_ret_ext4_sync_file(struct pt_regs *ctx)
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 bin, pid = (__u32)(pid_tgid >> 32);
 
-    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    fill = bpf_map_lookup_elem(&tmp_ext4, &pid);
     if (!fill)
         return 0;
 
@@ -197,7 +197,7 @@ int netdata_ret_ext4_sync_file(struct pt_regs *ctx)
     bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
     netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_SYNC);
 
-	return 0;
+    return 0;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -83,25 +83,21 @@ static void netdata_ext4_store_bin(__u32 bin, __u32 selection)
 {
     __u64 *fill, data;
     __u32 idx = selection*NETDATA_FS_MAX_BINS + bin;
-    if ( idx >= NETDATA_FS_MAX_ELEMENTS)
+    if (idx >= NETDATA_FS_MAX_ELEMENTS)
         return;
 
     fill = bpf_map_lookup_elem(&tbl_ext4 ,&idx);
     if (fill) {
         libnetdata_update_u64(fill, 1);
-    } else {
-        data = 1;
-        bpf_map_update_elem(&tbl_ext4, &idx, &data, BPF_NOEXIST);
-    }
+		return;
+    } 
+
+    data = 1;
+    bpf_map_update_elem(&tbl_ext4, &idx, &data, BPF_ANY);
 }
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
-static __always_inline int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
-#else
-static inline int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
-#endif
+SEC("kretprobe/ext4_file_read_iter")
+int netdata_ret_ext4_ext4_file_read_iter(struct pt_regs *ctx)
 {
     __u64 *fill, data;
     __u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -121,33 +117,87 @@ static inline int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
     // convert to microseconds
     data /= 1000;
     bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
-    netdata_ext4_store_bin(bin, selection);
+    netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_READ);
 
-    return 0;
-}
-
-SEC("kretprobe/ext4_file_read_iter")
-int netdata_ret_ext4_ext4_file_read_iter(struct pt_regs *ctx)
-{
-    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_READ);
+	return 0;
 }
 
 SEC("kretprobe/ext4_file_write_iter")
 int netdata_ret_ext4_file_write_iter(struct pt_regs *ctx)
 {
-    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_WRITE);
+    __u64 *fill, data;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+
+    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    if (!fill)
+        return 0;
+
+    data = bpf_ktime_get_ns() - *fill;
+    bpf_map_delete_elem(&tmp_ext4, &pid);
+
+    // Skip entries with backward time
+    if ( (s64)data < 0)
+        return 0;
+
+    // convert to microseconds
+    data /= 1000;
+    bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
+    netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_WRITE);
+
+	return 0;
 }
 
 SEC("kretprobe/ext4_file_open")
 int netdata_ret_ext4_file_open(struct pt_regs *ctx)
 {
-    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_OPEN);
+    __u64 *fill, data;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+
+    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    if (!fill)
+        return 0;
+
+    data = bpf_ktime_get_ns() - *fill;
+    bpf_map_delete_elem(&tmp_ext4, &pid);
+
+    // Skip entries with backward time
+    if ( (s64)data < 0)
+        return 0;
+
+    // convert to microseconds
+    data /= 1000;
+    bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
+    netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_OPEN);
+
+	return 0;
 }
 
 SEC("kretprobe/ext4_sync_file")
 int netdata_ret_ext4_sync_file(struct pt_regs *ctx) 
 {
-    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_SYNC);
+    __u64 *fill, data;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+
+    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    if (!fill)
+        return 0;
+
+    data = bpf_ktime_get_ns() - *fill;
+    bpf_map_delete_elem(&tmp_ext4, &pid);
+
+    // Skip entries with backward time
+    if ( (s64)data < 0)
+        return 0;
+
+    // convert to microseconds
+    data /= 1000;
+    bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
+    netdata_ext4_store_bin(bin, NETDATA_KEY_CALLS_SYNC);
+
+	return 0;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -33,11 +33,11 @@ struct bpf_map_def SEC("maps") tmp_ext4 = {
  ***********************************************************************************/
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_ext4_entry(struct pt_regs *ctx)
+static int netdata_ext4_entry()
 #elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
-static __always_inline int netdata_ext4_entry(struct pt_regs *ctx)
+static __always_inline int netdata_ext4_entry()
 #else
-static inline int netdata_ext4_entry(struct pt_regs *ctx)
+static inline int netdata_ext4_entry()
 #endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -52,25 +52,25 @@ static inline int netdata_ext4_entry(struct pt_regs *ctx)
 SEC("kprobe/ext4_file_read_iter")
 int netdata_ext4_file_read_iter(struct pt_regs *ctx) 
 {
-    return netdata_ext4_entry(ctx);
+    return netdata_ext4_entry();
 }
 
 SEC("kprobe/ext4_file_write_iter")
 int netdata_ext4_file_write_iter(struct pt_regs *ctx) 
 {
-    return netdata_ext4_entry(ctx);
+    return netdata_ext4_entry();
 }
 
 SEC("kprobe/ext4_file_open")
 int netdata_ext4_file_open(struct pt_regs *ctx) 
 {
-    return netdata_ext4_entry(ctx);
+    return netdata_ext4_entry();
 }
 
 SEC("kprobe/ext4_sync_file")
 int netdata_ext4_sync_file(struct pt_regs *ctx) 
 {
-    return netdata_ext4_entry(ctx);
+    return netdata_ext4_entry();
 }
 
 /************************************************************************************

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -103,7 +103,7 @@ static int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
     data /= 1000;
 
     blk.hist_id = selection;
-    blk.bin = libnetdata_select_idx(data);
+    blk.bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
 
     fill = bpf_map_lookup_elem(&tbl_ext4 ,&blk);
     if (fill) {

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -1,0 +1,144 @@
+#define KBUILD_MODNAME "ext4_netdata"
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <linux/genhd.h>
+
+#include "bpf_helpers.h"
+#include "netdata_ebpf.h"
+
+/************************************************************************************
+ *     
+ *                                 MAP Section
+ *     
+ ***********************************************************************************/
+
+struct bpf_map_def SEC("maps") tbl_ext4 = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(netdata_fs_hist_t),
+    .value_size = sizeof(__u64),
+    .max_entries = 8192
+};
+
+struct bpf_map_def SEC("maps") tmp_ext4 = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 8192
+};
+
+/************************************************************************************
+ *     
+ *                                 ENTRY Section
+ *     
+ ***********************************************************************************/
+
+static int netdata_ext4_entry(struct pt_regs *ctx)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u64 ts = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&tmp_ext4, &pid, &ts, BPF_ANY);
+
+    return 0;
+}
+
+SEC("kprobe/ext4_file_read_iter")
+int netdata_ext4_file_read_iter(struct pt_regs *ctx) 
+{
+    return netdata_ext4_entry(ctx);
+}
+
+SEC("kprobe/ext4_file_write_iter")
+int netdata_ext4_file_write_iter(struct pt_regs *ctx) 
+{
+    return netdata_ext4_entry(ctx);
+}
+
+SEC("kprobe/ext4_file_open")
+int netdata_ext4_file_open(struct pt_regs *ctx) 
+{
+    return netdata_ext4_entry(ctx);
+}
+
+SEC("kprobe/ext4_sync_file")
+int netdata_ext4_sync_file(struct pt_regs *ctx) 
+{
+    return netdata_ext4_entry(ctx);
+}
+
+/************************************************************************************
+ *     
+ *                                 END Section
+ *     
+ ***********************************************************************************/
+
+static int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
+{
+    __u64 *fill, data;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    netdata_fs_hist_t blk;
+
+    fill = bpf_map_lookup_elem(&tmp_ext4 ,&pid);
+    if (!fill)
+        return 0;
+
+    data = bpf_ktime_get_ns() - *fill;
+    bpf_map_delete_elem(&tmp_ext4, &pid);
+
+    // Skip entries with backward time
+    if ( (s64)data < 0)
+        return 0;
+
+    // convert to microseconds
+    data /= 1000;
+
+    blk.hist_id = selection;
+    blk.bin = libnetdata_select_idx(data);
+
+    fill = bpf_map_lookup_elem(&tbl_ext4 ,&blk);
+    if (fill) {
+        libnetdata_update_u64(fill, 1);
+    } else {
+        data = 1;
+        bpf_map_update_elem(&tbl_ext4, &blk, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("kretprobe/ext4_file_read_iter")
+int netdata_ret_ext4_ext4_file_read_iter(struct pt_regs *ctx)
+{
+    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_READ);
+}
+
+SEC("kretprobe/ext4_file_write_iter")
+int netdata_ret_ext4_file_write_iter(struct pt_regs *ctx)
+{
+    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_WRITE);
+}
+
+SEC("kretprobe/ext4_file_open")
+int netdata_ret_ext4_file_open(struct pt_regs *ctx)
+{
+    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("kretprobe/ext4_sync_file")
+int netdata_ret_ext4_sync_file(struct pt_regs *ctx) 
+{
+    return netdata_ext4_end(ctx, NETDATA_KEY_CALLS_SYNC);
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -40,7 +40,13 @@ struct bpf_map_def SEC("maps") tmp_ext4 = {
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
 static int netdata_ext4_entry(struct pt_regs *ctx)
+#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
+static __always_inline int netdata_ext4_entry(struct pt_regs *ctx)
+#else
+static inline int netdata_ext4_entry(struct pt_regs *ctx)
+#endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);
@@ -81,7 +87,13 @@ int netdata_ext4_sync_file(struct pt_regs *ctx)
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
 static int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
+#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
+static __always_inline int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
+#else
+static inline int netdata_ext4_end(struct pt_regs *ctx, __u32 selection)
+#endif
 {
     __u64 *fill, data;
     __u64 pid_tgid = bpf_get_current_pid_tgid();


### PR DESCRIPTION
Fixes #218 

We are monitoring the execution time to measure the latency.  All the buckets were defined using log2.

Some comments about the code to simplify reviewers life:
We are hard coding some values that we are considering safety, but remember it is possible to change these values before the eBPF program is loaded.

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.12.0  |
| Slackware Current | 5.10.41 |
| Slackware Current | 5.9.16 |
| Ubuntu 18.0.4 | 5.4.106 |
| Manjaro 21.04 | 5.4.106 |
| Ubuntu 18.0.4 | 4.15.18 |
| Slackware Current | 4.14.231 |
| CentOS 7.9.2009 | 3.10.0-1160 |
