### PR TITLE
Convert hash table to array

### DIFF
--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -10,7 +10,7 @@
 #include "netdata_ebpf.h"
 
 struct bpf_map_def SEC("maps") cstat_global = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_CACHESTAT_END

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -13,7 +13,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") dcstat_global = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_DIRECTORY_CACHE_END

--- a/kernel/fdatasync_kern.c
+++ b/kernel/fdatasync_kern.c
@@ -12,7 +12,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_fdatasync = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END

--- a/kernel/fsync_kern.c
+++ b/kernel/fsync_kern.c
@@ -12,7 +12,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_fsync = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END

--- a/kernel/msync_kern.c
+++ b/kernel/msync_kern.c
@@ -12,7 +12,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_msync = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -27,11 +27,7 @@ struct bpf_map_def SEC("maps") tbl_pid_stats = {
 };
 
 struct bpf_map_def SEC("maps") tbl_total_stats = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
-#else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries =  NETDATA_GLOBAL_COUNTER

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -139,11 +139,7 @@ struct bpf_map_def SEC("maps") tbl_nv_udp_conn_stats = {
  * Hash table used to create charts based in calls.
 */
 struct bpf_map_def SEC("maps") tbl_sock_total_stats = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
-#else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries =  NETDATA_SOCKET_COUNTER

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -14,7 +14,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_swap = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SWAP_END

--- a/kernel/sync_file_range_kern.c
+++ b/kernel/sync_file_range_kern.c
@@ -12,7 +12,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_syncfr = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -12,7 +12,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_sync = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END

--- a/kernel/syncfs_kern.c
+++ b/kernel/syncfs_kern.c
@@ -12,7 +12,7 @@
  ***********************************************************************************/
 
 struct bpf_map_def SEC("maps") tbl_syncfs = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries = NETDATA_SYNC_END

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -27,11 +27,7 @@ struct bpf_map_def SEC("maps") tbl_vfs_pid = {
 };
 
 struct bpf_map_def SEC("maps") tbl_vfs_stats = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
-#else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u64),
     .max_entries =  NETDATA_VFS_COUNTER


### PR DESCRIPTION
We are storing sequential data in some tables, these tables do not need to be `HASH TABLES`, to speed up processing we are converting all of them to `ARRAYS`, and for functions with high frequency access, we are converting them to `PERCPU_ARRAYS`.

This PR was tested on:

| Distribution | Kernel Version |
|--------------|----------------|
|Slackware current | 5.12.9 |
|Manjaro  | 5.10.36-2 |
|Ubuntu 18.0.4  | 5.4.114 |
|Debian 10.9  | 4.19.171 |
|Ubuntu 18.0.4  | 4.15.18 |
|CentOS 7.9  | 3.10.0-1160.25 |