### PR TITLE
Convert sync eBPF programs to CO-RE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libbpf"]
-	path = libbpf
-	url = https://github.com/netdata/libbpf
-        ignore = dirty
+    path = libbpf
+    url = https://github.com/netdata/libbpf
+    ignore = dirty

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -14,7 +14,7 @@ VER_MINOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f2)
 
 _LIBC ?= glibc
 
-APPS = syncfs \
+APPS = sync \
        #
 
 all: compress

--- a/co-re/sync.bpf.c
+++ b/co-re/sync.bpf.c
@@ -16,7 +16,7 @@ struct {
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries, NETDATA_SYNC_END);
-} tbl_syncfs SEC(".maps");
+} tbl_sync SEC(".maps");
 
 /************************************************************************************
  *
@@ -27,7 +27,7 @@ struct {
 SEC("fentry/netdata_sync")
 int BPF_PROG(netdata_sync_fentry)
 {
-    libnetdata_update_global(&tbl_syncfs, NETDATA_KEY_SYNC_CALL, 1);
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
 
     return 0;
 }
@@ -35,7 +35,7 @@ int BPF_PROG(netdata_sync_fentry)
 SEC("kprobe/netdata_sync")
 int BPF_KPROBE(netdata_sync_kprobe)
 {
-    libnetdata_update_global(&tbl_syncfs, NETDATA_KEY_SYNC_CALL, 1);
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
 
     return 0;
 }

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -136,7 +136,7 @@ static int ebpf_fcnt_tests(struct btf *bf, int (*fcnt)(int), enum netdata_sync_e
         int fd = bpf_map__fd(obj->maps.tbl_sync) ;
         ret = common_fcnt_tests(fd, fcnt);
     } else
-        fprintf(stderr, "Error to attach BPF program\n");
+        fprintf(stderr, "Failed to attach BPF program\n");
 
     sync_bpf__destroy(obj);
 
@@ -233,7 +233,7 @@ static int ebpf_msync_tests(struct btf *bf)
         int fd = bpf_map__fd(obj->maps.tbl_sync) ;
         ret = msync_tests(fd);
     } else
-        fprintf(stderr, "Error to attach BPF program\n");
+        fprintf(stderr, "Failed to attach BPF program\n");
 
     sync_bpf__destroy(obj);
 
@@ -258,7 +258,7 @@ static void test_sync_file_range_synchronization()
     size_t offset = 0;
     for ( i = 0 ; i < 1000; i++ )  {
         size_t length = 23;
-        write(fd, "Testing more one syscall", length);
+        write(fd, "Testing one more syscall", length);
         sync_file_range(fd, offset, length, SYNC_FILE_RANGE_WRITE);
         offset += length;
     }
@@ -309,18 +309,12 @@ static int ebpf_sync_file_range_tests(struct btf *bf)
         int fd = bpf_map__fd(obj->maps.tbl_sync) ;
         ret = sync_file_range_tests(fd);
     } else
-        fprintf(stderr, "Error to attach BPF program\n");
+        fprintf(stderr, "Failed to attach BPF program\n");
 
     sync_bpf__destroy(obj);
 
     return 0;
 }
-
-/****************************************************************************************
- *
- *                                      ENTRY
- *
- ***************************************************************************************/ 
 
 int main(int argc, char **argv)
 {

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -8,14 +8,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <bpf/bpf.h>
-#include <bpf/libbpf.h>
-#include <bpf/btf.h>
+#include "netdata_tests.h"
 
 #include <sys/mman.h>
 
 #include "sync.skel.h"
-#include "netdata_tests.h"
 
 enum netdata_sync_enum {
     NETDATA_SYNCFS_SYSCALL,

--- a/co-re/syncfs.bpf.c
+++ b/co-re/syncfs.bpf.c
@@ -20,12 +20,20 @@ struct {
 
 /************************************************************************************
  *
- *                               SYNC SECTION
+ *                               SYNC SECTION (trampoline and kprobe)
  *
  ***********************************************************************************/
 
 SEC("fentry/__x64_sys_syncfs")
-int BPF_PROG(__x64_sys_syncfs)
+int BPF_PROG(__x64_sys_syncfs_fentry)
+{
+    libnetdata_update_global(&tbl_syncfs, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
+SEC("kprobe/__x64_sys_syncfs")
+int BPF_KPROBE(__x64_sys_syncfs_kprobe)
 {
     libnetdata_update_global(&tbl_syncfs, NETDATA_KEY_SYNC_CALL, 1);
 

--- a/co-re/syncfs.bpf.c
+++ b/co-re/syncfs.bpf.c
@@ -24,16 +24,16 @@ struct {
  *
  ***********************************************************************************/
 
-SEC("fentry/__x64_sys_syncfs")
-int BPF_PROG(__x64_sys_syncfs_fentry)
+SEC("fentry/netdata_sync")
+int BPF_PROG(netdata_sync_fentry)
 {
     libnetdata_update_global(&tbl_syncfs, NETDATA_KEY_SYNC_CALL, 1);
 
     return 0;
 }
 
-SEC("kprobe/__x64_sys_syncfs")
-int BPF_KPROBE(__x64_sys_syncfs_kprobe)
+SEC("kprobe/netdata_sync")
+int BPF_KPROBE(netdata_sync_kprobe)
 {
     libnetdata_update_global(&tbl_syncfs, NETDATA_KEY_SYNC_CALL, 1);
 

--- a/co-re/syncfs.c
+++ b/co-re/syncfs.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
+#include <getopt.h>
 
 #define _GNU_SOURCE         /* See feature_test_macros(7) */
 #define __USE_GNU
@@ -8,9 +10,12 @@
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
+#include <bpf/btf.h>
 
 #include "syncfs.skel.h"
 #include "netdata_tests.h"
+
+static char *ebpf_syncfs_syscall = { "__x64_sys_syncfs" };
 
 void test_synchronization()
 {
@@ -55,8 +60,89 @@ int syncfs_tests(int fd) {
     return ret;
 }
 
+static inline int find_syncfs_id(struct btf *bf)
+{
+    const struct btf_type *type = netdata_find_bpf_attach_type(bf);
+    if (!type)
+        return -1;
+
+    const struct btf_enum *e = btf_enum(type);
+    int i, id;
+    for (id = -1, i = 0; i < btf_vlen(type); i++, e++) {
+        if (!strcmp(btf__name_by_offset(bf, e->name_off), "BPF_TRACE_FENTRY")) {
+            id = btf__find_by_name_kind(bf, ebpf_syncfs_syscall, BTF_KIND_FUNC);
+            break;
+        }
+    }
+
+    return id;
+}
+
+static inline int ebpf_load_and_attach(struct syncfs_bpf *obj, int id)
+{
+    if (id > 0) {
+        bpf_program__set_autoload(obj->progs.__x64_sys_syncfs_kprobe, false);
+    } else {
+        bpf_program__set_autoload(obj->progs.__x64_sys_syncfs_fentry, false);
+    }
+
+    int ret = syncfs_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    if (id > 0)
+        ret = syncfs_bpf__attach(obj);
+    else {
+        obj->links.__x64_sys_syncfs_kprobe = bpf_program__attach_kprobe(obj->progs.__x64_sys_syncfs_kprobe,
+                                                                         false, ebpf_syncfs_syscall);
+        ret = libbpf_get_error(obj->links.__x64_sys_syncfs_kprobe);
+    }
+
+    if (!ret)
+        fprintf(stdout, "%s loaded with success\n", (id > 0) ? "entry" : "probe");
+
+     return ret;
+}
+
 int main(int argc, char **argv)
 {
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = 0;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "sys_syncfs");
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = -1;
+                          break;
+                      }
+            case 't': {
+                          //id is already set to 0
+                          selector = 0;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    struct syncfs_bpf *obj = NULL;
     // Adjust memory
     int ret = netdata_ebf_memlock_limit();
     if (ret) {
@@ -64,20 +150,38 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    struct syncfs_bpf *obj = syncfs_bpf__open_and_load();
+    struct btf *bf = NULL;
+    int id = -1;
+    if (!selector) {
+        bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);
+        int has_btf = (!bf) ? 0 : 1;
+
+        if (has_btf) {
+            id = find_syncfs_id(bf);
+        }
+    }
+
+    obj = syncfs_bpf__open();
     if (!obj) {
         fprintf(stderr, "Cannot open or load BPF object\n");
+        if (bf)
+            btf__free(bf);
+
         return 2;
     }
 
-    ret = syncfs_bpf__attach(obj);
+    ret = ebpf_load_and_attach(obj, id);
     if (!ret) {
         int fd = bpf_map__fd(obj->maps.tbl_syncfs) ;
         ret = syncfs_tests(fd);
     } else
         fprintf(stderr, "Error to attach BPF program\n");
 
+    if (bf)
+        btf__free(bf);
+
     syncfs_bpf__destroy(obj);
 
     return ret;
 }
+

--- a/co-re/syncfs.c
+++ b/co-re/syncfs.c
@@ -81,9 +81,11 @@ static inline int find_syncfs_id(struct btf *bf)
 static inline int ebpf_load_and_attach(struct syncfs_bpf *obj, int id)
 {
     if (id > 0) {
-        bpf_program__set_autoload(obj->progs.__x64_sys_syncfs_kprobe, false);
+        bpf_program__set_autoload(obj->progs.netdata_sync_kprobe, false);
+        bpf_program__set_attach_target(obj->progs.netdata_sync_fentry, 0,
+                                       ebpf_syncfs_syscall);
     } else {
-        bpf_program__set_autoload(obj->progs.__x64_sys_syncfs_fentry, false);
+        bpf_program__set_autoload(obj->progs.netdata_sync_fentry, false);
     }
 
     int ret = syncfs_bpf__load(obj);
@@ -95,9 +97,9 @@ static inline int ebpf_load_and_attach(struct syncfs_bpf *obj, int id)
     if (id > 0)
         ret = syncfs_bpf__attach(obj);
     else {
-        obj->links.__x64_sys_syncfs_kprobe = bpf_program__attach_kprobe(obj->progs.__x64_sys_syncfs_kprobe,
-                                                                         false, ebpf_syncfs_syscall);
-        ret = libbpf_get_error(obj->links.__x64_sys_syncfs_kprobe);
+        obj->links.netdata_sync_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_sync_kprobe,
+                                                                    false, ebpf_syncfs_syscall);
+        ret = libbpf_get_error(obj->links.netdata_sync_kprobe);
     }
 
     if (!ret)

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -51,5 +51,23 @@ static inline void ebpf_print_help(char *name, char *info) {
                     , name, info);
 }
 
+static inline int ebpf_find_function_id(struct btf *bf, char *name)
+{
+    const struct btf_type *type = netdata_find_bpf_attach_type(bf);
+    if (!type)
+        return -1;
+
+    const struct btf_enum *e = btf_enum(type);
+    int i, id;
+    for (id = -1, i = 0; i < btf_vlen(type); i++, e++) {
+        if (!strcmp(btf__name_by_offset(bf, e->name_off), "BPF_TRACE_FENTRY")) {
+            id = btf__find_by_name_kind(bf, name, BTF_KIND_FUNC);
+            break;
+        }
+    }
+
+    return id;
+}
+
 #endif /* _NETDATA_TESTS_H_ */
 

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -61,7 +61,7 @@ static inline void ebpf_print_help(char *name, char *info) {
                     "The following options are available:\n\n"
                     "--help       (-h): Prints this help.\n"
                     "--probe      (-p): Use probe and do no try to use trampolines (fentry/fexit).\n"
-                    "--trampoline (-t): Try to use trampoline(fentry/fexit), when it is not possible" 
+                    "--trampoline (-t): Try to use trampoline(fentry/fexit). If this is not possible" 
                     " probes will be used.\n"
                     , name, info);
 }

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -6,6 +6,21 @@
 #define NETDATA_BTF_FILE "/sys/kernel/btf/vmlinux"
 
 #include <sys/resource.h>
+#include <linux/version.h>
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0))
+// Copied from https://elixir.bootlin.com/linux/v5.13/source/include/uapi/linux/btf.h#L75
+#define BTF_KIND_FLOAT		16	/* Floating point	*/
+
+#undef BTF_KIND_MAX
+#undef NR_BTF_KINDS
+
+#define BTF_KIND_MAX    BTF_KIND_FLOAT
+#define NR_BTF_KINDS    (BTF_KIND_MAX + 1)
+#endif
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
 #include <bpf/btf.h>
 
 static inline int netdata_ebf_memlock_limit(void)


### PR DESCRIPTION
### Description

This PR is extending CO-RE bringing monitoring for 4 additional `sync` syscalls.
It also adds to `sync` tester the possibility to load either `kprobe` or `trampoline`.

### Test


1. Clone branch
2. Run `./tools/check-kernel-core.sh` to test your kernel. If you do not receive any warning, your host has support for BTF.
3. Install `bpftool` on your host.
4. Execute commands: `cd co-re && make`
5. Finally run: `./tests/sync`. If you do not have any warning, and you are able to see the following output:

```bash
bash-5.1# ./tests/sync --probe
__x64_sys_syncfs: probe loaded with success
__x64_sys_msync: probe loaded with success
__x64_sys_sync_file_range: probe loaded with success
__x64_sys_fsync: probe loaded with success
__x64_sys_fdatasync: probe loaded with success
bash-5.1# ./tests/sync --trampoline
__x64_sys_syncfs: entry loaded with success
__x64_sys_msync: entry loaded with success
__x64_sys_sync_file_range: entry loaded with success
__x64_sys_fsync: entry loaded with success
__x64_sys_fdatasync: entry loaded with success
bash-5.1# 
```

everything is running as expected.