### PR TITLE
Software IRQ latency tracking

### DIFF
--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -21,6 +21,7 @@ This header has the common definitions for all `.c` files.
 #include "netdata_mount.h"
 #include "netdata_process.h"
 #include "netdata_socket.h"
+#include "netdata_softirq.h"
 #include "netdata_sync.h"
 #include "netdata_swap.h"
 #include "netdata_vfs.h"

--- a/includes/netdata_softirq.h
+++ b/includes/netdata_softirq.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_SOFTIRQ_H_
+#define _NETDATA_SOFTIRQ_H_ 1
+
+// /sys/kernel/debug/tracing/events/irq/softirq_entry
+struct netdata_softirq_entry {
+    u64 pad;                    // This is not used with eBPF
+    unsigned int vec;           // offset:8;       size:4; signed:0;
+};
+
+// /sys/kernel/debug/tracing/events/irq/softirq_exit
+struct netdata_softirq_exit {
+    u64 pad;                    // This is not used with eBPF
+    unsigned int vec;           // offset:8;       size:4; signed:0;
+};
+
+typedef struct softirq_val {
+    // incremental counter storing the total latency so far.
+    u64 latency;
+
+    // temporary timestamp stored at the entry handler, to be diff'd with a
+    // timestamp at the exit handler, to get the latency to add to the
+    // `latency` field.
+    u64 ts;
+} softirq_val_t;
+
+#endif /* _NETDATA_SOFTIRQ_H_ */

--- a/includes/netdata_softirq.h
+++ b/includes/netdata_softirq.h
@@ -3,16 +3,18 @@
 #ifndef _NETDATA_SOFTIRQ_H_
 #define _NETDATA_SOFTIRQ_H_ 1
 
+#define NETDATA_SOFTIRQ_MAX_IRQS 10
+
 // /sys/kernel/debug/tracing/events/irq/softirq_entry
 struct netdata_softirq_entry {
     u64 pad;                    // This is not used with eBPF
-    unsigned int vec;           // offset:8;       size:4; signed:0;
+    u32 vec;                    // offset:8;       size:4; signed:0;
 };
 
 // /sys/kernel/debug/tracing/events/irq/softirq_exit
 struct netdata_softirq_exit {
     u64 pad;                    // This is not used with eBPF
-    unsigned int vec;           // offset:8;       size:4; signed:0;
+    u32 vec;                    // offset:8;       size:4; signed:0;
 };
 
 typedef struct softirq_val {

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -44,8 +44,9 @@ NETDATA_APPS= btrfs \
 	      mount \
 	      msync \
 	      nfs \
-	      socket \
 	      process \
+	      socket \
+	      softirq \
 	      sync \
 	      sync_file_range \
 	      syncfs \

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -28,6 +28,7 @@ Right now we have the following `eBPF` program collectors:
 - `nfs_kern.c`            : provides nfs monitoring.
 - `process_kern.c`        : provides process, file and VFS stats.
 - `socket_kern.c`         : provides network stats;
+- `softirq_kern.c`        : provides software interrupt (soft IRQ) latency monitoring.
 - `swap_kern.c`           : provides swap stats;
 - `sync_file_range_kern.c`: monitor calls for syscall `sync_file_range`.
 - `sync_kern.c`           : monitor calls for syscall `sync`.

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -67,3 +67,5 @@ int netdata_softirq_exit(struct netdata_softirq_exit *ptr)
 
     return 0;
 }
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -1,0 +1,58 @@
+#define KBUILD_MODNAME "softirq_netdata"
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <linux/genhd.h>
+
+#include "bpf_helpers.h"
+#include "netdata_ebpf.h"
+
+/************************************************************************************
+ *                                 MAPS
+ ***********************************************************************************/
+
+// maps from irq index to latency.
+// there are only 10 software IRQs, all statically defined in the kernel.
+struct bpf_map_def SEC("maps") tbl_softirq = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(softirq_val_t),
+    .max_entries = 10
+};
+
+/************************************************************************************
+ *                                SOFTIRQ SECTION
+ ***********************************************************************************/
+
+SEC("tracepoint/irq/softirq_entry")
+int netdata_softirq_entry(struct netdata_softirq_entry *ptr)
+{
+    softirq_val_t *valp, val = {};
+
+    valp = bpf_map_lookup_elem(&tbl_softirq, &ptr->vec);
+    if (!valp) {
+        valp = &val;
+        val.latency = 0;
+    }
+
+    valp->ts = bpf_ktime_get_ns();
+    bpf_map_update_elem(&tbl_softirq, &ptr->vec, valp, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/irq/softirq_exit")
+int netdata_softirq_exit(struct netdata_softirq_exit *ptr)
+{
+    softirq_val_t *valp;
+
+    valp = bpf_map_lookup_elem(&tbl_softirq, &ptr->vec);
+    if (!valp) {
+        return 0;
+    }
+
+    // get time diff and convert to microseconds.
+    u64 latency = (bpf_ktime_get_ns() - valp->ts) / 1000;
+    libnetdata_update_u64(&valp->latency, latency);
+
+    return 0;
+}

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -35,12 +35,13 @@ int netdata_softirq_entry(struct netdata_softirq_entry *ptr)
 
     valp = bpf_map_lookup_elem(&tbl_softirq, &vec);
     if (!valp) {
-        valp = &val;
         val.latency = 0;
+    } else {
+        val.latency = valp->latency;
     }
 
-    valp->ts = bpf_ktime_get_ns();
-    bpf_map_update_elem(&tbl_softirq, &vec, valp, BPF_ANY);
+    val.ts = bpf_ktime_get_ns();
+    bpf_map_update_elem(&tbl_softirq, &vec, &val, BPF_ANY);
 
     return 0;
 }


### PR DESCRIPTION
https://github.com/netdata/product/issues/2154

Tested with:

- Ubuntu 18.04 (Linux 4.15)
- Ubuntu 21.04 (Linux 5.11.0-31)
- CentOS 7 (Linux 3.10)