### PR TITLE
Process monitoring with tracepoints

### DIFF
--- a/includes/netdata_process.h
+++ b/includes/netdata_process.h
@@ -13,6 +13,23 @@ typedef struct netdata_sched_process_exit {
     int prio;       // offset:28;      size:4; signed:1;
 } netdata_sched_process_exit_t;
 
+// /sys/kernel/tracing/events/sched/sched_process_exit/format
+typedef struct netdata_sched_process_fork {
+    __u64 pad;                // This is not used with eBPF
+    char parent_comm[16];     // offset:8;       size:16;        signed:1;
+    int parent_pid;           // offset:24;      size:4; signed:1;
+    char child_comm[16];      // offset:28;      size:16;        signed:1;
+    int child_pid;            // offset:44;      size:4; signed:1;
+} netdata_sched_process_fork_t;
+
+// /sys/kernel/tracing/events/sched/sched_process_exec/format
+typedef struct netdata_sched_process_exec {
+    __u64 pad;      // This is not used with eBPF
+    int filename;   // offset:8;       size:4; signed:1;
+    int pid;        // offset:12;      size:4; signed:1;
+    int old_pid;   // offset:16;      size:4; signed:1;
+} netdata_sched_process_exec_t;
+
 struct netdata_pid_stat_t {
     __u64 pid_tgid;                     //Unique identifier
     __u32 pid;                          //process id

--- a/includes/netdata_process.h
+++ b/includes/netdata_process.h
@@ -5,6 +5,14 @@
 
 #include <linux/sched.h>
 
+// /sys/kernel/tracing/events/sched/sched_process_exit/format
+typedef struct netdata_sched_process_exit {
+    __u64 pad;      // This is not used with eBPF
+    char comm[16] ; // offset:8;       size:16;        signed:1;
+    int pid;        // offset:24;      size:4; signed:1;
+    int prio;       // offset:28;      size:4; signed:1;
+} netdata_sched_process_exit_t;
+
 struct netdata_pid_stat_t {
     __u64 pid_tgid;                     //Unique identifier
     __u32 pid;                          //process id

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -122,6 +122,80 @@ int netdata_release_task(struct pt_regs* ctx)
     return 0;
 }
 
+SEC("tracepoint/sched/sched_process_exec")
+int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr)
+{
+    struct netdata_pid_stat_t data = { };
+    struct netdata_pid_stat_t *fill;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    // This is necessary, because it represents the main function to start a thread
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_FORK, 1);
+
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
+    if (fill) {
+        fill->release_call = 0;
+        libnetdata_update_u32(&fill->fork_call, 1) ;
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+        data.fork_call = 1;
+
+        bpf_map_update_elem(&tbl_pid_stats, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_fork")
+int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr)
+{
+    struct netdata_pid_stat_t data = { };
+    struct netdata_pid_stat_t *fill;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_FORK, 1);
+
+    // Parent ID = 1 means that init called process/thread creation
+    int thread = 0;
+    if (ptr->parent_pid != ptr->child_pid && ptr->parent_pid != 1) {
+        thread = 1;
+        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_SYS_CLONE, 1);
+    }
+
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
+    if (fill) {
+        fill->release_call = 0;
+        libnetdata_update_u32(&fill->clone_call, 1) ;
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+        data.fork_call = 1;
+        if (thread)
+            data.clone_call = 1;
+
+        bpf_map_update_elem(&tbl_pid_stats, &key, &data, BPF_ANY);
+    }
+
+
+    return 0;
+}
+
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(5,9,16))
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)) 
@@ -146,32 +220,9 @@ int netdata_fork(struct pt_regs* ctx)
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-    int threads = 0;
-    unsigned long clone_flags = PT_REGS_PARM1(ctx); 
-    unsigned long flags;
-    bpf_probe_read(&flags, sizeof(clone_flags), (void *)&clone_flags);
-    if (flags & CLONE_VM) {
-        threads = 1;
-    } else {
-        threads = 0;
-    }
-#endif
-
-    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_FORK, 1);
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-    if(threads) {
-        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_SYS_CLONE, 1);
-    }
-#endif
 #if NETDATASEL < 2
     if (ret < 0) {
         libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_DO_FORK, 1);
-# if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-        if(threads) {
-            libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_SYS_CLONE, 1);
-        }
-# endif
     } 
 #endif
 
@@ -186,40 +237,19 @@ int netdata_fork(struct pt_regs* ctx)
     fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
     if (fill) {
         fill->release_call = 0;
-        libnetdata_update_u32(&fill->fork_call, 1) ;
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-        if(threads) {
-            libnetdata_update_u32(&fill->clone_call, 1) ;
-        }
-#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
             libnetdata_update_u32(&fill->fork_err, 1) ;
-# if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-            if(threads) {
-                libnetdata_update_u32(&fill->clone_err, 1) ;
-            }
-# endif
         } 
 #endif
     } else {
         data.pid_tgid = pid_tgid;  
         data.pid = tgid;  
         data.fork_call = 1;
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-        if(threads) {
-            data.clone_call = 1;
-        }
-#endif
 #if NETDATASEL < 2
         if (ret < 0) {
             data.fork_err = 1;
-# if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)) 
-            if (threads) {
-                data.clone_err = 1;
-            }
-# endif
         } 
 #endif
         bpf_map_update_elem(&tbl_pid_stats, &key, &data, BPF_ANY);
@@ -227,68 +257,6 @@ int netdata_fork(struct pt_regs* ctx)
 
     return 0;
 }
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)) 
-#if NETDATASEL < 2
-SEC("kretprobe/" NETDATA_SYSCALL(clone))
-#else
-SEC("kprobe/" NETDATA_SYSCALL(clone))
-#endif
-int netdata_clone(struct pt_regs* ctx)
-{
-#if NETDATASEL < 2
-    int ret = (int)PT_REGS_RC(ctx);
-#endif
-    struct netdata_pid_stat_t *fill;
-    struct netdata_pid_stat_t data = { };
-    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
-    __u64 arg1 = (__u64)PT_REGS_PARM2(ctx);
-
-    arg1 &= CLONE_THREAD|CLONE_VM;
-    if(!arg1)
-        return 0;
-
-    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_SYS_CLONE, 1);
-#if NETDATASEL < 2
-    if (ret < 0) {
-        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_SYS_CLONE, 1);
-    } 
-#endif
-    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
-    if (apps)
-        if (*apps == 0)
-            return 0;
-
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
-    if (fill) {
-        libnetdata_update_u32(&fill->clone_call, 1) ;
-
-#if NETDATASEL < 2
-        if (ret < 0) {
-            libnetdata_update_u32(&fill->clone_err, 1) ;
-        } 
-#endif
-    } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
-        data.clone_call = 1;
-#if NETDATASEL < 2
-        if (ret < 0) {
-            data.clone_err = 1;
-        } 
-#endif
-
-        bpf_map_update_elem(&tbl_pid_stats, &key, &data, BPF_ANY);
-    }
-
-    return 0;
-}
-#endif
-
-
 
 #else // End kernel <= 5.9.16
 
@@ -307,23 +275,9 @@ int netdata_sys_clone(struct pt_regs *ctx)
     struct netdata_pid_stat_t *fill;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
 
-    int threads = 0;
-    struct kernel_clone_args *args = (struct kernel_clone_args *)PT_REGS_PARM1(ctx); 
-    int exit_signal;
-    bpf_probe_read(&exit_signal, sizeof(int), (void *)&args->exit_signal);
-    // SIGCHLD is used by vfork/fork
-    if (exit_signal != SIGCHLD) {
-        threads = 1;
-        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_SYS_CLONE, 1);
-    }
-
-    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_FORK, 1);
 #if NETDATASEL < 2
     if (ret < 0) {
         libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_DO_FORK, 1);
-        if(threads) {
-            libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_SYS_CLONE, 1);
-        }
     } 
 #endif
 
@@ -340,31 +294,18 @@ int netdata_sys_clone(struct pt_regs *ctx)
         fill->release_call = 0;
         libnetdata_update_u32(&fill->fork_call, 1) ;
 
-        if(threads) {
-            libnetdata_update_u32(&fill->clone_call, 1) ;
-        }
-
 #if NETDATASEL < 2
         if (ret < 0) {
             libnetdata_update_u32(&fill->fork_err, 1) ;
-            if(threads) {
-                libnetdata_update_u32(&fill->clone_err, 1) ;
-            }
         } 
 #endif
     } else {
         data.pid_tgid = pid_tgid;
         data.pid = tgid;
         data.fork_call = 1;
-        if(threads) {
-            data.clone_call = 1;
-        }
 #if NETDATASEL < 2
         if (ret < 0) {
             data.fork_err = 1;
-            if (threads) {
-                data.clone_err = 1;
-            }
         }
 #endif
 
@@ -374,27 +315,6 @@ int netdata_sys_clone(struct pt_regs *ctx)
 }
 
 #endif
-
-SEC("kprobe/try_to_wake_up")
-int netdata_enter_try_to_wake_up(struct pt_regs* ctx)
-{
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)(0x00000000FFFFFFFF & pid_tgid);
-    struct netdata_pid_stat_t *fill;
-    struct netdata_pid_stat_t data = { };
-
-    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&pid);
-    if (!fill) {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
-
-        bpf_map_update_elem(&tbl_pid_stats, &pid, &data, BPF_ANY);
-    }
-
-
-    return 0;
-}
 
 char _license[] SEC("license") = "GPL";
 

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -75,8 +75,8 @@ struct bpf_map_def SEC("maps") process_ctrl = {
  *     
  ***********************************************************************************/
 
-SEC("kprobe/do_exit")
-int netdata_sys_exit(struct pt_regs* ctx)
+SEC("tracepoint/sched/sched_process_exit")
+int netdata_tracepoint_sched_process_exit(struct netdata_sched_process_exit *ptr)
 {
     struct netdata_pid_stat_t *fill;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -71,35 +71,6 @@ struct bpf_map_def SEC("maps") process_ctrl = {
 
 /************************************************************************************
  *     
- *                                 COMMON Section
- *     
- ***********************************************************************************/
-
-static unsigned int log2(unsigned int v)
-{
-    unsigned int r;
-    unsigned int shift;
-
-    r = (v > 0xFFFF) << 4; v >>= r;
-    shift = (v > 0xFF) << 3; v >>= shift; r |= shift;
-    shift = (v > 0xF) << 2; v >>= shift; r |= shift;
-    shift = (v > 0x3) << 1; v >>= shift; r |= shift;
-    r |= (v >> 1);
-
-    return r;
-}
-
-static unsigned int log2l(unsigned long v)
-{
-    unsigned int hi = v >> 32;
-    if (hi)
-        return log2(hi) + 32;
-    else
-        return log2(v);
-}
-
-/************************************************************************************
- *     
  *                                   PROCESS Section
  *     
  ***********************************************************************************/


### PR DESCRIPTION
Since we started eBPF project there were internal changes inside kernel that forced us to update eBPF `process` and charts behavior were affected. This PR is addressing part of this problem adding `tracepoints` to monitor process creation and process exit.

We still keep `kprobes` to monitor fails on system.