### PR TITLE
Update libbpf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libbpf"]
+	path = libbpf
+	url = https://github.com/netdata/libbpf

--- a/includes/netdata_bpf_helpers.h
+++ b/includes/netdata_bpf_helpers.h
@@ -22,7 +22,7 @@ static int (*bpf_map_delete_elem)(void *map, void *key) =
 static int (*bpf_probe_read)(void *dst, int size, void *unsafe_ptr) =
 	(void *) BPF_FUNC_probe_read;
 static int (*bpf_probe_read_str)(void *dst, int size, void *unsafe_ptr) =
-	(void *)BPF_FUNC_probe_read_str        
+	(void *)BPF_FUNC_probe_read_str;
 static unsigned long long (*bpf_ktime_get_ns)(void) =
 	(void *) BPF_FUNC_ktime_get_ns;
 static int (*bpf_trace_printk)(const char *fmt, int fmt_size, ...) =

--- a/includes/netdata_bpf_helpers.h
+++ b/includes/netdata_bpf_helpers.h
@@ -1,0 +1,215 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copied from $(LINUX)/tools/testing/selftests/bpf/bpf_helpers.h */
+#ifndef __BPF_HELPERS_H
+#define __BPF_HELPERS_H
+
+/* helper macro to place programs, maps, license in
+ * different sections in elf_bpf file. Section names
+ * are interpreted by elf_bpf loader
+ */
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+#include <linux/version.h>
+
+/* helper functions called from eBPF programs written in C */
+static void *(*bpf_map_lookup_elem)(void *map, void *key) =
+	(void *) BPF_FUNC_map_lookup_elem;
+static int (*bpf_map_update_elem)(void *map, void *key, void *value,
+				  unsigned long long flags) =
+	(void *) BPF_FUNC_map_update_elem;
+static int (*bpf_map_delete_elem)(void *map, void *key) =
+	(void *) BPF_FUNC_map_delete_elem;
+static int (*bpf_probe_read)(void *dst, int size, void *unsafe_ptr) =
+	(void *) BPF_FUNC_probe_read;
+static unsigned long long (*bpf_ktime_get_ns)(void) =
+	(void *) BPF_FUNC_ktime_get_ns;
+static int (*bpf_trace_printk)(const char *fmt, int fmt_size, ...) =
+	(void *) BPF_FUNC_trace_printk;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+static void (*bpf_tail_call)(void *ctx, void *map, int index) =
+	(void *) BPF_FUNC_tail_call;
+#endif
+static unsigned long long (*bpf_get_smp_processor_id)(void) =
+	(void *) BPF_FUNC_get_smp_processor_id;
+static unsigned long long (*bpf_get_current_pid_tgid)(void) =
+	(void *) BPF_FUNC_get_current_pid_tgid;
+static unsigned long long (*bpf_get_current_uid_gid)(void) =
+	(void *) BPF_FUNC_get_current_uid_gid;
+static int (*bpf_get_current_comm)(void *buf, int buf_size) =
+	(void *) BPF_FUNC_get_current_comm;
+static unsigned long long (*bpf_perf_event_read)(void *map,
+						 unsigned long long flags) =
+	(void *) BPF_FUNC_perf_event_read;
+static int (*bpf_clone_redirect)(void *ctx, int ifindex, int flags) =
+	(void *) BPF_FUNC_clone_redirect;
+static int (*bpf_redirect)(int ifindex, int flags) =
+	(void *) BPF_FUNC_redirect;
+static int (*bpf_perf_event_output)(void *ctx, void *map,
+				    unsigned long long flags, void *data,
+				    int size) =
+	(void *) BPF_FUNC_perf_event_output;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+static int (*bpf_get_stackid)(void *ctx, void *map, int flags) =
+	(void *) BPF_FUNC_get_stackid;
+#endif
+static int (*bpf_probe_write_user)(void *dst, void *src, int size) =
+	(void *) BPF_FUNC_probe_write_user;
+static int (*bpf_current_task_under_cgroup)(void *map, int index) =
+	(void *) BPF_FUNC_current_task_under_cgroup;
+static int (*bpf_skb_get_tunnel_key)(void *ctx, void *key, int size, int flags) =
+	(void *) BPF_FUNC_skb_get_tunnel_key;
+static int (*bpf_skb_set_tunnel_key)(void *ctx, void *key, int size, int flags) =
+	(void *) BPF_FUNC_skb_set_tunnel_key;
+static int (*bpf_skb_get_tunnel_opt)(void *ctx, void *md, int size) =
+	(void *) BPF_FUNC_skb_get_tunnel_opt;
+static int (*bpf_skb_set_tunnel_opt)(void *ctx, void *md, int size) =
+	(void *) BPF_FUNC_skb_set_tunnel_opt;
+static unsigned long long (*bpf_get_prandom_u32)(void) =
+	(void *) BPF_FUNC_get_prandom_u32;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+static int (*bpf_xdp_adjust_head)(void *ctx, int offset) =
+	(void *) BPF_FUNC_xdp_adjust_head;
+#endif
+
+/* llvm builtin functions that eBPF C program may use to
+ * emit BPF_LD_ABS and BPF_LD_IND instructions
+ */
+struct sk_buff;
+unsigned long long load_byte(void *skb,
+			     unsigned long long off) asm("llvm.bpf.load.byte");
+unsigned long long load_half(void *skb,
+			     unsigned long long off) asm("llvm.bpf.load.half");
+unsigned long long load_word(void *skb,
+			     unsigned long long off) asm("llvm.bpf.load.word");
+
+/* a helper structure used by eBPF C program
+ * to describe map attributes to elf_bpf loader
+ */
+struct bpf_map_def {
+	unsigned int type;
+	unsigned int key_size;
+	unsigned int value_size;
+	unsigned int max_entries;
+	unsigned int map_flags;
+	unsigned int inner_map_idx;
+};
+
+static int (*bpf_skb_load_bytes)(void *ctx, int off, void *to, int len) =
+	(void *) BPF_FUNC_skb_load_bytes;
+static int (*bpf_skb_store_bytes)(void *ctx, int off, void *from, int len, int flags) =
+	(void *) BPF_FUNC_skb_store_bytes;
+static int (*bpf_l3_csum_replace)(void *ctx, int off, int from, int to, int flags) =
+	(void *) BPF_FUNC_l3_csum_replace;
+static int (*bpf_l4_csum_replace)(void *ctx, int off, int from, int to, int flags) =
+	(void *) BPF_FUNC_l4_csum_replace;
+static int (*bpf_skb_under_cgroup)(void *ctx, void *map, int index) =
+	(void *) BPF_FUNC_skb_under_cgroup;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+static int (*bpf_skb_change_head)(void *, int len, int flags) =
+	(void *) BPF_FUNC_skb_change_head;
+#endif
+
+#if defined(__x86_64__)
+
+#define PT_REGS_PARM1(x) ((x)->di)
+#define PT_REGS_PARM2(x) ((x)->si)
+#define PT_REGS_PARM3(x) ((x)->dx)
+#define PT_REGS_PARM4(x) ((x)->cx)
+#define PT_REGS_PARM5(x) ((x)->r8)
+#define PT_REGS_RET(x) ((x)->sp)
+#define PT_REGS_FP(x) ((x)->bp)
+#define PT_REGS_RC(x) ((x)->ax)
+#define PT_REGS_SP(x) ((x)->sp)
+#define PT_REGS_IP(x) ((x)->ip)
+
+#elif defined(__s390x__)
+
+#define PT_REGS_PARM1(x) ((x)->gprs[2])
+#define PT_REGS_PARM2(x) ((x)->gprs[3])
+#define PT_REGS_PARM3(x) ((x)->gprs[4])
+#define PT_REGS_PARM4(x) ((x)->gprs[5])
+#define PT_REGS_PARM5(x) ((x)->gprs[6])
+#define PT_REGS_RET(x) ((x)->gprs[14])
+#define PT_REGS_FP(x) ((x)->gprs[11]) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->gprs[2])
+#define PT_REGS_SP(x) ((x)->gprs[15])
+#define PT_REGS_IP(x) ((x)->psw.addr)
+
+#elif defined(__aarch64__)
+
+#define PT_REGS_PARM1(x) ((x)->regs[0])
+#define PT_REGS_PARM2(x) ((x)->regs[1])
+#define PT_REGS_PARM3(x) ((x)->regs[2])
+#define PT_REGS_PARM4(x) ((x)->regs[3])
+#define PT_REGS_PARM5(x) ((x)->regs[4])
+#define PT_REGS_RET(x) ((x)->regs[30])
+#define PT_REGS_FP(x) ((x)->regs[29]) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->regs[0])
+#define PT_REGS_SP(x) ((x)->sp)
+#define PT_REGS_IP(x) ((x)->pc)
+
+#elif defined(__powerpc__)
+
+#define PT_REGS_PARM1(x) ((x)->gpr[3])
+#define PT_REGS_PARM2(x) ((x)->gpr[4])
+#define PT_REGS_PARM3(x) ((x)->gpr[5])
+#define PT_REGS_PARM4(x) ((x)->gpr[6])
+#define PT_REGS_PARM5(x) ((x)->gpr[7])
+#define PT_REGS_RC(x) ((x)->gpr[3])
+#define PT_REGS_SP(x) ((x)->sp)
+#define PT_REGS_IP(x) ((x)->nip)
+
+#elif defined(__sparc__)
+
+#define PT_REGS_PARM1(x) ((x)->u_regs[UREG_I0])
+#define PT_REGS_PARM2(x) ((x)->u_regs[UREG_I1])
+#define PT_REGS_PARM3(x) ((x)->u_regs[UREG_I2])
+#define PT_REGS_PARM4(x) ((x)->u_regs[UREG_I3])
+#define PT_REGS_PARM5(x) ((x)->u_regs[UREG_I4])
+#define PT_REGS_RET(x) ((x)->u_regs[UREG_I7])
+#define PT_REGS_RC(x) ((x)->u_regs[UREG_I0])
+#define PT_REGS_SP(x) ((x)->u_regs[UREG_FP])
+#if defined(__arch64__)
+#define PT_REGS_IP(x) ((x)->tpc)
+#else
+#define PT_REGS_IP(x) ((x)->pc)
+#endif
+
+#endif
+
+#ifdef __powerpc__
+#define BPF_KPROBE_READ_RET_IP(ip, ctx)		({ (ip) = (ctx)->link; })
+#define BPF_KRETPROBE_READ_RET_IP		BPF_KPROBE_READ_RET_IP
+#elif defined(__sparc__)
+#define BPF_KPROBE_READ_RET_IP(ip, ctx)		({ (ip) = PT_REGS_RET(ctx); })
+#define BPF_KRETPROBE_READ_RET_IP		BPF_KPROBE_READ_RET_IP
+#else
+#define BPF_KPROBE_READ_RET_IP(ip, ctx)		({				\
+		bpf_probe_read(&(ip), sizeof(ip), (void *)PT_REGS_RET(ctx)); })
+#define BPF_KRETPROBE_READ_RET_IP(ip, ctx)	({				\
+		bpf_probe_read(&(ip), sizeof(ip),				\
+				(void *)(PT_REGS_FP(ctx) + sizeof(ip))); })
+#endif
+
+/*
+the TP_DATA_LOC_READ_* macros are used for reading from a field that's pointed
+to by a __data_loc variable.
+
+FYI, a __data_loc variable is really an int that contains within it the data
+needed to get the location of the actual value. these macros do the
+transformation needed to get that final location and then read from it.
+
+this code is from iovisor/bcc file src/cc/exports/helpers.h and modified by
+Netdata's Agent team for inclusion in Netdata.
+*/
+#define TP_DATA_LOC_READ_CONST(_dst, _arg, _data_loc, _length) do {           \
+    unsigned short __offset = _data_loc & 0xFFFF;                             \
+    bpf_probe_read((void *)_dst, _length, (char *)_arg + __offset);           \
+} while (0)
+#define TP_DATA_LOC_READ(_dst, _arg, _data_loc) do {                          \
+    unsigned short __offset = _data_loc & 0xFFFF;                             \
+    unsigned short __length = _data_loc >> 16;                                \
+    bpf_probe_read((void *)_dst, __length, (char *)_arg + __offset);          \
+} while (0)
+
+#endif

--- a/includes/netdata_bpf_helpers.h
+++ b/includes/netdata_bpf_helpers.h
@@ -191,25 +191,4 @@ static int (*bpf_skb_change_head)(void *, int len, int flags) =
 				(void *)(PT_REGS_FP(ctx) + sizeof(ip))); })
 #endif
 
-/*
-the TP_DATA_LOC_READ_* macros are used for reading from a field that's pointed
-to by a __data_loc variable.
-
-FYI, a __data_loc variable is really an int that contains within it the data
-needed to get the location of the actual value. these macros do the
-transformation needed to get that final location and then read from it.
-
-this code is from iovisor/bcc file src/cc/exports/helpers.h and modified by
-Netdata's Agent team for inclusion in Netdata.
-*/
-#define TP_DATA_LOC_READ_CONST(_dst, _arg, _data_loc, _length) do {           \
-    unsigned short __offset = _data_loc & 0xFFFF;                             \
-    bpf_probe_read((void *)_dst, _length, (char *)_arg + __offset);           \
-} while (0)
-#define TP_DATA_LOC_READ(_dst, _arg, _data_loc) do {                          \
-    unsigned short __offset = _data_loc & 0xFFFF;                             \
-    unsigned short __length = _data_loc >> 16;                                \
-    bpf_probe_read((void *)_dst, __length, (char *)_arg + __offset);          \
-} while (0)
-
 #endif

--- a/includes/netdata_bpf_helpers.h
+++ b/includes/netdata_bpf_helpers.h
@@ -21,6 +21,8 @@ static int (*bpf_map_delete_elem)(void *map, void *key) =
 	(void *) BPF_FUNC_map_delete_elem;
 static int (*bpf_probe_read)(void *dst, int size, void *unsafe_ptr) =
 	(void *) BPF_FUNC_probe_read;
+static int (*bpf_probe_read_str)(void *dst, int size, void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_str        
 static unsigned long long (*bpf_ktime_get_ns)(void) =
 	(void *) BPF_FUNC_ktime_get_ns;
 static int (*bpf_trace_printk)(const char *fmt, int fmt_size, ...) =

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -58,9 +58,9 @@ static inline void libnetdata_update_u64(__u64 *res, __u64 value)
 }
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
-static __always_inline void libnetdata_update_global(struct bpf_map_def *tbl,__u32 key, __u64 value)
+static __always_inline void libnetdata_update_global(void *tbl,__u32 key, __u64 value)
 #else
-static inline void libnetdata_update_global(struct bpf_map_def *tbl,__u32 key, __u64 value)
+static inline void libnetdata_update_global(void *tbl,__u32 key, __u64 value)
 #endif
 {
     __u64 *res;

--- a/includes/netdata_ebpf.h
+++ b/includes/netdata_ebpf.h
@@ -160,4 +160,25 @@ static inline __u32 libnetdata_select_idx(__u64 val, __u32 end)
 #define NETDATA_SYSCALL(SYS) "sys_" __stringify(SYS)
 #endif
 
+/*
+the TP_DATA_LOC_READ_* macros are used for reading from a field that's pointed
+to by a __data_loc variable.
+
+FYI, a __data_loc variable is really an int that contains within it the data
+needed to get the location of the actual value. these macros do the
+transformation needed to get that final location and then read from it.
+
+this code is from iovisor/bcc file src/cc/exports/helpers.h and modified by
+Netdata's Agent team for inclusion in Netdata.
+*/
+#define TP_DATA_LOC_READ_CONST(_dst, _arg, _data_loc, _length) do {           \
+    unsigned short __offset = _data_loc & 0xFFFF;                             \
+    bpf_probe_read((void *)_dst, _length, (char *)_arg + __offset);           \
+} while (0)
+#define TP_DATA_LOC_READ(_dst, _arg, _data_loc) do {                          \
+    unsigned short __offset = _data_loc & 0xFFFF;                             \
+    unsigned short __length = _data_loc >> 16;                                \
+    bpf_probe_read((void *)_dst, __length, (char *)_arg + __offset);          \
+} while (0)
+
 #endif /* _NETDATA_EBPF_ */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -60,6 +60,7 @@ NETDATA_APPS= btrfs \
 	      vfs \
 	      xfs \
 	      zfs \
+	      syncfs \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -65,6 +65,7 @@ NETDATA_APPS= btrfs \
 	      syncfs \
 	      sync_file_range \
 	      swap \
+	      xfs \
 	      vfs \
 	      #
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -64,6 +64,7 @@ NETDATA_APPS= btrfs \
 	      syncfs \
 	      sync_file_range \
 	      swap \
+	      vfs \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -40,7 +40,10 @@ NETDATA_APPS= btrfs \
 	      cachestat \
 	      dc \
 	      disk \
+<<<<<<< HEAD
 	      ext4 \
+=======
+>>>>>>> ca93e73 (bring_new_libbpf: Update fd_kern.c)
 	      fd \
 	      fdatasync \
 	      fsync \
@@ -64,6 +67,21 @@ NETDATA_APPS= btrfs \
 	      sync_file_range \
 	      #
 
+<<<<<<< HEAD
+=======
+#NETDATA_APPS= btrfs \
+#	      ext4 \
+#	      hardirq \
+#	      mount \
+#	      nfs \
+#	      socket \
+#	      swap \
+#	      vfs \
+#	      xfs \
+#	      zfs \
+	      #
+
+>>>>>>> ca93e73 (bring_new_libbpf: Update fd_kern.c)
 all: $(NETDATA_APPS)
 
 %_kern.o: %_kern.c

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -55,6 +55,7 @@ NETDATA_APPS= btrfs \
 	      vfs \
 	      xfs \
 	      zfs \
+	      process \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,7 @@
 CLANG = clang
 LLC = llc
 KERNELSOURCE = /usr/src/linux
+LIBBPF = ../libbpf
 ARCH = x86
 
 EXTRA_CFLAGS += -fno-stack-protector
@@ -16,6 +17,9 @@ LINUXINCLUDE += -I$(KERNELSOURCE)/arch/$(ARCH)/include/generated
 LINUXINCLUDE += -I$(KERNELSOURCE)/arch/$(ARCH)/include/generated/uapi
 LINUXINCLUDE += -I$(KERNELSOURCE)/include
 LINUXINCLUDE += -I$(KERNELSOURCE)/include/uapi
+LINUXINCLUDE += -I$(LIBBPF)/src
+LINUXINCLUDE += -I$(LIBBPF)/include
+LINUXINCLUDE += -I$(LIBBPF)/include/uapi
 LINUXINCLUDE += -include $(KERNELSOURCE)/include/linux/kconfig.h
 LINUXINCLUDE += -I../includes
 
@@ -70,7 +74,7 @@ all: $(NETDATA_APPS)
 		-DNETDATASEL=0 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
-		-O2 -emit-llvm -c $<
+		-O2 -g -emit-llvm -c $<
 	$(LLC) -march=bpf -filetype=obj -o r$@ $(<:.c=.ll)
 	$(CLANG) $(EXTRA_CFLAGS) -S -nostdinc $(LINUXINCLUDE) $(LLVM_INCLUDES) \
 		-D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
@@ -80,7 +84,7 @@ all: $(NETDATA_APPS)
 		-DNETDATASEL=1 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
-		-O2 -emit-llvm -c $<
+		-O2 -g -emit-llvm -c $<
 	$(LLC) -march=bpf -filetype=obj -o d$@ $(<:.c=.ll)
 	$(CLANG) $(EXTRA_CFLAGS) -S -nostdinc $(LINUXINCLUDE) $(LLVM_INCLUDES) \
 		-D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
@@ -90,7 +94,7 @@ all: $(NETDATA_APPS)
 		-DNETDATASEL=2 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
-		-O2 -emit-llvm -c $<
+		-O2 -g -emit-llvm -c $<
 	$(LLC) -march=bpf -filetype=obj -o p$@ $(<:.c=.ll)
 	/bin/bash rename_binaries.sh "$(VER_MAJOR)" "$(VER_MINOR)" "$@"
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -63,6 +63,7 @@ NETDATA_APPS= btrfs \
 	      zfs \
 	      syncfs \
 	      sync_file_range \
+	      swap \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -36,7 +36,6 @@ VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3)
 
 CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATCH) |bc)
 
-<<<<<<< HEAD
 NETDATA_APPS= btrfs \
 	      cachestat \
 	      dc \
@@ -50,6 +49,7 @@ NETDATA_APPS= btrfs \
 	      msync \
 	      nfs \
 	      oomkill \
+	      msync \
 	      process \
 	      socket \
 	      softirq \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -67,6 +67,7 @@ NETDATA_APPS= btrfs \
 	      swap \
 	      xfs \
 	      vfs \
+	      zfs \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -40,10 +40,7 @@ NETDATA_APPS= btrfs \
 	      cachestat \
 	      dc \
 	      disk \
-<<<<<<< HEAD
 	      ext4 \
-=======
->>>>>>> ca93e73 (bring_new_libbpf: Update fd_kern.c)
 	      fd \
 	      fdatasync \
 	      fsync \
@@ -52,6 +49,7 @@ NETDATA_APPS= btrfs \
 	      msync \
 	      nfs \
 	      oomkill \
+	      mount \
 	      msync \
 	      process \
 	      socket \
@@ -67,21 +65,6 @@ NETDATA_APPS= btrfs \
 	      sync_file_range \
 	      #
 
-<<<<<<< HEAD
-=======
-#NETDATA_APPS= btrfs \
-#	      ext4 \
-#	      hardirq \
-#	      mount \
-#	      nfs \
-#	      socket \
-#	      swap \
-#	      vfs \
-#	      xfs \
-#	      zfs \
-	      #
-
->>>>>>> ca93e73 (bring_new_libbpf: Update fd_kern.c)
 all: $(NETDATA_APPS)
 
 %_kern.o: %_kern.c

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -61,6 +61,7 @@ NETDATA_APPS= btrfs \
 	      xfs \
 	      zfs \
 	      syncfs \
+	      sync_file_range \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -36,6 +36,7 @@ VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3)
 
 CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATCH) |bc)
 
+<<<<<<< HEAD
 NETDATA_APPS= btrfs \
 	      cachestat \
 	      dc \
@@ -59,7 +60,6 @@ NETDATA_APPS= btrfs \
 	      vfs \
 	      xfs \
 	      zfs \
-	      process \
 	      #
 
 all: $(NETDATA_APPS)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -51,6 +51,7 @@ NETDATA_APPS= btrfs \
 	      oomkill \
 	      mount \
 	      msync \
+	      nfs \
 	      process \
 	      socket \
 	      softirq \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -49,24 +49,15 @@ NETDATA_APPS= btrfs \
 	      msync \
 	      nfs \
 	      oomkill \
-	      mount \
-	      msync \
-	      nfs \
 	      process \
 	      socket \
 	      softirq \
 	      sync \
-	      sync_file_range \
-	      syncfs \
-	      swap \
-	      vfs \
-	      xfs \
-	      zfs \
 	      syncfs \
 	      sync_file_range \
 	      swap \
-	      xfs \
 	      vfs \
+	      xfs \
 	      zfs \
 	      #
 

--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -9,7 +9,7 @@
 #include <linux/fs.h>
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -23,7 +23,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -1,6 +1,5 @@
 #define KBUILD_MODNAME "btrfs_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 #include <linux/genhd.h>
 #include <linux/version.h>
 // Condition added because struct kiocb was moved when 4.1.0 was released
@@ -11,6 +10,7 @@
 #endif
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,30 +19,30 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_btrfs = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_FS_MAX_ELEMENTS
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_btrfs SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_ext_addr = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = 1
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_HASH);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries,  1);
+} tbl_ext_addr SEC(".maps");
 
-struct bpf_map_def SEC("maps") tmp_btrfs = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif    
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = 4192
-};
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries,  4192);
+} tmp_btrfs SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -39,11 +39,7 @@ struct {
 } tbl_ext_addr SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries,  4192);

--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -9,8 +9,12 @@
 #include <linux/fs.h>
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,6 +23,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
@@ -43,6 +48,34 @@ struct {
         __type(value, __u64);
         __uint(max_entries,  4192);
 } tmp_btrfs SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") tbl_btrfs = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_FS_MAX_ELEMENTS
+};
+
+struct bpf_map_def SEC("maps") tbl_ext_addr = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 1
+};
+
+struct bpf_map_def SEC("maps") tmp_btrfs = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 4192
+};
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -25,28 +25,28 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
 } tbl_btrfs SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_HASH);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries,  1);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  1);
 } tbl_ext_addr SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries,  4192);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
 } tmp_btrfs SEC(".maps");
 
 #else

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -4,7 +4,7 @@
 #include <linux/threads.h>
 #include <linux/version.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -12,7 +12,7 @@
 #endif
 #include "netdata_ebpf.h"
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -21,11 +21,7 @@ struct {
 } cstat_global  SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, netdata_cachestat_t);
     __uint(max_entries, PID_MAX_DEFAULT);

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -14,28 +14,28 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_CACHESTAT_END);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_CACHESTAT_END);
 } cstat_global  SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, netdata_cachestat_t);
-        __uint(max_entries, PID_MAX_DEFAULT);
+    __type(key, __u32);
+    __type(value, netdata_cachestat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
 } cstat_pid SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u32);
-        __uint(max_entries, NETDATA_CONTROLLER_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
 } cstat_ctrl SEC(".maps");
 
 #else

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -1,38 +1,37 @@
-#define KBUILD_MODNAME "process_kern"
+#define KBUILD_MODNAME "cachestat_kern"
 #include <linux/bpf.h>
-#include <linux/version.h>
-#include <linux/ptrace.h>
 
 #include <linux/threads.h>
 #include <linux/version.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
-struct bpf_map_def SEC("maps") cstat_global = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_CACHESTAT_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_CACHESTAT_END);
+} cstat_global  SEC(".maps");
 
-struct bpf_map_def SEC("maps") cstat_pid = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(netdata_cachestat_t),
-    .max_entries = PID_MAX_DEFAULT
-};
+        __type(key, __u32);
+        __type(value, netdata_cachestat_t);
+        __uint(max_entries, PID_MAX_DEFAULT);
+} cstat_pid SEC(".maps");
 
-struct bpf_map_def SEC("maps") cstat_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u32);
+        __uint(max_entries, NETDATA_CONTROLLER_END);
+} cstat_ctrl SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -1,9 +1,8 @@
 #define KBUILD_MODNAME "dc_kern"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
-#include <linux/threads.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,30 +11,30 @@
  *
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") dcstat_global = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_DIRECTORY_CACHE_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_DIRECTORY_CACHE_END);
+} dcstat_global SEC(".maps");
 
-struct bpf_map_def SEC("maps") dcstat_pid = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(netdata_dc_stat_t),
-    .max_entries = PID_MAX_DEFAULT
-};
+        __type(key, __u32);
+        __type(value, netdata_dc_stat_t);
+        __uint(max_entries, PID_MAX_DEFAULT);
+} dcstat_pid SEC(".maps");
 
-struct bpf_map_def SEC("maps") dcstat_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u32);
+        __uint(max_entries, NETDATA_CONTROLLER_END);
+} dcstat_ctrl SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -1,8 +1,12 @@
 #define KBUILD_MODNAME "dc_kern"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -11,6 +15,7 @@
  *
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
@@ -35,6 +40,35 @@ struct {
         __type(value, __u32);
         __uint(max_entries, NETDATA_CONTROLLER_END);
 } dcstat_ctrl SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") dcstat_global = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_DIRECTORY_CACHE_END
+};
+
+struct bpf_map_def SEC("maps") dcstat_pid = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(netdata_dc_stat_t),
+    .max_entries = PID_MAX_DEFAULT
+};
+
+struct bpf_map_def SEC("maps") dcstat_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+
+#endif
 
 /************************************************************************************
  *

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "dc_kern"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -17,28 +17,28 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_DIRECTORY_CACHE_END);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_DIRECTORY_CACHE_END);
 } dcstat_global SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, netdata_dc_stat_t);
-        __uint(max_entries, PID_MAX_DEFAULT);
+    __type(key, __u32);
+    __type(value, netdata_dc_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
 } dcstat_pid SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u32);
-        __uint(max_entries, NETDATA_CONTROLLER_END);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
 } dcstat_ctrl SEC(".maps");
 
 #else

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -24,11 +24,7 @@ struct {
 } dcstat_global SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, netdata_dc_stat_t);
     __uint(max_entries, PID_MAX_DEFAULT);

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -19,11 +19,7 @@
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 //Hardware
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, block_key_t);
     __type(value, __u64);
     __uint(max_entries, NETDATA_DISK_HISTOGRAM_LENGTH);
@@ -31,11 +27,7 @@ struct {
 
 // Temporary use only
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, netdata_disk_key_t);
     __type(value, __u64);
     __uint(max_entries, 8192);

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -20,25 +20,25 @@
 //Hardware
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, block_key_t);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_DISK_HISTOGRAM_LENGTH);
+    __type(key, block_key_t);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_DISK_HISTOGRAM_LENGTH);
 } tbl_disk_iocall SEC(".maps");
 
 // Temporary use only
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, netdata_disk_key_t);
-        __type(value, __u64);
-        __uint(max_entries, 8192);
+    __type(key, netdata_disk_key_t);
+    __type(value, __u64);
+    __uint(max_entries, 8192);
 } tmp_disk_tp_stat SEC(".maps");
 
 #else

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -1,9 +1,9 @@
 #define KBUILD_MODNAME "disk_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 #include <linux/genhd.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -13,28 +13,28 @@
  ***********************************************************************************/
 
 //Hardware
-struct bpf_map_def SEC("maps") tbl_disk_iocall = {
+struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(block_key_t),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_DISK_HISTOGRAM_LENGTH
-};
+        __type(key, block_key_t);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_DISK_HISTOGRAM_LENGTH);
+} tbl_disk_iocall SEC(".maps");
 
 // Temporary use only
-struct bpf_map_def SEC("maps") tmp_disk_tp_stat = {
+struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(netdata_disk_key_t),
-    .value_size = sizeof(__u64),
-    .max_entries = 8192
-};
+        __type(key, netdata_disk_key_t);
+        __type(value, __u64);
+        __uint(max_entries, 8192);
+} tmp_disk_tp_stat SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -2,7 +2,7 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -16,7 +16,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 //Hardware
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -25,11 +25,7 @@ struct {
 } tbl_ext4 SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries,  4192);

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -1,9 +1,9 @@
 #define KBUILD_MODNAME "ext4_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 #include <linux/genhd.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,23 +12,23 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_ext4 = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_FS_MAX_ELEMENTS
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_ext4 SEC(".maps");
 
-struct bpf_map_def SEC("maps") tmp_ext4 = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif    
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = 4192
-};
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries,  4192);
+} tmp_ext4 SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -18,21 +18,21 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
 } tbl_ext4 SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries,  4192);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
 } tmp_ext4 SEC(".maps");
 
 #else

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -2,8 +2,12 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,6 +16,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
@@ -29,6 +34,28 @@ struct {
         __type(value, __u64);
         __uint(max_entries,  4192);
 } tmp_ext4 SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") tbl_ext4 = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_FS_MAX_ELEMENTS
+};
+
+struct bpf_map_def SEC("maps") tmp_ext4 = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 4192
+};
+
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -2,7 +2,7 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -16,7 +16,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -1,7 +1,6 @@
 #define KBUILD_MODNAME "fd_kern"
 #include <linux/bpf.h>
 #include <linux/version.h>
-#include <linux/ptrace.h>
 #include <linux/sched.h>
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,10,17))
 # include <linux/sched/task.h>
@@ -11,6 +10,7 @@
 #include <linux/version.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,26 +19,26 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_fd_pid = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(struct netdata_fd_stat_t),
-    .max_entries = PID_MAX_DEFAULT
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_HASH);
+        __type(key, __u32);
+        __type(value, struct netdata_fd_stat_t);
+        __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_fd_pid SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_fd_global = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries =  NETDATA_FD_COUNTER
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_FD_COUNTER);
+} tbl_fd_global SEC(".maps");
 
-struct bpf_map_def SEC("maps") fd_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u32);
+        __uint(max_entries, NETDATA_CONTROLLER_END);
+} fd_ctrl SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -9,7 +9,7 @@
 #include <linux/threads.h>
 #include <linux/version.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -23,7 +23,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_HASH);
         __type(key, __u32);

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -9,8 +9,12 @@
 #include <linux/threads.h>
 #include <linux/version.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,6 +23,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_HASH);
         __type(key, __u32);
@@ -39,6 +44,31 @@ struct {
         __type(value, __u32);
         __uint(max_entries, NETDATA_CONTROLLER_END);
 } fd_ctrl SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") tbl_fd_pid = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(struct netdata_fd_stat_t),
+    .max_entries = PID_MAX_DEFAULT
+};
+
+struct bpf_map_def SEC("maps") tbl_fd_global = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries =  NETDATA_FD_COUNTER
+};
+
+struct bpf_map_def SEC("maps") fd_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -25,24 +25,24 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_HASH);
-        __type(key, __u32);
-        __type(value, struct netdata_fd_stat_t);
-        __uint(max_entries, PID_MAX_DEFAULT);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct netdata_fd_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
 } tbl_fd_pid SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_FD_COUNTER);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FD_COUNTER);
 } tbl_fd_global SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u32);
-        __uint(max_entries, NETDATA_CONTROLLER_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
 } fd_ctrl SEC(".maps");
 
 #else

--- a/kernel/fdatasync_kern.c
+++ b/kernel/fdatasync_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "fdatasync_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);

--- a/kernel/fdatasync_kern.c
+++ b/kernel/fdatasync_kern.c
@@ -1,6 +1,5 @@
-#define KBUILD_MODNAME "latency_tp_netdata"
+#define KBUILD_MODNAME "fdatasync_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -11,12 +10,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_fdatasync = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SYNC_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SYNC_END);
+} tbl_fdatasync SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/fdatasync_kern.c
+++ b/kernel/fdatasync_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SYNC_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SYNC_END);
 } tbl_fdatasync SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_fdatasync = {

--- a/kernel/fdatasync_kern.c
+++ b/kernel/fdatasync_kern.c
@@ -1,7 +1,12 @@
 #define KBUILD_MODNAME "fdatasync_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -10,12 +15,21 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_SYNC_END);
 } tbl_fdatasync SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_fdatasync = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+#endif
 
 /************************************************************************************
  *

--- a/kernel/fsync_kern.c
+++ b/kernel/fsync_kern.c
@@ -1,6 +1,5 @@
-#define KBUILD_MODNAME "latency_tp_netdata"
+#define KBUILD_MODNAME "fsync_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -11,12 +10,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_fsync = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SYNC_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SYNC_END);
+} tbl_fsync SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/fsync_kern.c
+++ b/kernel/fsync_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "fsync_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);

--- a/kernel/fsync_kern.c
+++ b/kernel/fsync_kern.c
@@ -1,7 +1,12 @@
 #define KBUILD_MODNAME "fsync_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -10,12 +15,21 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_SYNC_END);
 } tbl_fsync SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_fsync = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+#endif
 
 /************************************************************************************
  *

--- a/kernel/fsync_kern.c
+++ b/kernel/fsync_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SYNC_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SYNC_END);
 } tbl_fsync SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_fsync = {

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -3,13 +3,39 @@
 #include <linux/ptrace.h>
 #include <linux/genhd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
+
 
 /************************************************************************************
  *                                 MAPS
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
+#else
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+        __type(key, hardirq_key_t);
+        __type(value, hardirq_val_t);
+        __uint(max_entries, NETDATA_HARDIRQ_MAX_IRQS);
+} tbl_hardirq SEC(".maps");
+
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, hardirq_static_val_t);
+        __uint(max_entries, NETDATA_HARDIRQ_STATIC_END);
+} tbl_hardirq_static SEC(".maps");
+
+#else
 struct bpf_map_def SEC("maps") tbl_hardirq = {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
     .type = BPF_MAP_TYPE_HASH,
@@ -28,6 +54,7 @@ struct bpf_map_def SEC("maps") tbl_hardirq_static = {
     .value_size = sizeof(hardirq_static_val_t),
     .max_entries = NETDATA_HARDIRQ_STATIC_END
 };
+#endif
 
 /************************************************************************************
  *                                HARDIRQ SECTION
@@ -236,3 +263,4 @@ HARDIRQ_STATIC_GEN_EXIT(
 )
 
 char _license[] SEC("license") = "GPL";
+

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -3,7 +3,7 @@
 #include <linux/ptrace.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -16,7 +16,7 @@
  *                                 MAPS
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
         __uint(type, BPF_MAP_TYPE_HASH);

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -18,11 +18,7 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, hardirq_key_t);
     __type(value, hardirq_val_t);
     __uint(max_entries, NETDATA_HARDIRQ_MAX_IRQS);

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -19,20 +19,20 @@
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, hardirq_key_t);
-        __type(value, hardirq_val_t);
-        __uint(max_entries, NETDATA_HARDIRQ_MAX_IRQS);
+    __type(key, hardirq_key_t);
+    __type(value, hardirq_val_t);
+    __uint(max_entries, NETDATA_HARDIRQ_MAX_IRQS);
 } tbl_hardirq SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, hardirq_static_val_t);
-        __uint(max_entries, NETDATA_HARDIRQ_STATIC_END);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, hardirq_static_val_t);
+    __uint(max_entries, NETDATA_HARDIRQ_STATIC_END);
 } tbl_hardirq_static SEC(".maps");
 
 #else

--- a/kernel/mount_kern.c
+++ b/kernel/mount_kern.c
@@ -1,8 +1,8 @@
 #define KBUILD_MODNAME "mount_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -11,12 +11,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_mount = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_MOUNT_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_MOUNT_END);
+} tbl_mount SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/mount_kern.c
+++ b/kernel/mount_kern.c
@@ -1,8 +1,12 @@
 #define KBUILD_MODNAME "mount_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -11,12 +15,21 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_MOUNT_END);
 } tbl_mount SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_mount = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_MOUNT_END
+};
+#endif
 
 /************************************************************************************
  *

--- a/kernel/mount_kern.c
+++ b/kernel/mount_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "mount_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/mount_kern.c
+++ b/kernel/mount_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_MOUNT_END);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_MOUNT_END);
 } tbl_mount SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_mount = {

--- a/kernel/msync_kern.c
+++ b/kernel/msync_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SYNC_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SYNC_END);
 } tbl_msync SEC(".maps");
 
 #else

--- a/kernel/msync_kern.c
+++ b/kernel/msync_kern.c
@@ -1,7 +1,12 @@
 #define KBUILD_MODNAME "msync_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -10,12 +15,24 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_SYNC_END);
 } tbl_msync SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") tbl_msync = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+
+#endif
 
 /************************************************************************************
  *

--- a/kernel/msync_kern.c
+++ b/kernel/msync_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "msync_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);

--- a/kernel/msync_kern.c
+++ b/kernel/msync_kern.c
@@ -1,6 +1,5 @@
-#define KBUILD_MODNAME "latency_tp_netdata"
+#define KBUILD_MODNAME "msync_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -11,12 +10,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_msync = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SYNC_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SYNC_END);
+} tbl_msync SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -2,8 +2,12 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,6 +16,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
@@ -29,6 +34,28 @@ struct {
         __type(value, __u64);
         __uint(max_entries,  4192);
 } tmp_nfs SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") tbl_nfs = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_FS_MAX_ELEMENTS
+};
+
+struct bpf_map_def SEC("maps") tmp_nfs = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 4192
+};
+
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -1,9 +1,9 @@
 #define KBUILD_MODNAME "nfs_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 #include <linux/genhd.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,23 +12,23 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_nfs = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_FS_MAX_ELEMENTS
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_nfs SEC(".maps");
 
-struct bpf_map_def SEC("maps") tmp_nfs = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif    
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = 4192
-};
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries,  4192);
+} tmp_nfs SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -18,21 +18,21 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
 } tbl_nfs SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries,  4192);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
 } tmp_nfs SEC(".maps");
 
 #else

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -2,7 +2,7 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -16,7 +16,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -25,11 +25,7 @@ struct {
 } tbl_nfs SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries,  4192);

--- a/kernel/oomkill_kern.c
+++ b/kernel/oomkill_kern.c
@@ -14,11 +14,7 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, int);
     __type(value, __u8);
     __uint(max_entries, NETDATA_OOMKILL_MAX_ENTRIES);

--- a/kernel/oomkill_kern.c
+++ b/kernel/oomkill_kern.c
@@ -4,9 +4,26 @@
 #include <linux/oom.h>
 #include <linux/threads.h>
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    __uint(type, BPF_MAP_TYPE_HASH);
+#else
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+    __type(key, int);
+    __type(value, __u8);
+    __uint(max_entries, NETDATA_OOMKILL_MAX_ENTRIES);
+} tbl_oomkill SEC(".maps");
+#else
 struct bpf_map_def SEC("maps") tbl_oomkill = {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
     .type = BPF_MAP_TYPE_HASH,
@@ -17,6 +34,7 @@ struct bpf_map_def SEC("maps") tbl_oomkill = {
     .value_size = sizeof(__u8),
     .max_entries = NETDATA_OOMKILL_MAX_ENTRIES
 };
+#endif
 
 SEC("tracepoint/oom/mark_victim")
 int netdata_oom_mark_victim(struct netdata_oom_mark_victim_entry *ptr) {

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -8,9 +8,12 @@
 # include <linux/sched/task.h>
 #endif
 
-
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,6 +22,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_HASH);
         __type(key, __u32);
@@ -39,6 +43,31 @@ struct {
         __type(value, __u32);
         __uint(max_entries, NETDATA_CONTROLLER_END);
 } process_ctrl SEC(".maps");
+
+#else
+
+struct bpf_map_def SEC("maps") tbl_pid_stats = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(struct netdata_pid_stat_t),
+    .max_entries = PID_MAX_DEFAULT
+};
+
+struct bpf_map_def SEC("maps") tbl_total_stats = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries =  NETDATA_GLOBAL_COUNTER
+};
+
+struct bpf_map_def SEC("maps") process_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -8,7 +8,7 @@
 # include <linux/sched/task.h>
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -22,7 +22,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_HASH);
         __type(key, __u32);

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -24,24 +24,24 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_HASH);
-        __type(key, __u32);
-        __type(value, struct netdata_pid_stat_t);
-        __uint(max_entries, PID_MAX_DEFAULT);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct netdata_pid_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
 } tbl_pid_stats SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_GLOBAL_COUNTER);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_GLOBAL_COUNTER);
 } tbl_total_stats SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u32);
-        __uint(max_entries, NETDATA_CONTROLLER_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
 } process_ctrl SEC(".maps");
 
 #else

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -2,15 +2,15 @@
 #include <linux/bpf.h>
 #include <linux/version.h>
 #include <linux/ptrace.h>
+#include <linux/threads.h>
 #include <linux/sched.h>
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,10,17))
 # include <linux/sched/task.h>
 #endif
 
-#include <linux/threads.h>
-#include <linux/version.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,26 +19,26 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_pid_stats = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(struct netdata_pid_stat_t),
-    .max_entries = PID_MAX_DEFAULT
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_HASH);
+        __type(key, __u32);
+        __type(value, struct netdata_pid_stat_t);
+        __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_pid_stats SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_total_stats = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries =  NETDATA_GLOBAL_COUNTER
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_GLOBAL_COUNTER);
+} tbl_total_stats SEC(".maps");
 
-struct bpf_map_def SEC("maps") process_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u32);
+        __uint(max_entries, NETDATA_CONTROLLER_END);
+} process_ctrl SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -26,11 +26,7 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, netdata_bandwidth_t);
     __uint(max_entries, PID_MAX_DEFAULT);
@@ -44,33 +40,21 @@ struct {
 } tbl_global_sock SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, netdata_socket_idx_t);
     __type(value, netdata_socket_t);
     __uint(max_entries, 65536);
 } tbl_conn_ipv4 SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, netdata_socket_idx_t);
     __type(value, netdata_socket_t);
     __uint(max_entries, 65536);
 } tbl_conn_ipv6 SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u64);
     __type(value, void *);
     __uint(max_entries, 8192);

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -1,4 +1,4 @@
-#define KBUILD_MODNAME "socket"
+#define KBUILD_MODNAME "socket_netdata"
 #include <linux/bpf.h>
 #include <linux/if_ether.h>
 #include <linux/in.h>
@@ -10,9 +10,8 @@
 #include <linux/udp.h>
 #include <linux/version.h>
 
-#include <linux/ptrace.h>
-
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -21,70 +20,70 @@
  *
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_bandwidth = {
+struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(netdata_bandwidth_t),
-    .max_entries = 65536
-};
+    __type(key, __u32);
+    __type(value, netdata_bandwidth_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_bandwidth SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_global_sock = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries =  NETDATA_SOCKET_COUNTER
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SOCKET_COUNTER);
+} tbl_global_sock SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_conn_ipv4 = {
+struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(netdata_socket_idx_t),
-    .value_size = sizeof(netdata_socket_t),
-    .max_entries = 65536
-};
+    __type(key, netdata_socket_idx_t);
+    __type(value, netdata_socket_t);
+    __uint(max_entries, 65536);
+} tbl_conn_ipv4 SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_conn_ipv6 = {
+struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(netdata_socket_idx_t),
-    .value_size = sizeof(netdata_socket_t),
-    .max_entries = 65536
-};
+    __type(key, netdata_socket_idx_t);
+    __type(value, netdata_socket_t);
+    __uint(max_entries, 65536);
+} tbl_conn_ipv6 SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_nv_udp = {
+struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    .type = BPF_MAP_TYPE_HASH,
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(__u64),
-    .value_size = sizeof(void *),
-    .max_entries = 8192
-};
+    __type(key, __u64);
+    __type(value, void *);
+    __uint(max_entries, 8192);
+} tbl_nv_udp SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_lports = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u16),
-    .value_size = sizeof(__u8),
-    .max_entries =  65536
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u16);
+    __type(value, __u8);
+    __uint(max_entries, 65536);
+} tbl_lports SEC(".maps");
 
-struct bpf_map_def SEC("maps") socket_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
+} socket_ctrl SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -10,7 +10,7 @@
 #include <linux/udp.h>
 #include <linux/version.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -24,7 +24,7 @@
  *
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
     __uint(type, BPF_MAP_TYPE_HASH);

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -3,7 +3,12 @@
 #include <linux/ptrace.h>
 #include <linux/genhd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -11,12 +16,21 @@
  ***********************************************************************************/
 
 // maps from irq index to latency.
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
         __type(value, softirq_val_t);
         __uint(max_entries, NETDATA_SOFTIRQ_MAX_IRQS);
 } tbl_softirq SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_softirq = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(softirq_val_t),
+    .max_entries = NETDATA_SOFTIRQ_MAX_IRQS
+};
+#endif
 
 /************************************************************************************
  *                                SOFTIRQ SECTION

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -11,12 +11,12 @@
  ***********************************************************************************/
 
 // maps from irq index to latency.
-struct bpf_map_def SEC("maps") tbl_softirq = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(softirq_val_t),
-    .max_entries = NETDATA_SOFTIRQ_MAX_IRQS
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, softirq_val_t);
+        __uint(max_entries, NETDATA_SOFTIRQ_MAX_IRQS);
+} tbl_softirq SEC(".maps");
 
 /************************************************************************************
  *                                SOFTIRQ SECTION

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -3,7 +3,7 @@
 #include <linux/ptrace.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -16,7 +16,7 @@
  ***********************************************************************************/
 
 // maps from irq index to latency.
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -3,7 +3,7 @@
 
 #include <linux/threads.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -17,7 +17,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -19,28 +19,28 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SWAP_END);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SWAP_END);
 } tbl_swap  SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, netdata_swap_access_t);
-        __uint(max_entries, PID_MAX_DEFAULT);
+    __type(key, __u32);
+    __type(value, netdata_swap_access_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
 } tbl_pid_swap SEC(".maps");
 
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u32);
-        __uint(max_entries, NETDATA_CONTROLLER_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
 } swap_ctrl SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_swap = {

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -26,11 +26,7 @@ struct {
 } tbl_swap  SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, netdata_swap_access_t);
     __uint(max_entries, PID_MAX_DEFAULT);

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -1,10 +1,10 @@
 #define KBUILD_MODNAME "swap_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include <linux/threads.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -13,30 +13,30 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_swap = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SWAP_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SWAP_END);
+} tbl_swap  SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_pid_swap = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(netdata_swap_access_t),
-    .max_entries = PID_MAX_DEFAULT
-};
+        __type(key, __u32);
+        __type(value, netdata_swap_access_t);
+        __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_pid_swap SEC(".maps");
 
-struct bpf_map_def SEC("maps") swap_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u32);
+        __uint(max_entries, NETDATA_CONTROLLER_END);
+} swap_ctrl SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/sync_file_range_kern.c
+++ b/kernel/sync_file_range_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "sfrange_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);

--- a/kernel/sync_file_range_kern.c
+++ b/kernel/sync_file_range_kern.c
@@ -1,7 +1,12 @@
 #define KBUILD_MODNAME "sfrange_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -10,12 +15,21 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_SYNC_END);
 } tbl_syncfr SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_syncfr = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+#endif
 
 /************************************************************************************
  *

--- a/kernel/sync_file_range_kern.c
+++ b/kernel/sync_file_range_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SYNC_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SYNC_END);
 } tbl_syncfr SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_syncfr = {

--- a/kernel/sync_file_range_kern.c
+++ b/kernel/sync_file_range_kern.c
@@ -1,6 +1,5 @@
-#define KBUILD_MODNAME "latency_tp_netdata"
+#define KBUILD_MODNAME "sfrange_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -11,12 +10,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_syncfr = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SYNC_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SYNC_END);
+} tbl_syncfr SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "sync_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -1,7 +1,12 @@
 #define KBUILD_MODNAME "sync_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -10,12 +15,21 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_SYNC_END);
 } tbl_sync SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_sync = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+#endif
 
 /************************************************************************************
  *

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SYNC_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    _uint(max_entries, NETDATA_SYNC_END);
 } tbl_sync SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_sync = {

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -20,7 +20,7 @@ struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
     __type(value, __u64);
-    _uint(max_entries, NETDATA_SYNC_END);
+    __uint(max_entries, NETDATA_SYNC_END);
 } tbl_sync SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_sync = {

--- a/kernel/sync_kern.c
+++ b/kernel/sync_kern.c
@@ -1,6 +1,5 @@
-#define KBUILD_MODNAME "latency_tp_netdata"
+#define KBUILD_MODNAME "sync_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -11,12 +10,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_sync = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SYNC_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SYNC_END);
+} tbl_sync SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/syncfs_kern.c
+++ b/kernel/syncfs_kern.c
@@ -1,6 +1,5 @@
-#define KBUILD_MODNAME "latency_tp_netdata"
+#define KBUILD_MODNAME "syncfs_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 
 #include "bpf_helpers.h"
 #include "netdata_ebpf.h"
@@ -11,12 +10,12 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_syncfs = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_SYNC_END
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_SYNC_END);
+} tbl_syncfs SEC(".maps");
 
 /************************************************************************************
  *

--- a/kernel/syncfs_kern.c
+++ b/kernel/syncfs_kern.c
@@ -1,7 +1,7 @@
 #define KBUILD_MODNAME "syncfs_netdata"
 #include <linux/bpf.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -15,7 +15,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);

--- a/kernel/syncfs_kern.c
+++ b/kernel/syncfs_kern.c
@@ -17,10 +17,10 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_SYNC_END);
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SYNC_END);
 } tbl_syncfs SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_syncfs = {

--- a/kernel/syncfs_kern.c
+++ b/kernel/syncfs_kern.c
@@ -1,7 +1,12 @@
 #define KBUILD_MODNAME "syncfs_netdata"
 #include <linux/bpf.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -10,12 +15,21 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_ARRAY);
         __type(key, __u32);
         __type(value, __u64);
         __uint(max_entries, NETDATA_SYNC_END);
 } tbl_syncfs SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_syncfs = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_SYNC_END
+};
+#endif
 
 /************************************************************************************
  *

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -9,7 +9,7 @@
 
 #include <linux/threads.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -23,7 +23,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, __u32);

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -9,8 +9,12 @@
 
 #include <linux/threads.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,6 +23,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, __u32);
@@ -39,6 +44,28 @@ struct {
     __type(value, __u32);
     __uint(max_entries, NETDATA_CONTROLLER_END);
 } vfs_ctrl SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_vfs_pid = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(struct netdata_vfs_stat_t),
+    .max_entries = PID_MAX_DEFAULT
+};
+
+struct bpf_map_def SEC("maps") tbl_vfs_stats = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries =  NETDATA_VFS_COUNTER
+};
+
+struct bpf_map_def SEC("maps") vfs_ctrl = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = NETDATA_CONTROLLER_END
+};
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -8,9 +8,9 @@
 #endif
 
 #include <linux/threads.h>
-#include <linux/version.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -19,26 +19,26 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_vfs_pid = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(struct netdata_vfs_stat_t),
-    .max_entries = PID_MAX_DEFAULT
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct netdata_vfs_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_vfs_pid SEC(".maps");
 
-struct bpf_map_def SEC("maps") tbl_vfs_stats = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries =  NETDATA_VFS_COUNTER
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_VFS_COUNTER);
+} tbl_vfs_stats  SEC(".maps");
 
-struct bpf_map_def SEC("maps") vfs_ctrl = {
-    .type = BPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = NETDATA_CONTROLLER_END
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
+} vfs_ctrl SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -3,8 +3,12 @@
 #include <linux/ptrace.h>
 #include <linux/genhd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -13,6 +17,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
@@ -30,6 +35,25 @@ struct {
         __type(value, __u64);
         __uint(max_entries,  4192);
 } tmp_xfs SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_xfs = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_FS_MAX_ELEMENTS
+};
+
+struct bpf_map_def SEC("maps") tmp_xfs = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 4192
+};
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -26,11 +26,7 @@ struct {
 } tbl_xfs SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries,  4192);

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -19,21 +19,21 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
 } tbl_xfs SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries,  4192);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
 } tmp_xfs SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_xfs = {

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -3,7 +3,7 @@
 #include <linux/ptrace.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -17,7 +17,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -4,6 +4,7 @@
 #include <linux/genhd.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,23 +13,23 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_xfs = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_FS_MAX_ELEMENTS
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_xfs SEC(".maps");
 
-struct bpf_map_def SEC("maps") tmp_xfs = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif    
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = 4192
-};
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries,  4192);
+} tmp_xfs SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -1,9 +1,9 @@
 #define KBUILD_MODNAME "zfs_netdata"
 #include <linux/bpf.h>
-#include <linux/ptrace.h>
 #include <linux/genhd.h>
 
 #include "bpf_helpers.h"
+#include "bpf_tracing.h"
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,23 +12,23 @@
  *     
  ***********************************************************************************/
 
-struct bpf_map_def SEC("maps") tbl_zfs = {
-    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = NETDATA_FS_MAX_ELEMENTS
-};
+struct {
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_zfs SEC(".maps");
 
-struct bpf_map_def SEC("maps") tmp_zfs = {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)) 
-    .type = BPF_MAP_TYPE_HASH,
+struct {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        __uint(type, BPF_MAP_TYPE_HASH);
 #else
-    .type = BPF_MAP_TYPE_PERCPU_HASH,
-#endif    
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u64),
-    .max_entries = 4192
-};
+        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#endif
+        __type(key, __u32);
+        __type(value, __u64);
+        __uint(max_entries,  4192);
+} tmp_zfs SEC(".maps");
 
 /************************************************************************************
  *     

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -2,8 +2,12 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#else
+#include "netdata_bpf_helpers.h"
+#endif
 #include "netdata_ebpf.h"
 
 /************************************************************************************
@@ -12,6 +16,7 @@
  *     
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);
@@ -29,6 +34,25 @@ struct {
         __type(value, __u64);
         __uint(max_entries,  4192);
 } tmp_zfs SEC(".maps");
+#else
+struct bpf_map_def SEC("maps") tbl_zfs = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = NETDATA_FS_MAX_ELEMENTS
+};
+
+struct bpf_map_def SEC("maps") tmp_zfs = {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+    .type = BPF_MAP_TYPE_HASH,
+#else
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+#endif
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 4192
+};
+#endif
 
 /************************************************************************************
  *     

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -25,11 +25,7 @@ struct {
 } tbl_zfs SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries,  4192);

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -18,21 +18,21 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
-        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
 } tbl_zfs SEC(".maps");
 
 struct {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-        __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
 #else
-        __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #endif
-        __type(key, __u32);
-        __type(value, __u64);
-        __uint(max_entries,  4192);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
 } tmp_zfs SEC(".maps");
 #else
 struct bpf_map_def SEC("maps") tbl_zfs = {

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -2,7 +2,7 @@
 #include <linux/bpf.h>
 #include <linux/genhd.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 #else
@@ -16,7 +16,7 @@
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,14))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,4,14))
 struct {
         __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
         __type(key, __u32);


### PR DESCRIPTION
This PR is bringing the latest version of `libbpf` to netdata, this version began to be implemented with kernel `5.4.14` and it is expected to be alive until `1.0.0`, after this probably another big PR will come.

This PR is also adding `libbpf` as submodule for this repo, because it will be necessary for `CO-RE` and other features we plan to bring.

The following changes are coming with this PR:

-   Change in the format we declare tables
-   Rename `bpf_helpers.h` to avoid confusion
-   Move pre processors to allow `hardirq` to work with latest release
-   Add necessary flags to generate information for latest `libbpf`. They were also added for old versions.
-   Rename of some eBPF program modules.

This PR was tested on:

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.14.0  |
| Manjaro 21.1 | 5.10.60 |
| Ubuntu 18.04 | 5.4.128 |
| Debian 10.10 | 4.19.171 |
| Slackware Current | 4.14.239 |
| CentOS 7.9 | 3.10.0-1160 |


**This PR is waiting for #252 to be merged.**