### PR TITLE
eBPF mount

### DIFF
--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -10,6 +10,7 @@
 #include "netdata_dc.h"
 #include "netdata_disk.h"
 #include "netdata_fs.h"
+#include "netdata_mount.h"
 #include "netdata_network.h"
 #include "netdata_process.h"
 #include "netdata_sync.h"

--- a/includes/netdata_mount.h
+++ b/includes/netdata_mount.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_MOUNT_H_
+#define _NETDATA_MOUNT_H_ 1
+
+enum mount_counters {
+    NETDATA_KEY_MOUNT_CALL,
+    NETDATA_KEY_UMOUNT_CALL,
+    NETDATA_KEY_MOUNT_ERROR,
+    NETDATA_KEY_UMOUNT_ERROR,
+
+    NETDATA_MOUNT_END
+};
+
+#endif /* _NETDATA_MOUNT_H_ */
+

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -39,6 +39,7 @@ NETDATA_APPS= btrfs \
 	      ext4 \
 	      fdatasync \
 	      fsync \
+	      mount \
 	      msync \
 	      nfs \
 	      socket \

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -27,6 +27,7 @@ Right now we have two `eBPF` program collections:
 -  `ext4_kern.c`           : eBPF program that provides ext4 monitoring.
 -  `fdatasync_kern.c`      : eBPF program that monitor calls for syscall `fdatasync`.
 -  `fsync_kern.c`          : eBPF program that monitor calls for syscall `fsync`.
+-  `mount_kern.c`          : eBPF program that monitor calls for syscalls `mount` and `umount`.
 -  `msync_kern.c`          : eBPF program that monitor calls for syscall `msync`.
 -  `nfs_kern.c`            : eBPF program that provides nfs monitoring.
 -  `process_kern.c`        : eBPF program that provides process, file and VFS stats.
@@ -38,3 +39,4 @@ Right now we have two `eBPF` program collections:
 -  `vfs_kern.c`            : eBPF program that monitor Virtual Filesystem functions.
 -  `xfs_kern.c`            : eBPF program that provides XFS monitoring.
 -  `zfs_kern.c`            : eBPF program that provides ZFS monitoring.
+

--- a/kernel/mount_kern.c
+++ b/kernel/mount_kern.c
@@ -1,0 +1,68 @@
+#define KBUILD_MODNAME "mount_netdata"
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+
+#include "bpf_helpers.h"
+#include "netdata_ebpf.h"
+
+/************************************************************************************
+ *     
+ *                                 MAPS
+ *     
+ ***********************************************************************************/
+
+struct bpf_map_def SEC("maps") tbl_mount = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_MOUNT_END
+};
+
+/************************************************************************************
+ *
+ *                               MOUNT SECTION
+ *
+ ***********************************************************************************/
+
+#if NETDATASEL < 2
+SEC("kretprobe/" NETDATA_SYSCALL(mount))
+#else
+SEC("kprobe/" NETDATA_SYSCALL(mount))
+#endif
+int netdata_syscall_mount(struct pt_regs* ctx)
+{
+    libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_CALL, 1);
+#if NETDATASEL < 2
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_ERROR, 1);
+#endif
+
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/" NETDATA_SYSCALL(umount))
+#else
+SEC("kprobe/" NETDATA_SYSCALL(umount))
+#endif
+int netdata_syscall_umount(struct pt_regs* ctx)
+{
+    libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_CALL, 1);
+#if NETDATASEL < 2
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_ERROR, 1);
+#endif
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                             END MOUNT SECTION
+ *
+ ***********************************************************************************/
+
+char _license[] SEC("license") = "GPL";
+


### PR DESCRIPTION
Bring monitoring for `mount` and `umount` syscalls.

This PR was tested on : 


| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.13.4  |
| Manajaro | 5.10.49 |
| Ubuntu 18.04 | 5.4.119 |
| Slackware Current | 4.14.239 |
