### PR TITLE
Remove warning

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -71,6 +71,7 @@ all: $(NETDATA_APPS)
 	    	-Wno-compare-distinct-pointer-types \
 	    	-Wno-gnu-variable-sized-type-not-at-end \
 	    	-Wno-tautological-compare \
+		-fno-asynchronous-unwind-tables \
 		-DNETDATASEL=0 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
@@ -81,6 +82,7 @@ all: $(NETDATA_APPS)
 	    	-Wno-compare-distinct-pointer-types \
 	    	-Wno-gnu-variable-sized-type-not-at-end \
 	    	-Wno-tautological-compare \
+		-fno-asynchronous-unwind-tables \
 		-DNETDATASEL=1 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
@@ -91,6 +93,7 @@ all: $(NETDATA_APPS)
 	    	-Wno-compare-distinct-pointer-types \
 	    	-Wno-gnu-variable-sized-type-not-at-end \
 	    	-Wno-tautological-compare \
+		-fno-asynchronous-unwind-tables \
 		-DNETDATASEL=2 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -71,7 +71,7 @@ all: $(NETDATA_APPS)
 	    	-Wno-compare-distinct-pointer-types \
 	    	-Wno-gnu-variable-sized-type-not-at-end \
 	    	-Wno-tautological-compare \
-		-fno-asynchronous-unwind-tables \
+	    	-fno-asynchronous-unwind-tables \
 		-DNETDATASEL=0 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
@@ -82,7 +82,7 @@ all: $(NETDATA_APPS)
 	    	-Wno-compare-distinct-pointer-types \
 	    	-Wno-gnu-variable-sized-type-not-at-end \
 	    	-Wno-tautological-compare \
-		-fno-asynchronous-unwind-tables \
+	    	-fno-asynchronous-unwind-tables \
 		-DNETDATASEL=1 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \
@@ -93,7 +93,7 @@ all: $(NETDATA_APPS)
 	    	-Wno-compare-distinct-pointer-types \
 	    	-Wno-gnu-variable-sized-type-not-at-end \
 	    	-Wno-tautological-compare \
-		-fno-asynchronous-unwind-tables \
+	    	-fno-asynchronous-unwind-tables \
 		-DNETDATASEL=2 \
 		-D__BPF_TRACING__ \
 		-include ../includes/netdata_asm_goto.h \


### PR DESCRIPTION
Since we started using `libbpf 0.42` our eBPF programs show the following warning:

```
libbpf: elf: skipping unrecognized data section(22) .eh_frame
libbpf: elf: skipping relo section(23) .rel.eh_frame for section(22) .eh_frame
```

This PR is removing this warning from user log.