### PR TITLE
Filesystem CO-RE

### DIFF
--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -14,7 +14,8 @@ VER_MINOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f2)
 
 _LIBC ?= glibc
 
-APPS = sync \
+APPS = filesystem \
+       sync \
        #
 
 all: compress

--- a/co-re/filesystem.bpf.c
+++ b/co-re/filesystem.bpf.c
@@ -1,0 +1,257 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_core_read.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_fs.h"
+
+/************************************************************************************
+ *     
+ *                                 MAP Section
+ *     
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_fs SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
+} tmp_fs SEC(".maps");
+
+
+/************************************************************************************
+ *     
+ *                                 COMMON
+ *     
+ ***********************************************************************************/
+
+static int netdata_fs_entry()
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u64 ts = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&tmp_fs, &pid, &ts, BPF_ANY);
+
+    return 0;
+}
+
+static int netdata_fs_store_bin(__u32 selection)
+{
+    __u64 *fill, data;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+
+    fill = bpf_map_lookup_elem(&tmp_fs, &pid);
+    if (!fill)
+        return 0;
+
+    data = bpf_ktime_get_ns() - *fill;
+    bpf_map_delete_elem(&tmp_fs, &pid);
+
+    // Skip entries with backward time
+    if ( (s64)data < 0)
+        return 0;
+
+    // convert to microseconds
+    data /= 1000;
+    bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
+    __u32 idx = selection * NETDATA_FS_MAX_BINS + bin;
+    if (idx >= NETDATA_FS_MAX_ELEMENTS)
+        return 0;
+
+    fill = bpf_map_lookup_elem(&tbl_fs, &idx);
+    if (fill) {
+        libnetdata_update_u64(fill, 1);
+		return 0;
+    } 
+
+    data = 1;
+    bpf_map_update_elem(&tbl_fs, &idx, &data, BPF_ANY);
+
+    return 0;
+}
+
+/************************************************************************************
+ *     
+ *                                 ENTRY SECTION (trampoline)
+ *     
+ ***********************************************************************************/
+
+SEC("fentry/fs_file_read")
+int BPF_PROG(netdata_fs_file_read_entry, struct kiocb *iocb) 
+{
+    struct file *fp = iocb->ki_filp;
+    if (!fp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("fentry/fs_file_write")
+int BPF_PROG(netdata_fs_file_write_entry, struct kiocb *iocb) 
+{
+    struct file *fp = iocb->ki_filp;
+    if (!fp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("fentry/fs_file_open")
+int BPF_PROG(netdata_fs_file_open_entry, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("fentry/fs_2nd_file_open")
+int BPF_PROG(netdata_fs_2nd_file_open_entry, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("fentry/fs_getattr")
+int BPF_PROG(netdata_fs_getattr_entry) 
+{
+    return netdata_fs_entry();
+}
+
+/************************************************************************************
+ *     
+ *                                 END SECTION (trampoline)
+ *     
+ ***********************************************************************************/
+
+SEC("fexit/fs_file_read")
+int BPF_PROG(netdata_fs_file_read_exit)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_READ);
+}
+
+SEC("fexit/fs_file_write")
+int BPF_PROG(netdata_fs_file_write_exit)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_WRITE);
+}
+
+SEC("fexit/fs_file_open")
+int BPF_PROG(netdata_fs_file_open_exit)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("fexit/fs_2nd_file_open")
+int BPF_PROG(netdata_fs_2nd_file_open_exit)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("fexit/fs_getattr")
+int BPF_PROG(netdata_fs_getattr_exit)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_SYNC);
+}
+
+/************************************************************************************
+ *     
+ *                                 ENTRY SECTION (kprobe)
+ *     
+ ***********************************************************************************/
+
+SEC("kprobe/fs_file_read")
+int BPF_KPROBE(netdata_fs_file_read_probe, struct kiocb *iocb) 
+{
+    struct file *fp = BPF_CORE_READ(iocb, ki_filp);
+    if (!fp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("kprobe/fs_file_write")
+int BPF_KPROBE(netdata_fs_file_write_probe, struct kiocb *iocb) 
+{
+    struct file *fp = BPF_CORE_READ(iocb, ki_filp);
+    if (!fp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("kprobe/fs_file_open")
+int BPF_KPROBE(netdata_fs_file_open_probe, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("kprobe/fs_2nd_file_open")
+int BPF_KPROBE(netdata_fs_2nd_file_open_probe, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_fs_entry();
+}
+
+SEC("kprobe/fs_getattr")
+int BPF_KPROBE(netdata_fs_getattr_probe) 
+{
+    return netdata_fs_entry();
+}
+
+/************************************************************************************
+ *     
+ *                                 END SECTION (kretprobe)
+ *     
+ ***********************************************************************************/
+
+SEC("kretprobe/fs_file_read")
+int BPF_KRETPROBE(netdata_fs_file_read_retprobe)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_READ);
+}
+
+SEC("kretprobe/fs_file_write")
+int BPF_KRETPROBE(netdata_fs_file_write_retprobe)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_WRITE);
+}
+
+SEC("kretprobe/fs_file_open")
+int BPF_KRETPROBE(netdata_fs_file_open_retprobe)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("kretprobe/fs_2nd_file_open")
+int BPF_KRETPROBE(netdata_fs_2nd_file_open_retprobe)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("kretprobe/fs_getattr")
+int BPF_KRETPROBE(netdata_fs_getattr_retprobe)
+{
+    return netdata_fs_store_bin(NETDATA_KEY_CALLS_SYNC);
+}
+
+char _license[] SEC("license") = "GPL";
+
+

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -22,6 +22,7 @@ struct filesystem_data {
 };
 
 #define NETDATA_EXT4_BTF_FILE "/sys/kernel/btf/ext4"
+#define NETDATA_BTRFS_BTF_FILE "/sys/kernel/btf/btrfs"
 
 struct filesystem_data fd[] = {
     {   
@@ -42,6 +43,17 @@ struct filesystem_data fd[] = {
                         "ext4_file_write_iter",
                         "ext4_file_open",
                         "ext4_sync_file",
+                        NULL },
+        .ids = { -1, -1, -1, -1, -1},
+        .bf = NULL
+    },
+    {   
+        .name = "btrfs",
+        .path = NETDATA_BTRFS_BTF_FILE,
+        .functions = {  "btrfs_file_read_iter",
+                        "btrfs_file_write_iter",
+                        "btrfs_file_open",
+                        "btrfs_sync_file",
                         NULL },
         .ids = { -1, -1, -1, -1, -1},
         .bf = NULL
@@ -259,6 +271,7 @@ static inline void ebpf_print_fs_help(char *name, char *info) {
                     "--trampoline (-t): Try to use trampoline(fentry/fexit).\n" 
                     "--nfs        (-n): Run tests for nfs filesystem\n" 
                     "--ext4       (-e): Run tests for ext4 filesystem\n" 
+                    "--btrfs      (-b): Run tests for btrfs filesystem\n" 
                     "\n\n"
                     "Usage: %s --probe --ext4\n"
                     , name, info, name);
@@ -272,6 +285,7 @@ int main(int argc, char **argv)
         {"trampoline",  no_argument,    0,  't' },
         {"nfs",         no_argument,    0,  'n' },
         {"ext4",        no_argument,    0,  'e' },
+        {"btrfs",       no_argument,    0,  'b' },
         {0, 0, 0, 0}
     };
 
@@ -303,6 +317,10 @@ int main(int argc, char **argv)
                       }
             case 'e': {
                           fs = 1;
+                          break;
+                      }
+            case 'b': {
+                          fs = 2;
                           break;
                       }
             default: {

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -1,0 +1,318 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "netdata_tests.h"
+#include "filesystem.skel.h"
+
+#include "netdata_fs.h"
+
+struct filesystem_data {
+    const char *name;
+    const char *path;
+    const char *functions[NETDATA_FS_BTF_END];
+    int ids[NETDATA_FS_BTF_END];
+    struct btf *bf;
+};
+
+
+struct filesystem_data fd[] = {
+    {   
+        .name = "nfs",
+        .path = NETDATA_BTF_FILE,
+        .functions = {  "nfs_file_read",
+                        "nfs_file_write",
+                        "nfs_open",
+                        "nfs_getattr",
+                        "nfs4_file_open" },
+        .ids = { -1, -1, -1, -1, -1},
+        .bf = NULL
+    },
+    {
+        .name = NULL,
+        .path = NULL,
+        .functions = { NULL },
+        .ids = { -1, -1, -1, -1, -1},
+        .bf = NULL
+    }
+};
+
+static int ebpf_load_btf_file()
+{
+    int counter = 0;
+    while (fd[counter].name) {
+        fd[counter].bf = netdata_parse_btf_file(fd[counter].path);
+        if (!fd[counter].bf)
+            return -1;
+
+        counter++;
+    }
+
+    return 0;
+}
+
+static int ebpf_find_ids()
+{
+    int counter = 0;
+    while (fd[counter].name) {
+        int *ids = fd[counter].ids;
+        struct btf *bf = fd[counter].bf;
+        int i;
+        for (i = 0; i < NETDATA_FS_BTF_END ; i++) {
+            ids[i] = ebpf_find_function_id(bf, (char *)fd[counter].functions[i]);
+            if (ids[i] < 0)
+                return -1;
+        }
+
+        counter++;
+    }
+
+    return 0;
+}
+
+static void ebpf_clean_btf_file()
+{
+    int counter = 0;
+    while (fd[counter].name) {
+        if (fd[counter].bf)
+            btf__free(fd[counter].bf);
+
+        counter++;
+    }
+}
+
+static void ebpf_fs_disable_kprobe(struct filesystem_bpf *obj)
+{
+    // kprobe
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_read_probe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_write_probe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_open_probe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_2nd_file_open_probe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_getattr_probe, false);
+    // kretprobe
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_read_retprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_write_retprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_open_retprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_2nd_file_open_retprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_getattr_retprobe, false);
+}
+
+static void ebpf_fs_set_target(struct filesystem_bpf *obj, const char **functions)
+{
+    // entry
+    bpf_program__set_attach_target(obj->progs.netdata_fs_file_read_entry, 0,
+                                   functions[NETDATA_KEY_BTF_READ]);
+    bpf_program__set_attach_target(obj->progs.netdata_fs_file_write_entry, 0,
+                                   functions[NETDATA_KEY_BTF_WRITE]);
+    bpf_program__set_attach_target(obj->progs.netdata_fs_file_open_entry, 0,
+                                   functions[NETDATA_KEY_BTF_OPEN]);
+    bpf_program__set_attach_target(obj->progs.netdata_fs_getattr_entry, 0,
+                                   functions[NETDATA_KEY_BTF_SYNC_ATTR]);
+
+    // exit
+    bpf_program__set_attach_target(obj->progs.netdata_fs_file_read_exit, 0,
+                                   functions[NETDATA_KEY_BTF_READ]);
+    bpf_program__set_attach_target(obj->progs.netdata_fs_file_write_exit, 0,
+                                   functions[NETDATA_KEY_BTF_WRITE]);
+    bpf_program__set_attach_target(obj->progs.netdata_fs_file_open_exit, 0,
+                                   functions[NETDATA_KEY_BTF_OPEN]);
+    bpf_program__set_attach_target(obj->progs.netdata_fs_getattr_exit, 0,
+                                   functions[NETDATA_KEY_BTF_SYNC_ATTR]);
+
+    if (functions[NETDATA_KEY_BTF_OPEN2]) {
+        bpf_program__set_attach_target(obj->progs.netdata_fs_2nd_file_open_entry, 0,
+                                       functions[NETDATA_KEY_BTF_OPEN2]);
+        bpf_program__set_attach_target(obj->progs.netdata_fs_2nd_file_open_exit, 0,
+                                       functions[NETDATA_KEY_BTF_OPEN2]);
+    } else {
+        bpf_program__set_autoload(obj->progs.netdata_fs_2nd_file_open_entry, false);
+        bpf_program__set_autoload(obj->progs.netdata_fs_2nd_file_open_exit, false);
+    }
+}
+
+static void ebpf_fs_disable_trampoline(struct filesystem_bpf *obj)
+{
+    // entry
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_read_entry, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_write_entry, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_open_entry, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_getattr_entry, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_2nd_file_open_entry, false);
+
+    // exit
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_read_exit, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_write_exit, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_file_open_exit, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_getattr_exit, false);
+    bpf_program__set_autoload(obj->progs.netdata_fs_2nd_file_open_exit, false);
+}
+
+static int ebpf_fs_attach_kprobe(struct filesystem_bpf *obj, const char **functions)
+{
+    // kprobe
+    obj->links.netdata_fs_file_read_probe = bpf_program__attach_kprobe(obj->progs.netdata_fs_file_read_probe,
+                                                                false, functions[NETDATA_KEY_BTF_READ]);
+    if (libbpf_get_error(obj->links.netdata_fs_file_read_probe))
+        return -1;
+
+    obj->links.netdata_fs_file_write_probe = bpf_program__attach_kprobe(obj->progs.netdata_fs_file_write_probe,
+                                                                false, functions[NETDATA_KEY_BTF_WRITE]);
+    if (libbpf_get_error(obj->links.netdata_fs_file_write_probe))
+        return -1;
+
+    obj->links.netdata_fs_file_open_probe = bpf_program__attach_kprobe(obj->progs.netdata_fs_file_open_probe,
+                                                                false, functions[NETDATA_KEY_BTF_OPEN]);
+    if (libbpf_get_error(obj->links.netdata_fs_file_open_probe))
+        return -1;
+
+    obj->links.netdata_fs_getattr_probe = bpf_program__attach_kprobe(obj->progs.netdata_fs_getattr_probe,
+                                                                false, functions[NETDATA_KEY_BTF_SYNC_ATTR]);
+    if (libbpf_get_error(obj->links.netdata_fs_getattr_probe))
+        return -1;
+    
+    // kretprobe
+    obj->links.netdata_fs_file_read_retprobe = bpf_program__attach_kprobe(obj->progs.netdata_fs_file_read_retprobe,
+                                                                false, functions[NETDATA_KEY_BTF_READ]);
+    if (libbpf_get_error(obj->links.netdata_fs_file_read_retprobe))
+        return -1;
+
+    obj->links.netdata_fs_file_write_retprobe = bpf_program__attach_kprobe(obj->progs.netdata_fs_file_write_retprobe,
+                                                                false, functions[NETDATA_KEY_BTF_WRITE]);
+    if (libbpf_get_error(obj->links.netdata_fs_file_write_retprobe))
+        return -1;
+
+    obj->links.netdata_fs_file_open_retprobe = bpf_program__attach_kprobe(obj->progs.netdata_fs_file_open_retprobe,
+                                                                false, functions[NETDATA_KEY_BTF_OPEN]);
+    if (libbpf_get_error(obj->links.netdata_fs_file_open_retprobe))
+        return -1;
+
+    obj->links.netdata_fs_getattr_retprobe = bpf_program__attach_kprobe(obj->progs.netdata_fs_getattr_retprobe,
+                                                                false, functions[NETDATA_KEY_BTF_SYNC_ATTR]);
+    if (libbpf_get_error(obj->links.netdata_fs_getattr_retprobe))
+        return -1;
+
+    if (functions[NETDATA_KEY_BTF_OPEN2]) {
+        obj->links.netdata_fs_2nd_file_open_probe = bpf_program__attach_kprobe(obj->progs.netdata_fs_2nd_file_open_probe,
+                                                                false, functions[NETDATA_KEY_BTF_OPEN2]);
+        if (libbpf_get_error(obj->links.netdata_fs_2nd_file_open_probe))
+            return -1;
+
+        obj->links.netdata_fs_2nd_file_open_retprobe = bpf_program__attach_kprobe(obj->progs.netdata_fs_2nd_file_open_retprobe,
+                                                                false, functions[NETDATA_KEY_BTF_OPEN2]);
+        if (libbpf_get_error(obj->links.netdata_fs_2nd_file_open_retprobe))
+            return -1;
+    }
+
+    return 0;
+}
+
+static inline int ebpf_load_and_attach(struct filesystem_bpf *obj, const char **functions,
+                                       const char *name, struct btf *bf)
+{
+    if (bf) {
+        ebpf_fs_disable_kprobe(obj);
+        ebpf_fs_set_target(obj, functions);
+    } else {
+        ebpf_fs_disable_trampoline(obj);
+    }
+
+    int ret = filesystem_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    if (bf)
+        ret = filesystem_bpf__attach(obj);
+    else
+        ret = ebpf_fs_attach_kprobe(obj, functions);
+
+    if (!ret)
+        fprintf(stdout, "%s: %s loaded with success\n", name, (bf) ? "entry" : "probe");
+
+     return ret;
+}
+
+
+static int ebpf_load_fs()
+{
+    struct filesystem_bpf *obj = NULL;
+    int counter = 0;
+    while (fd[counter].name) {
+        obj = filesystem_bpf__open();
+        if (obj) {
+            ebpf_load_and_attach(obj, fd[counter].functions, fd[counter].name, fd[counter].bf);
+            filesystem_bpf__destroy(obj);
+        }
+
+        counter++;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = 0;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "filesystem");
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = -1;
+                          break;
+                      }
+            case 't': {
+                          //id is already set to 0
+                          selector = 0;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+
+    if (!selector) {
+        ret = ebpf_load_btf_file();
+        if (!ret) {
+            ret = ebpf_find_ids();
+        }
+    }
+
+    // run tests here
+    if (!ret)
+        ret = ebpf_load_fs();
+
+    ebpf_clean_btf_file();
+
+    return ret;
+}
+

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -83,9 +83,14 @@ struct filesystem_data fd[] = {
 
 static int ebpf_load_btf_file(int idx)
 {
+    if (!fd[idx].path) {
+        fprintf(stderr, "BTF file not given, use kprobe instead.\n");
+        return -1;
+    }
+
     fd[idx].bf = netdata_parse_btf_file(fd[idx].path);
     if (!fd[idx].bf) {
-        fprintf(stderr, "BTF file not given, use kprobe instead.\n");
+        fprintf(stderr, "Cannot load BTF file.\n");
         return -1;
     }
 

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -58,6 +58,17 @@ struct filesystem_data fd[] = {
         .ids = { -1, -1, -1, -1, -1},
         .bf = NULL
     },
+    {   
+        .name = "xfs",
+        .path = NETDATA_BTF_FILE,
+        .functions = {  "xfs_file_read_iter",
+                        "xfs_file_write_iter",
+                        "xfs_file_open",
+                        "xfs_file_fsync",
+                        NULL },
+        .ids = { -1, -1, -1, -1, -1},
+        .bf = NULL
+    },
     {
         .name = NULL,
         .path = NULL,
@@ -272,6 +283,7 @@ static inline void ebpf_print_fs_help(char *name, char *info) {
                     "--nfs        (-n): Run tests for nfs filesystem\n" 
                     "--ext4       (-e): Run tests for ext4 filesystem\n" 
                     "--btrfs      (-b): Run tests for btrfs filesystem\n" 
+                    "--xfs        (-x): Run tests for xfs filesystem\n" 
                     "\n\n"
                     "Usage: %s --probe --ext4\n"
                     , name, info, name);
@@ -286,6 +298,7 @@ int main(int argc, char **argv)
         {"nfs",         no_argument,    0,  'n' },
         {"ext4",        no_argument,    0,  'e' },
         {"btrfs",       no_argument,    0,  'b' },
+        {"xfs",         no_argument,    0,  'x' },
         {0, 0, 0, 0}
     };
 
@@ -307,7 +320,6 @@ int main(int argc, char **argv)
                           break;
                       }
             case 't': {
-                          //id is already set to 0
                           selector = 0;
                           break;
                       }
@@ -321,6 +333,10 @@ int main(int argc, char **argv)
                       }
             case 'b': {
                           fs = 2;
+                          break;
+                      }
+            case 'x': {
+                          fs = 3;
                           break;
                       }
             default: {

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -288,14 +288,12 @@ static inline void ebpf_print_fs_help(char *name, char *info) {
     fprintf(stdout, "%s tests if it is possible to monitor %s on host\n\n"
                     "The following options are available:\n\n"
                     "--help       (-h): Prints this help.\n"
-                    "--probe      (-p): Use probe and do no try to use trampolines (fentry/fexit).\n"
-                    "--trampoline (-t): Try to use trampoline(fentry/fexit).\n" 
                     "--nfs        (-n): Run tests for nfs filesystem\n" 
                     "--ext4       (-e): Run tests for ext4 filesystem\n" 
                     "--btrfs      (-b): Run tests for btrfs filesystem\n" 
                     "--xfs        (-x): Run tests for xfs filesystem\n" 
                     "\n\n"
-                    "Usage: %s --probe --ext4\n"
+                    "Usage: %s --ext4\n"
                     , name, info, name);
 }
 
@@ -303,8 +301,6 @@ int main(int argc, char **argv)
 {
     static struct option long_options[] = {
         {"help",        no_argument,    0,  'h' },
-        {"probe",       no_argument,    0,  'p' },
-        {"trampoline",  no_argument,    0,  't' },
         {"nfs",         no_argument,    0,  'n' },
         {"ext4",        no_argument,    0,  'e' },
         {"btrfs",       no_argument,    0,  'b' },
@@ -312,7 +308,10 @@ int main(int argc, char **argv)
         {0, 0, 0, 0}
     };
 
-    int selector = 0;
+    // Selector is kept for the moment that distributions start compiling
+    // their filesystem with support for trampoline, for while we are using
+    // only probes
+    int selector = 1;
     int option_index = 0;
     int fs = -1;
     while (1) {
@@ -324,14 +323,6 @@ int main(int argc, char **argv)
             case 'h': {
                           ebpf_print_fs_help(argv[0], "filesystem");
                           exit(0);
-                      }
-            case 'p': {
-                          selector = -1;
-                          break;
-                      }
-            case 't': {
-                          selector = 0;
-                          break;
                       }
             case 'n': {
                           fs = 0;

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -21,8 +21,11 @@ struct filesystem_data {
     struct btf *bf;
 };
 
+/* Files used with ext4 and btrfs, but the usage depends of
+ * kerel compliation, to avoid problems we will use only probes.
 #define NETDATA_EXT4_BTF_FILE "/sys/kernel/btf/ext4"
 #define NETDATA_BTRFS_BTF_FILE "/sys/kernel/btf/btrfs"
+*/
 
 struct filesystem_data fd[] = {
     {   
@@ -32,13 +35,13 @@ struct filesystem_data fd[] = {
                         "nfs_file_write",
                         "nfs_open",
                         "nfs_getattr",
-                        "nfs4_file_open" },
+                        NULL }, // "nfs4_file_open" - not present on all kernels
         .ids = { -1, -1, -1, -1, -1},
         .bf = NULL
     },
     {   
         .name = "ext4",
-        .path = NETDATA_EXT4_BTF_FILE,
+        .path = NULL,
         .functions = {  "ext4_file_read_iter",
                         "ext4_file_write_iter",
                         "ext4_file_open",
@@ -49,7 +52,7 @@ struct filesystem_data fd[] = {
     },
     {   
         .name = "btrfs",
-        .path = NETDATA_BTRFS_BTF_FILE,
+        .path = NULL,
         .functions = {  "btrfs_file_read_iter",
                         "btrfs_file_write_iter",
                         "btrfs_file_open",
@@ -60,7 +63,7 @@ struct filesystem_data fd[] = {
     },
     {   
         .name = "xfs",
-        .path = NETDATA_BTF_FILE,
+        .path = NULL,
         .functions = {  "xfs_file_read_iter",
                         "xfs_file_write_iter",
                         "xfs_file_open",
@@ -81,8 +84,10 @@ struct filesystem_data fd[] = {
 static int ebpf_load_btf_file(int idx)
 {
     fd[idx].bf = netdata_parse_btf_file(fd[idx].path);
-    if (!fd[idx].bf)
+    if (!fd[idx].bf) {
+        fprintf(stderr, "BTF file not given, use kprobe instead.\n");
         return -1;
+    }
 
     return 0;
 }

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -30,7 +30,7 @@ struct filesystem_data {
 struct filesystem_data fd[] = {
     {   
         .name = "nfs",
-        .path = NETDATA_BTF_FILE,
+        .path = NULL,
         .functions = {  "nfs_file_read",
                         "nfs_file_write",
                         "nfs_open",

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -21,6 +21,7 @@ struct filesystem_data {
     struct btf *bf;
 };
 
+#define NETDATA_EXT4_BTF_FILE "/sys/kernel/btf/ext4"
 
 struct filesystem_data fd[] = {
     {   
@@ -31,6 +32,17 @@ struct filesystem_data fd[] = {
                         "nfs_open",
                         "nfs_getattr",
                         "nfs4_file_open" },
+        .ids = { -1, -1, -1, -1, -1},
+        .bf = NULL
+    },
+    {   
+        .name = "ext4",
+        .path = NETDATA_EXT4_BTF_FILE,
+        .functions = {  "ext4_file_read_iter",
+                        "ext4_file_write_iter",
+                        "ext4_file_open",
+                        "ext4_sync_file",
+                        NULL },
         .ids = { -1, -1, -1, -1, -1},
         .bf = NULL
     },
@@ -47,6 +59,7 @@ static int ebpf_load_btf_file()
 {
     int counter = 0;
     while (fd[counter].name) {
+        fprintf(stderr, "KILLME %s\n", fd[counter].path);
         fd[counter].bf = netdata_parse_btf_file(fd[counter].path);
         if (!fd[counter].bf)
             return -1;
@@ -308,10 +321,10 @@ int main(int argc, char **argv)
     }
 
     // run tests here
-    if (!ret)
+    if (!ret) {
         ret = ebpf_load_fs();
-
-    ebpf_clean_btf_file();
+        ebpf_clean_btf_file();
+    }
 
     return ret;
 }

--- a/co-re/nfs.bpf.c
+++ b/co-re/nfs.bpf.c
@@ -1,0 +1,257 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_core_read.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_fs.h"
+
+/************************************************************************************
+ *     
+ *                                 MAP Section
+ *     
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FS_MAX_ELEMENTS);
+} tbl_nfs SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries,  4192);
+} tmp_nfs SEC(".maps");
+
+
+/************************************************************************************
+ *     
+ *                                 COMMON
+ *     
+ ***********************************************************************************/
+
+static int netdata_nfs_entry()
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u64 ts = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&tmp_nfs, &pid, &ts, BPF_ANY);
+
+    return 0;
+}
+
+static int netdata_nfs_store_bin(__u32 selection)
+{
+    __u64 *fill, data;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+
+    fill = bpf_map_lookup_elem(&tmp_nfs, &pid);
+    if (!fill)
+        return 0;
+
+    data = bpf_ktime_get_ns() - *fill;
+    bpf_map_delete_elem(&tmp_nfs, &pid);
+
+    // Skip entries with backward time
+    if ( (s64)data < 0)
+        return 0;
+
+    // convert to microseconds
+    data /= 1000;
+    bin = libnetdata_select_idx(data, NETDATA_FS_MAX_BINS_POS);
+    __u32 idx = selection * NETDATA_FS_MAX_BINS + bin;
+    if (idx >= NETDATA_FS_MAX_ELEMENTS)
+        return 0;
+
+    fill = bpf_map_lookup_elem(&tbl_nfs, &idx);
+    if (fill) {
+        libnetdata_update_u64(fill, 1);
+		return 0;
+    } 
+
+    data = 1;
+    bpf_map_update_elem(&tbl_nfs, &idx, &data, BPF_ANY);
+
+    return 0;
+}
+
+/************************************************************************************
+ *     
+ *                                 ENTRY SECTION (trampoline)
+ *     
+ ***********************************************************************************/
+
+SEC("fentry/nfs_file_read")
+int BPF_PROG(netdata_nfs_file_read_entry, struct kiocb *iocb) 
+{
+    struct file *fp = iocb->ki_filp;
+    if (!fp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("fentry/nfs_file_write")
+int BPF_PROG(netdata_nfs_file_write_entry, struct kiocb *iocb) 
+{
+    struct file *fp = iocb->ki_filp;
+    if (!fp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("fentry/nfs_file_open")
+int BPF_PROG(netdata_nfs_file_open_entry, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("fentry/nfs4_file_open")
+int BPF_PROG(netdata_nfs4_file_open_entry, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("fentry/nfs_getattr")
+int BPF_PROG(netdata_nfs_getattr_entry) 
+{
+    return netdata_nfs_entry();
+}
+
+/************************************************************************************
+ *     
+ *                                 END SECTION (trampoline)
+ *     
+ ***********************************************************************************/
+
+SEC("fexit/nfs_file_read")
+int BPF_PROG(netdata_nfs_file_read_exit)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_READ);
+}
+
+SEC("fexit/nfs_file_write")
+int BPF_PROG(netdata_nfs_file_write_exit)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_WRITE);
+}
+
+SEC("fexit/nfs_file_open")
+int BPF_PROG(netdata_nfs_file_open_exit)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("fexit/nfs4_file_open")
+int BPF_PROG(netdata_nfs4_file_open_exit)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("fexit/nfs_getattr")
+int BPF_PROG(netdata_nfs_getattr_exit)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_SYNC);
+}
+
+/************************************************************************************
+ *     
+ *                                 ENTRY SECTION (kprobe)
+ *     
+ ***********************************************************************************/
+
+SEC("kprobe/nfs_file_read")
+int BPF_KPROBE(netdata_nfs_file_read_probe, struct kiocb *iocb) 
+{
+    struct file *fp = BPF_CORE_READ(iocb, ki_filp);
+    if (!fp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("kprobe/nfs_file_write")
+int BPF_KPROBE(netdata_nfs_file_write_probe, struct kiocb *iocb) 
+{
+    struct file *fp = BPF_CORE_READ(iocb, ki_filp);
+    if (!fp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("kprobe/nfs_file_open")
+int BPF_KPROBE(netdata_nfs_file_open_probe, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("kprobe/nfs4_file_open")
+int BPF_KPROBE(netdata_nfs4_file_open_probe, struct inode *inode, struct file *filp) 
+{
+    if (!filp)
+        return 0;
+
+    return netdata_nfs_entry();
+}
+
+SEC("kprobe/nfs_getattr")
+int BPF_KPROBE(netdata_nfs_getattr_probe) 
+{
+    return netdata_nfs_entry();
+}
+
+/************************************************************************************
+ *     
+ *                                 END SECTION (kretprobe)
+ *     
+ ***********************************************************************************/
+
+SEC("kretprobe/nfs_file_read")
+int BPF_KRETPROBE(netdata_nfs_file_read_retprobe)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_READ);
+}
+
+SEC("kretprobe/nfs_file_write")
+int BPF_KRETPROBE(netdata_nfs_file_write_retprobe)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_WRITE);
+}
+
+SEC("kretprobe/nfs_file_open")
+int BPF_KRETPROBE(netdata_nfs_file_open_retprobe)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("kretprobe/nfs4_file_open")
+int BPF_KRETPROBE(netdata_nfs4_file_open_retprobe)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_OPEN);
+}
+
+SEC("kretprobe/nfs_getattr")
+int BPF_KRETPROBE(netdata_nfs_getattr_retprobe)
+{
+    return netdata_nfs_store_bin(NETDATA_KEY_CALLS_SYNC);
+}
+
+char _license[] SEC("license") = "GPL";
+
+

--- a/includes/netdata_fs.h
+++ b/includes/netdata_fs.h
@@ -12,6 +12,16 @@ enum fs_counters {
     NETDATA_FS_END
 };
 
+enum fs_btf_counters {
+    NETDATA_KEY_BTF_READ,
+    NETDATA_KEY_BTF_WRITE,
+    NETDATA_KEY_BTF_OPEN,
+    NETDATA_KEY_BTF_SYNC_ATTR,
+    NETDATA_KEY_BTF_OPEN2,
+
+    NETDATA_FS_BTF_END
+};
+
 // We are using 24 as hard limit to avoid intervals bigger than
 // 8 seconds and to keep memory aligment.
 #define NETDATA_FS_MAX_BINS 24UL


### PR DESCRIPTION
### Description

This PR is converting all eBPF software that are delivered by Linux filesystem to new `libbpf`.

During development it was observed that neither Slackware nor Manjaro are compiling all filesystems with all options enabled, so the tester attached with this PR is using the more conservative approach. 

For you have a successful test, it is necessary to have filesystem modules loaded. It is not necessary to mount a partition with filesystem, you can load the module and in sequence to run the tester.

### Tests

1 - Clone branch;
2 -  Go to `co-re` directory and run `make`;
3 - Load a module and run in sequence `./tests/filesystem --probe --btrfs`, changing the option for the filesystem

A complete example is given below:

```bash
bash-5.1# ./tests/filesystem --help
./tests/filesystem tests if it is possible to monitor filesystem on host

The following options are available:

--help       (-h): Prints this help.
--probe      (-p): Use probe and do no try to use trampolines (fentry/fexit).
--trampoline (-t): Try to use trampoline(fentry/fexit).
--nfs        (-n): Run tests for nfs filesystem
--ext4       (-e): Run tests for ext4 filesystem
--btrfs      (-b): Run tests for btrfs filesystem
--xfs        (-x): Run tests for xfs filesystem


Usage: ./tests/filesystem --probe --ext4
bash-5.1# ./tests/filesystem --probe --nfs
nfs: probe loaded with success
bash-5.1# ./tests/filesystem --probe --ext4
ext4: probe loaded with success
bash-5.1# ./tests/filesystem --probe --btrfs
btrfs: probe loaded with success
bash-5.1# ./tests/filesystem --probe --xfs
xfs: probe loaded with success
bash-5.1# ./tests/filesystem --trampoline --nfs
nfs: entry loaded with success
```
For this example, I used mounted partitions. 