### PR TITLE
Fix tables for ext4

### DIFF
--- a/includes/netdata_fs.h
+++ b/includes/netdata_fs.h
@@ -15,7 +15,7 @@ enum fs_counters {
 // We are using 24 as hard limit to avoid intervals bigger than
 // 8 seconds and to keep memory aligment.
 #define NETDATA_FS_MAX_BINS 24UL
-#define NETDATA_FS_MAX_TABLES 5UL
+#define NETDATA_FS_MAX_TABLES 4UL
 #define NETDATA_FS_MAX_ELEMENTS (NETDATA_FS_MAX_BINS * NETDATA_FS_MAX_TABLES)
 #define NETDATA_FS_MAX_BINS_POS (NETDATA_FS_MAX_BINS - 1)
 #define NETDATA_FS_HISTOGRAM_LENGTH  (NETDATA_FS_MAX_BINS * NETDATA_FS_MAX_BINS)

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -20,7 +20,11 @@ struct bpf_map_def SEC("maps") tbl_ext4 = {
 };
 
 struct bpf_map_def SEC("maps") tmp_ext4 = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif    
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = 4192


### PR DESCRIPTION
This PR is bringing two small fixes for EXT4:

- I am converting the temporary table from `ARRAY` to `HASH`  for we store all PIDs.
- I am reducing the number of elements for main table, because we had addresses never used.

This PR was tested on:


| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.12.0  |
| Slackware Current | 5.10.41 |
| Slackware Current | 5.9.16 |
| Ubuntu 18.0.4 | 5.4.106 |
| Manjaro 21.04 | 5.4.106 |
| Ubuntu 18.0.4 | 4.15.18 |
| Slackware Current | 4.14.231 |
| CentOS 7.9.2009 | 3.10.0-1160 |
