### PR TITLE
Add controller table and reduce memory usage

### DIFF
--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -23,6 +23,12 @@ struct netdata_error_report_t {
     int err;
 };
 
+enum netdata_controller {
+    NETDATA_CONTROLLER_APPS_ENABLED,
+
+    NETDATA_CONTROLLER_END
+};
+
 // Use __always_inline instead inline to keep compatiblity with old kernels
 // https://docs.cilium.io/en/v1.8/bpf/
 // The condition to test kernel was added, because __always_inline broke the epbf.plugin

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -27,6 +27,13 @@ struct bpf_map_def SEC("maps") cstat_pid = {
     .max_entries = PID_MAX_DEFAULT
 };
 
+struct bpf_map_def SEC("maps") cstat_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+
 /************************************************************************************
  *
  *                                   Probe Section
@@ -39,8 +46,14 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
     netdata_cachestat_t *fill, data = {};
     libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU, 1);
 
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    pid = (__u32)(pid_tgid >> 32);
     fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
     if (fill) {
         libnetdata_update_u64(&fill->add_to_page_cache_lru, 1);
@@ -58,8 +71,14 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
     netdata_cachestat_t *fill, data = {};
     libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED, 1);
 
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    pid = (__u32)(pid_tgid >> 32);
     fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
     if (fill) {
         libnetdata_update_u64(&fill->mark_page_accessed, 1);
@@ -77,8 +96,14 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
     netdata_cachestat_t *fill, data = {};
     libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
 
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    pid = (__u32)(pid_tgid >> 32);
     fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
     if (fill) {
         libnetdata_update_u64(&fill->account_page_dirtied, 1);

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -46,20 +46,20 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
     netdata_cachestat_t *fill, data = {};
     libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU, 1);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    key = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
     if (fill) {
         libnetdata_update_u64(&fill->add_to_page_cache_lru, 1);
     } else {
         data.add_to_page_cache_lru = 1;
-        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -71,20 +71,20 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
     netdata_cachestat_t *fill, data = {};
     libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED, 1);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    key = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
     if (fill) {
         libnetdata_update_u64(&fill->mark_page_accessed, 1);
     } else {
         data.mark_page_accessed = 1;
-        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -96,20 +96,20 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
     netdata_cachestat_t *fill, data = {};
     libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    key = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
     if (fill) {
         libnetdata_update_u64(&fill->account_page_dirtied, 1);
     } else {
         data.account_page_dirtied = 1;
-        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
     }
 
     return 0;

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -49,20 +49,20 @@ int netdata_lookup_fast(struct pt_regs* ctx)
     netdata_dc_stat_t *fill, data = {};
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+    key = (__u32)(pid_tgid >> 32);
+    fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
     if (fill) {
         libnetdata_update_u64(&fill->references, 1);
     } else {
         data.references = 1;
-        bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -76,20 +76,20 @@ int netdata_d_lookup(struct pt_regs* ctx)
 
     int ret = PT_REGS_RC(ctx);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&key);
     if (!apps)
         return 0;
 
     if (*apps == 1) {
         __u64 pid_tgid = bpf_get_current_pid_tgid();
-        pid = (__u32)(pid_tgid >> 32);
-        fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+        key = (__u32)(pid_tgid >> 32);
+        fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
         if (fill) {
             libnetdata_update_u64(&fill->slow, 1);
         } else {
             data.slow = 1;
-            bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+            bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
         }
     }
 
@@ -97,12 +97,12 @@ int netdata_d_lookup(struct pt_regs* ctx)
     if (ret == 0) {
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
         if (*apps == 1) {
-            fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+            fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
             if (fill) {
                 libnetdata_update_u64(&fill->missed, 1);
             } else {
                 data.missed = 1;
-                bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+                bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
             }
         }
     }

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -30,6 +30,13 @@ struct bpf_map_def SEC("maps") dcstat_pid = {
     .max_entries = PID_MAX_DEFAULT
 };
 
+struct bpf_map_def SEC("maps") dcstat_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+
 /************************************************************************************
  *
  *                                   Probe Section
@@ -42,8 +49,14 @@ int netdata_lookup_fast(struct pt_regs* ctx)
     netdata_dc_stat_t *fill, data = {};
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
 
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    pid = (__u32)(pid_tgid >> 32);
     fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
     if (fill) {
         libnetdata_update_u64(&fill->references, 1);
@@ -63,25 +76,34 @@ int netdata_d_lookup(struct pt_regs* ctx)
 
     int ret = PT_REGS_RC(ctx);
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
-    if (fill) {
-        libnetdata_update_u64(&fill->slow, 1);
-    } else {
-        data.slow = 1;
-        bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&pid);
+    if (!apps)
+        return 0;
+
+    if (*apps == 1) {
+        __u64 pid_tgid = bpf_get_current_pid_tgid();
+        pid = (__u32)(pid_tgid >> 32);
+        fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+        if (fill) {
+            libnetdata_update_u64(&fill->slow, 1);
+        } else {
+            data.slow = 1;
+            bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+        }
     }
 
     // file not found
     if (ret == 0) {
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
-        fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
-        if (fill) {
-            libnetdata_update_u64(&fill->missed, 1);
-        } else {
-            data.missed = 1;
-            bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+        if (*apps == 1) {
+            fill = bpf_map_lookup_elem(&dcstat_pid ,&pid);
+            if (fill) {
+                libnetdata_update_u64(&fill->missed, 1);
+            } else {
+                data.missed = 1;
+                bpf_map_update_elem(&dcstat_pid, &pid, &data, BPF_ANY);
+            }
         }
     }
 

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -329,7 +329,7 @@ int netdata_clone(struct pt_regs* ctx)
         libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_SYS_CLONE, 1);
     } 
 #endif
-    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&NETDATA_CONTROLLER_APPS_ENABLEDid);
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -51,20 +51,20 @@ int netdata_swap_readpage(struct pt_regs* ctx)
 
     libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_READPAGE_CALL, 1);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&swap_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&swap_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
-    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&pid);
+    key = (__u32)(pid_tgid >> 32);
+    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&key);
     if (fill) {
         libnetdata_update_u64(&fill->read, 1);
     } else {
         data.read = 1;
-        bpf_map_update_elem(&tbl_pid_swap, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_pid_swap, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -77,20 +77,20 @@ int netdata_swap_writepage(struct pt_regs* ctx)
 
     libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_WRITEPAGE_CALL, 1);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&swap_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&swap_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
-    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&pid);
+    key = (__u32)(pid_tgid >> 32);
+    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&key);
     if (fill) {
         libnetdata_update_u64(&fill->write, 1);
     } else {
         data.write = 1;
-        bpf_map_update_elem(&tbl_pid_swap, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_pid_swap, &key, &data, BPF_ANY);
     }
 
     return 0;

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -33,6 +33,13 @@ struct bpf_map_def SEC("maps") tbl_vfs_stats = {
     .max_entries =  NETDATA_VFS_COUNTER
 };
 
+struct bpf_map_def SEC("maps") vfs_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+
 /************************************************************************************
  *     
  *                                   FILE Section
@@ -53,25 +60,36 @@ int netdata_sys_write(struct pt_regs* ctx)
     struct netdata_vfs_stat_t *fill;
     struct netdata_vfs_stat_t data = { };
     __u64 tot;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITE, 1);
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
+    }
+#endif
+
+    ret = (ssize_t)PT_REGS_PARM3(ctx);
+    tot = libnetdata_log2l(ret);
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
             libnetdata_update_u32(&fill->write_err, 1) ;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
             libnetdata_update_u64(&fill->write_bytes, tot);
 #if NETDATASEL < 2
         }
@@ -82,13 +100,9 @@ int netdata_sys_write(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
             data.write_err = 1;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
             data.write_bytes = tot;
 #if NETDATASEL < 2
         }
@@ -115,24 +129,37 @@ int netdata_sys_writev(struct pt_regs* ctx)
     struct netdata_vfs_stat_t *fill;
     struct netdata_vfs_stat_t data = { };
     __u64 tot;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITEV, 1);
+
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
+    }
+#endif
+
+    ret = (ssize_t)PT_REGS_PARM3(ctx);
+    tot = libnetdata_log2l(ret);
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->writev_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
             libnetdata_update_u32(&fill->writev_err, 1) ;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
             libnetdata_update_u64(&fill->writev_bytes, tot);
 #if NETDATASEL < 2
         }
@@ -143,13 +170,9 @@ int netdata_sys_writev(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
             data.writev_err = 1;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
             data.writev_bytes = (unsigned long)tot;
 #if NETDATASEL < 2
         }
@@ -176,24 +199,37 @@ int netdata_sys_read(struct pt_regs* ctx)
     struct netdata_vfs_stat_t *fill;
     struct netdata_vfs_stat_t data = { };
     __u64 tot;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_READ, 1);
+
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
+    }
+#endif
+
+    ret = (ssize_t)PT_REGS_PARM3(ctx);
+    tot = libnetdata_log2l(ret);
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->read_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
             libnetdata_update_u32(&fill->read_err, 1) ;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
             libnetdata_update_u64(&fill->read_bytes, tot);
 #if NETDATASEL < 2
         }
@@ -204,13 +240,9 @@ int netdata_sys_read(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
             data.read_err = 1;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
             data.read_bytes = (unsigned long)tot;
 #if NETDATASEL < 2
         }
@@ -237,11 +269,28 @@ int netdata_sys_readv(struct pt_regs* ctx)
     struct netdata_vfs_stat_t *fill;
     struct netdata_vfs_stat_t data = { };
     __u64 tot;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_READV, 1);
+
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
+    }
+#endif
+
+    ret = (ssize_t)PT_REGS_PARM3(ctx);
+    tot = libnetdata_log2l(ret);
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->readv_call, 1) ;
@@ -252,9 +301,6 @@ int netdata_sys_readv(struct pt_regs* ctx)
             libnetdata_update_u32(&fill->readv_err, 1) ;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
             libnetdata_update_u64(&fill->readv_bytes, tot);
 #if NETDATASEL < 2
         }
@@ -265,13 +311,9 @@ int netdata_sys_readv(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
             data.readv_err = 1;
         } else {
 #endif
-            ret = (ssize_t)PT_REGS_PARM3(ctx);
-            tot = libnetdata_log2l(ret);
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
             data.readv_bytes = (unsigned long)tot;
 #if NETDATASEL < 2
         }
@@ -296,18 +338,30 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 #endif
     struct netdata_vfs_stat_t data = { };
     struct netdata_vfs_stat_t *fill;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_UNLINK, 1);
+
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
+    } 
+#endif
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
             libnetdata_update_u32(&fill->unlink_err, 1) ;
         } 
 #endif
@@ -317,7 +371,6 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
             data.unlink_err = 1;
         } else {
 #endif
@@ -345,18 +398,30 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 #endif
     struct netdata_vfs_stat_t data = { };
     struct netdata_vfs_stat_t *fill;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_FSYNC, 1);
+
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
+    } 
+#endif
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->fsync_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
             libnetdata_update_u32(&fill->fsync_err, 1) ;
         } 
 #endif
@@ -366,7 +431,6 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
             data.fsync_err = 1;
         } else {
 #endif
@@ -394,18 +458,30 @@ int netdata_vfs_open(struct pt_regs* ctx)
 #endif
     struct netdata_vfs_stat_t data = { };
     struct netdata_vfs_stat_t *fill;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_OPEN, 1);
+    
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
+    } 
+#endif
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
             libnetdata_update_u32(&fill->open_err, 1) ;
         } 
 #endif
@@ -415,7 +491,6 @@ int netdata_vfs_open(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
             data.open_err = 1;
         } else {
 #endif
@@ -443,18 +518,30 @@ int netdata_vfs_create(struct pt_regs* ctx)
 #endif
     struct netdata_vfs_stat_t data = { };
     struct netdata_vfs_stat_t *fill;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_CREATE, 1);
+
+#if NETDATASEL < 2
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
+    } 
+#endif
+
+    __u32 pid = 0;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
     fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
     if (fill) {
         libnetdata_update_u32(&fill->create_call, 1) ;
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
             libnetdata_update_u32(&fill->create_err, 1) ;
         } 
 #endif
@@ -464,7 +551,6 @@ int netdata_vfs_create(struct pt_regs* ctx)
 
 #if NETDATASEL < 2
         if (ret < 0) {
-            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
             data.create_err = 1;
         } else {
 #endif

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -61,8 +61,8 @@ int netdata_sys_write(struct pt_regs* ctx)
     struct netdata_vfs_stat_t data = { };
     __u64 tot;
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
@@ -79,9 +79,9 @@ int netdata_sys_write(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
@@ -109,7 +109,7 @@ int netdata_sys_write(struct pt_regs* ctx)
 #endif
         data.write_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -142,16 +142,16 @@ int netdata_sys_writev(struct pt_regs* ctx)
     tot = libnetdata_log2l(ret);
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->writev_call, 1) ;
 
@@ -179,7 +179,7 @@ int netdata_sys_writev(struct pt_regs* ctx)
 #endif
         data.writev_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -212,16 +212,16 @@ int netdata_sys_read(struct pt_regs* ctx)
     tot = libnetdata_log2l(ret);
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->read_call, 1) ;
 
@@ -249,7 +249,7 @@ int netdata_sys_read(struct pt_regs* ctx)
 #endif
         data.read_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -282,16 +282,16 @@ int netdata_sys_readv(struct pt_regs* ctx)
     tot = libnetdata_log2l(ret);
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->readv_call, 1) ;
 
@@ -320,7 +320,7 @@ int netdata_sys_readv(struct pt_regs* ctx)
 #endif
         data.readv_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -347,16 +347,16 @@ int netdata_sys_unlink(struct pt_regs* ctx)
     } 
 #endif
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
@@ -380,7 +380,7 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 #endif
         data.unlink_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -407,16 +407,16 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
     } 
 #endif
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->fsync_call, 1) ;
 
@@ -440,7 +440,7 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 #endif
         data.fsync_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -467,16 +467,16 @@ int netdata_vfs_open(struct pt_regs* ctx)
     } 
 #endif
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
@@ -500,7 +500,7 @@ int netdata_vfs_open(struct pt_regs* ctx)
 #endif
         data.open_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;
@@ -527,16 +527,16 @@ int netdata_vfs_create(struct pt_regs* ctx)
     } 
 #endif
 
-    __u32 pid = 0;
-    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&pid);
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    key = (__u32)(pid_tgid >> 32);
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&pid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
     if (fill) {
         libnetdata_update_u32(&fill->create_call, 1) ;
 
@@ -560,7 +560,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
 #endif
         data.create_call = 1;
 
-        bpf_map_update_elem(&tbl_vfs_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
     }
 
     return 0;


### PR DESCRIPTION
This PR is adding a new table (array) that will allow us to reduce the memory usage for the minimum possible(4096B) when integration with `apps.plugin` is disabled. This is also a necessary step to integrate `eBPF.plugin` with `systemd`.

I am also using this PR to  remove a dead code from `process_ kern`.

I am not touching `socket`, because this specific eBPF program will have a PR for it. It will be an important part of the integration with `systemd` and I plan to split it in two different eBPF programs.

This PR was tested on :

| Distribution | Kernel Version |
|--------------|----------------|
|Slackware current | 5.12.10 |
|Manjaro  | 5.10.41-1 |
|Ubuntu 18.4 | 5.4.114|
|Ubuntu 18.0.4  | 4.15.18 
|Slackware current | 4.14.236 |
|CentOS 7.9  | 3.10.0-1160.25 | 
