### PR TITLE
Fix hardirq/softirq value init logic

### DIFF
--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -41,15 +41,14 @@ int netdata_irq_handler_entry(struct netdata_irq_handler_entry *ptr)
 
     key.irq = ptr->irq;
     valp = bpf_map_lookup_elem(&tbl_hardirq, &key);
-    if (!valp) {
-        val.latency = 0;
-        TP_DATA_LOC_READ_CONST(val.name, ptr, ptr->data_loc_name, NETDATA_HARDIRQ_NAME_LEN);
+    if (valp) {
+        valp->ts = bpf_ktime_get_ns();
     } else {
-        val.latency = valp->latency;
+        val.latency = 0;
+        val.ts = bpf_ktime_get_ns();
+        TP_DATA_LOC_READ_CONST(val.name, ptr, ptr->data_loc_name, NETDATA_HARDIRQ_NAME_LEN);
+        bpf_map_update_elem(&tbl_hardirq, &key, &val, BPF_ANY);
     }
-
-    val.ts = bpf_ktime_get_ns();
-    bpf_map_update_elem(&tbl_hardirq, &key, &val, BPF_ANY);
 
     return 0;
 }
@@ -85,14 +84,13 @@ int netdata_irq_ ##__type(struct netdata_irq_vectors_entry *ptr)              \
                                                                               \
     idx = __enum_idx;                                                         \
     valp = bpf_map_lookup_elem(&tbl_hardirq_static, &idx);                    \
-    if (!valp) {                                                              \
-        val.latency = 0;                                                      \
+    if (valp) {                                                               \
+        valp->ts = bpf_ktime_get_ns();                                        \
     } else {                                                                  \
-        val.latency = valp->latency;                                          \
+        val.latency = 0;                                                      \
+        val.ts = bpf_ktime_get_ns();                                          \
+        bpf_map_update_elem(&tbl_hardirq_static, &idx, &val, BPF_ANY);        \
     }                                                                         \
-                                                                              \
-    val.ts = bpf_ktime_get_ns();                                              \
-    bpf_map_update_elem(&tbl_hardirq_static, &idx, &val, BPF_ANY);            \
                                                                               \
     return 0;                                                                 \
 }

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -34,14 +34,13 @@ int netdata_softirq_entry(struct netdata_softirq_entry *ptr)
     }
 
     valp = bpf_map_lookup_elem(&tbl_softirq, &vec);
-    if (!valp) {
-        val.latency = 0;
+    if (valp) {
+        valp->ts = bpf_ktime_get_ns();
     } else {
-        val.latency = valp->latency;
+        val.latency = 0;
+        val.ts = bpf_ktime_get_ns();
+        bpf_map_update_elem(&tbl_softirq, &vec, &val, BPF_ANY);
     }
-
-    val.ts = bpf_ktime_get_ns();
-    bpf_map_update_elem(&tbl_softirq, &vec, &val, BPF_ANY);
 
     return 0;
 }


### PR DESCRIPTION
I did not realize that `valp` in the entrypoint functions was pointing to the *actual* ebpf map value, and that the update we do on it will persist for the value in the actual map.

This PR fixes it so we take this into account. Other collectors, including the swap one, do the same thing.

Tested with:

- Ubuntu 18.04 (Linux 4.15)
- Ubuntu 21.04 (Linux 5.11.0-31)
- CentOS 7 (Linux 3.10)