### PR TITLE
Disk latency

### DIFF
--- a/includes/netdata_disk.h
+++ b/includes/netdata_disk.h
@@ -38,14 +38,6 @@ typedef struct netdata_disk_key {
     sector_t sector;
 } netdata_disk_key_t;
 
-typedef struct netdata_bootsector {
-    u64 start_sector;
-    u64 end_sector;
-    u64 timestamp;
-    u64 changed_sector;
-    u64 size;
-} netdata_bootsector_t;
-
 typedef struct block_key {
     __u32 bin;
     u32 dev;

--- a/includes/netdata_disk.h
+++ b/includes/netdata_disk.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_DISK_H_
+#define _NETDATA_DISK_H_ 1
+
+#include "netdata_fs.h"
+
+#define NETDATA_DISK_MAX_HD 256L
+#define NETDATA_DISK_HISTOGRAM_LENGTH  (NETDATA_FS_MAX_BINS * NETDATA_DISK_MAX_HD)
+
+// /sys/kernel/debug/tracing/events/block/block_rq_issue/
+struct netdata_block_rq_issue {
+    u64 pad;                    // This is not used with eBPF
+    dev_t dev;                  // offset:8;       size:4; signed:0;
+    sector_t sector;            // offset:16;      size:8; signed:0;
+    unsigned int nr_sector;     // offset:24;      size:4; signed:0;
+    unsigned int bytes;         // offset:28;      size:4; signed:0;
+    char rwbs[8];               // offset:32;      size:8; signed:1;
+    char comm[16];              // offset:40;      size:16;        signed:1;
+    int data_loc_name;          // offset:56;      size:4; signed:1; (https://github.com/iovisor/bpftrace/issues/385)
+};
+
+// /sys/kernel/debug/tracing/events/block/block_rq_complete
+// https://elixir.bootlin.com/linux/latest/source/include/trace/events/block.h
+struct netdata_block_rq_complete {
+    u64 pad;                    // This is not used with eBPF
+    dev_t dev;                  // offset:8;       size:4; signed:0;
+    sector_t sector;            // offset:16;      size:8; signed:0;
+    unsigned int nr_sector;     // offset:24;      size:4; signed:0;
+    int error;                  // offset:28;      size:4; signed:1;
+    char rwbs[8];               // offset:32;      size:8; signed:1;
+    int data_loc_name;          // offset:40;      size:4; signed:1; ()https://lists.linuxfoundation.org/pipermail/iovisor-dev/2017-February/000627.html
+};
+
+typedef struct netdata_disk_key {
+    dev_t dev;
+    sector_t sector;
+} netdata_disk_key_t;
+
+typedef struct netdata_bootsector {
+    u64 start_sector;
+    u64 end_sector;
+    u64 timestamp;
+    u64 changed_sector;
+    u64 size;
+} netdata_bootsector_t;
+
+typedef struct block_key {
+    __u32 bin;
+    u32 dev;
+} block_key_t;
+
+#endif /* _NETDATA_DISK_H_ */
+

--- a/includes/netdata_disk.h
+++ b/includes/netdata_disk.h
@@ -29,7 +29,8 @@ struct netdata_block_rq_complete {
     unsigned int nr_sector;     // offset:24;      size:4; signed:0;
     int error;                  // offset:28;      size:4; signed:1;
     char rwbs[8];               // offset:32;      size:8; signed:1;
-    int data_loc_name;          // offset:40;      size:4; signed:1; ()https://lists.linuxfoundation.org/pipermail/iovisor-dev/2017-February/000627.html
+    int data_loc_name;          // offset:40;      size:4; signed:1; 
+                                //(https://lists.linuxfoundation.org/pipermail/iovisor-dev/2017-February/000627.html)
 };
 
 typedef struct netdata_disk_key {

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -8,6 +8,7 @@
 
 #include "netdata_cache.h"
 #include "netdata_dc.h"
+#include "netdata_disk.h"
 #include "netdata_fs.h"
 #include "netdata_network.h"
 #include "netdata_process.h"

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,6 +34,7 @@ CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATC
 
 NETDATA_APPS= cachestat \
 	      dc \
+	      disk \
 	      ext4 \
 	      fdatasync \
 	      fsync \

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -1,0 +1,125 @@
+#define KBUILD_MODNAME "disk_netdata"
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <linux/genhd.h>
+
+#include "bpf_helpers.h"
+#include "netdata_ebpf.h"
+
+/************************************************************************************
+ *     
+ *                                 MAPS
+ *     
+ ***********************************************************************************/
+
+//Hardware
+struct bpf_map_def SEC("maps") tbl_disk_rcall = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(block_key_t),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_DISK_HISTOGRAM_LENGTH
+};
+
+struct bpf_map_def SEC("maps") tbl_disk_wcall = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(block_key_t),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_DISK_HISTOGRAM_LENGTH
+};
+
+// Temporary use only
+struct bpf_map_def SEC("maps") tmp_disk_tp_stat = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(netdata_disk_key_t),
+    .value_size = sizeof(__u64),
+    .max_entries = 8192
+};
+
+/************************************************************************************
+ *     
+ *                                 DISK SECTION
+ *     
+ ***********************************************************************************/
+
+// Probably it is available after 4.13 only
+
+SEC("tracepoint/block/block_rq_issue")
+int netdata_block_rq_issue(struct netdata_block_rq_issue *ptr)
+{
+    // blkid generates these and we're not interested in them
+    if (!ptr->dev)
+        return 0;
+
+    netdata_disk_key_t key = {};
+    key.dev = ptr->dev;
+    key.sector = ptr->sector;
+
+    if (key.sector < 0)
+        key.sector = 0;
+
+    __u64 value = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&tmp_disk_tp_stat, &key, &value, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/block/block_rq_complete")
+int netdata_block_rq_complete(struct netdata_block_rq_complete *ptr)
+{
+    __u64 *fill;
+    netdata_disk_key_t key = {};
+    block_key_t blk = {};
+    key.dev = ptr->dev;
+    key.sector = ptr->sector;
+
+    if (key.sector < 0)
+        key.sector = 0;
+
+    fill = bpf_map_lookup_elem(&tmp_disk_tp_stat ,&key);
+    if (!fill)
+        return 0;
+
+    // W - write
+    // S - Sync
+    int selector = ((ptr->rwbs[0] == 'F') || (ptr->rwbs[0] == 'S') || (ptr->rwbs[0] == 'W') ||
+                    (ptr->rwbs[1] == 'F') || (ptr->rwbs[1] == 'S') || (ptr->rwbs[0] == 'W'));
+
+    // calculate and convert to microsecond
+    u64 curr = bpf_ktime_get_ns();
+    __u64 data, *update;
+    curr -= *fill;
+    curr /= 1000;
+
+    blk.bin = libnetdata_select_idx(curr, NETDATA_FS_MAX_BINS_POS);
+    blk.dev = new_encode_dev(ptr->dev);
+
+    // Update IOPS
+    struct bpf_map_def *tbl = (!selector)?&tbl_disk_rcall:&tbl_disk_wcall;
+    update = bpf_map_lookup_elem(tbl ,&blk);
+    if (update) {
+        libnetdata_update_u64(update, 1);
+    } else {
+        data = 1;
+        bpf_map_update_elem(tbl, &blk, &data, BPF_ANY);
+    }
+
+    bpf_map_delete_elem(&tmp_disk_tp_stat, &key);
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+


### PR DESCRIPTION
This PR is bringing `tracepoints` for Netdata.

When it is merged, we will be able to monitor disk latency independent of the filesystem used on disk.

This PR was already tested on:

| Distribution | Kernel Version |
|--------------|----------------|
|Slackware current | 5.12.12 |
|Manjaro  | 5.10.42-1 |
|Ubuntu 18.0.4  | 5.4.114 |
|Debian 10.9  | 4.19.171 |
|Ubuntu 18.0.4  | 4.15.18 |
|Slackware current | 4.14.236 |
|CentOS 7.9  | 3.10.0-1160.25 | 

