### PR TITLE
Syscalls CO-RE

### DIFF
--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -16,6 +16,7 @@ _LIBC ?= glibc
 
 APPS = filesystem \
        mount \
+       shm \
        sync \
        #
 

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -15,6 +15,7 @@ VER_MINOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f2)
 _LIBC ?= glibc
 
 APPS = filesystem \
+       mount \
        sync \
        #
 

--- a/co-re/mount.bpf.c
+++ b/co-re/mount.bpf.c
@@ -24,16 +24,6 @@ struct {
  *
  ***********************************************************************************/
 
-/*
- *  To use these tracepoints, the kernel must be compiled with option:
- *
- *  CONFIG_FTRACE_SYSCALLS (Kernel hacking->Tracer->Trace Syscalls)
- *
- *  after this the following directory will be available:
- *  
- *  /sys/kernel/debug/tracing/events/syscalls
- */
-
 SEC("tracepoint/syscalls/sys_exit_mount")
 int netdata_mount_fexit(struct trace_event_raw_sys_exit *arg)
 {

--- a/co-re/mount.bpf.c
+++ b/co-re/mount.bpf.c
@@ -1,0 +1,104 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_mount.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS
+ *
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_MOUNT_END);
+} tbl_mount SEC(".maps");
+
+/************************************************************************************
+ *
+ *                     MOUNT SECTION (trampoline)
+ *
+ ***********************************************************************************/
+
+/*
+ *  To use these tracepoints, the kernel must be compiled with option:
+ *
+ *  CONFIG_FTRACE_SYSCALLS (Kernel hacking->Tracer->Trace Syscalls)
+ *
+ *  after this the following directory will be available:
+ *  
+ *  /sys/kernel/debug/tracing/events/syscalls
+ */
+
+SEC("tracepoint/syscalls/sys_exit_mount")
+int netdata_mount_fexit(struct trace_event_raw_sys_exit *arg)
+{
+    libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_CALL, 1);
+
+    int ret = (int)arg->ret;
+    if (ret < 0)
+        libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_ERROR, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_umount")
+int netdata_umount_fexit(struct trace_event_raw_sys_exit *arg)
+{
+    libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_CALL, 1);
+
+    int ret = (int)arg->ret;
+    if (ret < 0)
+        libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_ERROR, 1);
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                     MOUNT SECTION (kprobe)
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/netdata_mount_probe")
+int BPF_KPROBE(netdata_mount_probe)
+{
+    libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_CALL, 1);
+
+    return 0;
+}
+
+SEC("kretprobe/netdata_mount_retprobe")
+int BPF_KRETPROBE(netdata_mount_retprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_ERROR, 1);
+
+    return 0;
+}
+
+SEC("kprobe/netdata_umount_probe")
+int BPF_KPROBE(netdata_umount_probe)
+{
+    libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_CALL, 1);
+
+    return 0;
+}
+
+SEC("kretprobe/netdata_umount_retprobe")
+int BPF_KRETPROBE(netdata_umount_retprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_ERROR, 1);
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/co-re/mount.bpf.c
+++ b/co-re/mount.bpf.c
@@ -105,12 +105,11 @@ int BPF_PROG(netdata_mount_fentry)
 }
 
 SEC("fexit/netdata_mount")
-int BPF_PROG(netdata_mount_fexit, int ret)
+int BPF_PROG(netdata_mount_fexit, const struct pt_regs *regs)
 {
-    /*
+    int ret = (int)PT_REGS_RC(regs);
     if (ret < 0)
         libnetdata_update_global(&tbl_mount, NETDATA_KEY_MOUNT_ERROR, 1);
-        */
 
     return 0;
 }
@@ -124,12 +123,11 @@ int BPF_PROG(netdata_umount_fentry)
 }
 
 SEC("fexit/netdata_umount")
-int BPF_PROG(netdata_umount_fexit, int ret)
+int BPF_PROG(netdata_umount_fexit, const struct pt_regs *regs)
 {
-    /*
+    int ret = (int)PT_REGS_RC(regs);
     if (ret < 0)
         libnetdata_update_global(&tbl_mount, NETDATA_KEY_UMOUNT_ERROR, 1);
-        */
 
     return 0;
 }

--- a/co-re/mount.c
+++ b/co-re/mount.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    return 0;
+}

--- a/co-re/mount.c
+++ b/co-re/mount.c
@@ -16,12 +16,109 @@
 
 #include "mount.skel.h"
 
+static inline int ebpf_load_and_attach(struct mount_bpf *obj, int selector)
+{
+    if (selector) { // tracepoint
+        bpf_program__set_autoload(obj->progs.netdata_mount_probe, false);
+        bpf_program__set_autoload(obj->progs.netdata_mount_retprobe, false);
+        bpf_program__set_autoload(obj->progs.netdata_umount_probe, false);
+        bpf_program__set_autoload(obj->progs.netdata_umount_retprobe, false);
+    }
+
+    int ret = mount_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    if (selector)
+        ret = mount_bpf__attach(obj);
+
+    if (!ret) {
+        fprintf(stdout, "%s loaded with success\n", (selector) ? "tracepoint" : "probe");
+    }
+
+    return ret;
+}
+
+static int call_syscalls()
+{
+    char *dst = { "./mydst" };
+    if (mkdir(dst, 0777)) {
+        fprintf(stdout, "Cannot create directory\n");
+        return -1;
+    }
+
+    // I am not testing return, because errors are also stored at hash map
+    mount("none", dst, "tmpfs", 0, "mode=0777");
+    umount(dst);
+
+    rmdir(dst);
+
+    return 0;
+}
+
+static int mount_read_array(int fd)
+{
+    int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
+    uint64_t *stored = calloc((size_t)ebpf_nprocs, sizeof(uint64_t));
+    if (!stored)
+        return 2;
+
+    uint32_t idx;
+    uint64_t counter = 0;
+    for (idx = 0; idx < NETDATA_MOUNT_END; idx++)  {
+        if (!bpf_map_lookup_elem(fd, &idx, stored)) {
+            int j;
+            for (j = 0; j < ebpf_nprocs; j++) {
+                counter += stored[j];
+            }
+        }
+
+        memset(stored, 0, sizeof(uint64_t) * ebpf_nprocs);
+    }
+
+    free(stored);
+
+    if (counter >= 2) {
+        fprintf(stdout, "Data stored with success\n");
+        return 0;
+    }
+
+    return 2;
+}
+
+static int ebpf_mount_tests(int selector)
+{
+    struct mount_bpf *obj = NULL;
+
+    obj = mount_bpf__open();
+    if (!obj) {
+        fprintf(stderr, "Cannot open or load BPF object\n");
+
+        return 2;
+    }
+
+    int ret = ebpf_load_and_attach(obj, selector);
+    if (!ret) {
+        ret = call_syscalls();
+        if (!ret) {
+            int fd = bpf_map__fd(obj->maps.tbl_mount);
+            ret = mount_read_array(fd);
+        }
+    }
+
+    mount_bpf__destroy(obj);
+
+    return ret;
+}
+
 int main(int argc, char **argv)
 {
     static struct option long_options[] = {
         {"help",        no_argument,    0,  'h' },
         {"probe",       no_argument,    0,  'p' },
-        {"tracepoint",  no_argument,    0,  't' },
+        {"tracepoint",  no_argument,    0,  'r' },
         {0, 0, 0, 0}
     };
 
@@ -51,5 +148,13 @@ int main(int argc, char **argv)
         }
     }
 
-    return 0;
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+
+    return ebpf_mount_tests(selector);
 }
+

--- a/co-re/mount.c
+++ b/co-re/mount.c
@@ -1,6 +1,55 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/stat.h>
+#include <sys/mount.h>
+
+#include "netdata_tests.h"
+#include "netdata_mount.h"
+
+#include "mount.skel.h"
 
 int main(int argc, char **argv)
 {
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"tracepoint",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = 0;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "mount", 0);
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = 0;
+                          break;
+                      }
+            case 'r': {
+                          selector = 1;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
     return 0;
 }

--- a/co-re/shm.bpf.c
+++ b/co-re/shm.bpf.c
@@ -34,7 +34,7 @@ struct {
 
 /************************************************************************************
  *
- *                     MOUNT SECTION (trampoline)
+ *                     SHARED MEMORY (common)
  *
  ***********************************************************************************/
 
@@ -56,7 +56,7 @@ static inline int netdata_global_apps_shm(__u32 idx)
 
 /************************************************************************************
  *
- *                     MOUNT SECTION (tracepoint)
+ *                     SHARED MEMORY (tracepoint)
  *
  ***********************************************************************************/
 
@@ -92,6 +92,52 @@ int netdata_syscall_shmdt(struct trace_event_raw_sys_enter *arg)
 
 SEC("tracepoint/syscalls/sys_enter_shmctl")
 int netdata_syscall_shmctl(struct trace_event_raw_sys_enter *arg)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                     SHARED MEMORY (kprobe)
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/netdata_shmget_probe")
+int BPF_KPROBE(netdata_shmget_probe)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("kprobe/netdata_shmat_probe")
+int BPF_KPROBE(netdata_shmat_probe)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("kprobe/netdata_shmdt_probe")
+int BPF_KPROBE(netdata_shmdt_probe)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("kprobe/netdata_shmctl_probe")
+int BPF_KPROBE(netdata_shmctl_probe)
 {
     int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
     if (!store_apps)

--- a/co-re/shm.bpf.c
+++ b/co-re/shm.bpf.c
@@ -146,5 +146,51 @@ int BPF_KPROBE(netdata_shmctl_probe)
     return 0;
 }
 
+/************************************************************************************
+ *
+ *                     SHARED MEMORY (trampoline)
+ *
+ ***********************************************************************************/
+
+SEC("fentry/netdata_shmget")
+int BPF_PROG(netdata_shmget_fentry)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("fentry/netdata_shmat")
+int BPF_PROG(netdata_shmat_fentry)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("fentry/netdata_shmdt")
+int BPF_PROG(netdata_shmdt_fentry)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("fentry/netdata_shmctl")
+int BPF_PROG(netdata_shmctl_fentry)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
 char _license[] SEC("license") = "GPL";
 

--- a/co-re/shm.bpf.c
+++ b/co-re/shm.bpf.c
@@ -54,6 +54,42 @@ static inline int netdata_global_apps_shm(__u32 idx)
     return 1;
 }
 
+static inline int netdata_ebpf_common_shmget()
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+static inline int netdata_ebpf_common_shmat()
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+static inline int netdata_ebpf_common_shmdt()
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+static inline int netdata_ebpf_common_shmctl()
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
 /************************************************************************************
  *
  *                     SHARED MEMORY (tracepoint)
@@ -63,41 +99,25 @@ static inline int netdata_global_apps_shm(__u32 idx)
 SEC("tracepoint/syscalls/sys_enter_shmget")
 int netdata_syscall_shmget(struct trace_event_raw_sys_enter *arg)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmget();
 }
 
 SEC("tracepoint/syscalls/sys_enter_shmat")
 int netdata_syscall_shmat(struct trace_event_raw_sys_enter *arg)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmat();
 }
 
 SEC("tracepoint/syscalls/sys_enter_shmdt")
 int netdata_syscall_shmdt(struct trace_event_raw_sys_enter *arg)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmdt();
 }
 
 SEC("tracepoint/syscalls/sys_enter_shmctl")
 int netdata_syscall_shmctl(struct trace_event_raw_sys_enter *arg)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmctl();
 }
 
 /************************************************************************************
@@ -109,41 +129,25 @@ int netdata_syscall_shmctl(struct trace_event_raw_sys_enter *arg)
 SEC("kprobe/netdata_shmget_probe")
 int BPF_KPROBE(netdata_shmget_probe)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmget();
 }
 
 SEC("kprobe/netdata_shmat_probe")
 int BPF_KPROBE(netdata_shmat_probe)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmat();
 }
 
 SEC("kprobe/netdata_shmdt_probe")
 int BPF_KPROBE(netdata_shmdt_probe)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmdt();
 }
 
 SEC("kprobe/netdata_shmctl_probe")
 int BPF_KPROBE(netdata_shmctl_probe)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmctl();
 }
 
 /************************************************************************************
@@ -155,41 +159,25 @@ int BPF_KPROBE(netdata_shmctl_probe)
 SEC("fentry/netdata_shmget")
 int BPF_PROG(netdata_shmget_fentry)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmget();
 }
 
 SEC("fentry/netdata_shmat")
 int BPF_PROG(netdata_shmat_fentry)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmat();
 }
 
 SEC("fentry/netdata_shmdt")
 int BPF_PROG(netdata_shmdt_fentry)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmdt();
 }
 
 SEC("fentry/netdata_shmctl")
 int BPF_PROG(netdata_shmctl_fentry)
 {
-    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
-    if (!store_apps)
-        return 0;
-
-    return 0;
+    return netdata_ebpf_common_shmctl();
 }
 
 char _license[] SEC("license") = "GPL";

--- a/co-re/shm.bpf.c
+++ b/co-re/shm.bpf.c
@@ -1,0 +1,104 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_shm.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS
+ *
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_SHM_END);
+} tbl_shm  SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __type(key, __u32);
+    __type(value, netdata_shm_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_pid_shm SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
+} shm_ctrl SEC(".maps");
+
+/************************************************************************************
+ *
+ *                     MOUNT SECTION (trampoline)
+ *
+ ***********************************************************************************/
+
+static inline int netdata_global_apps_shm(__u32 idx)
+{
+    libnetdata_update_global(&tbl_shm, idx, 1);
+
+    // check if apps is enabled; if not, don't record apps data.
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&shm_ctrl, &key);
+    if (apps) {
+        if (*apps == 0) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/************************************************************************************
+ *
+ *                     MOUNT SECTION (tracepoint)
+ *
+ ***********************************************************************************/
+
+SEC("tracepoint/syscalls/sys_enter_shmget")
+int netdata_syscall_shmget(struct trace_event_raw_sys_enter *arg)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_shmat")
+int netdata_syscall_shmat(struct trace_event_raw_sys_enter *arg)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_shmdt")
+int netdata_syscall_shmdt(struct trace_event_raw_sys_enter *arg)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_shmctl")
+int netdata_syscall_shmctl(struct trace_event_raw_sys_enter *arg)
+{
+    int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
+    if (!store_apps)
+        return 0;
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/co-re/shm.c
+++ b/co-re/shm.c
@@ -219,29 +219,14 @@ static int shm_read_apps_array(int fd, int ebpf_nprocs)
     return 2;
 }
 
-static int ebpf_find_functions(struct btf *bf, int selector)
-{
-    if (!bf)
-        return selector;
-
-    uint32_t i;
-    for (i = 0; i < NETDATA_SHM_END; i++) {
-        if (ebpf_find_function_id(bf, syscalls[i]) < 0 ) {
-            fprintf(stderr, "Cannot find function %s\n", syscalls[i]);
-            selector = NETDATA_MODE_PROBE;
-            break;
-        }
-    }
-
-    return selector;
-}
-
 int ebpf_shm_tests(struct btf *bf, int selector)
 {
     struct shm_bpf *obj = NULL;
     int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
 
-    selector = ebpf_find_functions(bf, selector);
+    if (bf)
+        selector = ebpf_find_functions(bf, selector, syscalls, NETDATA_SHM_END);
+
     obj = shm_bpf__open();
     if (!obj) {
         fprintf(stderr, "Cannot open or load BPF object\n");

--- a/co-re/shm.c
+++ b/co-re/shm.c
@@ -282,3 +282,4 @@ int main(int argc, char **argv)
 
     return 0;
 }
+

--- a/co-re/shm.c
+++ b/co-re/shm.c
@@ -1,0 +1,209 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "netdata_tests.h"
+#include "netdata_shm.h"
+
+#include "shm.skel.h"
+
+static void ebpf_disable_tracepoint(struct shm_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_syscall_shmget, false);
+    bpf_program__set_autoload(obj->progs.netdata_syscall_shmat, false);
+    bpf_program__set_autoload(obj->progs.netdata_syscall_shmdt, false);
+    bpf_program__set_autoload(obj->progs.netdata_syscall_shmctl, false);
+}
+
+static inline int ebpf_load_and_attach(struct shm_bpf *obj, int selector)
+{
+    if (!selector) { // trampoline
+        ebpf_disable_tracepoint(obj);
+    } else if (selector == 1) { // kprobe
+        ebpf_disable_tracepoint(obj);
+    } else { // tracepoint
+    }
+
+    int ret = shm_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    if (selector != 1) // Not kprobe
+        ret = shm_bpf__attach(obj);
+
+    if (!ret) {
+        char *method = ebpf_select_type(selector);
+        fprintf(stdout, "%s loaded with success\n", method);
+    }
+
+    return ret;
+}
+
+int call_syscalls()
+{
+#define SHMSZ   27
+    // Copied and adapt from https://github.com/netdata/netdata/pull/11560#issuecomment-927613811
+    key_t name = 5678;
+
+    int shmid = shmget(name, SHMSZ, IPC_CREAT | 0666);
+    if (shmid < 0)
+         return 2;
+
+    sleep(1);
+
+    char *shm = shmat(shmid, NULL, 0);
+    if (shm == (char *) -1) {
+        perror("shmat");
+        return 2;
+    }
+
+    char c, *s = shm;
+    for (c = 'a'; c <= 'z'; c++)
+        *s++ = c;
+    *s = 0;
+
+    sleep(1);
+
+    struct shmid_ds dsbuf;
+    if ((shmctl(shmid, IPC_STAT, &dsbuf)) == -1) {
+        perror("shmctl");
+        return 2;
+    }
+
+    if ((shmdt(shm)) == -1) {
+        perror("shmdt");
+        return 2;
+    }
+
+    return 0;
+}
+
+static int shm_read_global_array(int fd, int ebpf_nprocs)
+{
+    uint64_t *stored = calloc((size_t)ebpf_nprocs, sizeof(uint64_t));
+    if (!stored)
+        return 2;
+
+    size_t length = (size_t)ebpf_nprocs * sizeof(uint64_t);
+    uint32_t idx;
+    uint64_t counter = 0;
+    for (idx = 0; idx < NETDATA_SHM_END; idx++) {
+        if (!bpf_map_lookup_elem(fd, &idx, stored)) {
+            int j;
+            for (j = 0; j < ebpf_nprocs; j++) {
+                counter += stored[j];
+            }
+        }
+
+        memset(stored, 0, length);
+    }
+
+    free(stored);
+
+    if (counter >= 4) {
+        fprintf(stdout, "Global data stored with success\n");
+        return 0;
+    }
+
+    return 2;
+}
+
+int ebpf_shm_tests(int selector)
+{
+    struct shm_bpf *obj = NULL;
+    int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
+
+    obj = shm_bpf__open();
+    if (!obj) {
+        fprintf(stderr, "Cannot open or load BPF object\n");
+
+        return 2;
+    }
+
+    int ret = ebpf_load_and_attach(obj, selector);
+    if (!ret) {
+        int fd = bpf_map__fd(obj->maps.shm_ctrl);
+        update_controller_table(fd);
+        ret = call_syscalls();
+        if (!ret) {
+            int fd = bpf_map__fd(obj->maps.tbl_shm);
+            ret = shm_read_global_array(fd, ebpf_nprocs);
+        }
+    }
+
+    shm_bpf__destroy(obj);
+
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"tracepoint",  no_argument,    0,  'r' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    // use trampoline as default
+    int selector = 0;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "shared_memory", 1);
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = 1;
+                          break;
+                      }
+            case 'r': {
+                          selector = 2;
+                          break;
+                      }
+            case 't': {
+                          selector = 0;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+    
+    struct btf *bf = NULL;
+    if (!selector) {
+        bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);
+    }
+
+    ret = ebpf_shm_tests(selector);
+
+    if (bf)
+        btf__free(bf);
+
+    return 0;
+}

--- a/co-re/sync.bpf.c
+++ b/co-re/sync.bpf.c
@@ -40,5 +40,13 @@ int BPF_KPROBE(netdata_sync_kprobe)
     return 0;
 }
 
+SEC("tracepoint/syscalls/sys_entry_sync")
+int netdata_sync_entry(struct trace_event_raw_sys_enter *ctx)
+{
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
 char _license[] SEC("license") = "GPL";
 

--- a/co-re/sync.bpf.c
+++ b/co-re/sync.bpf.c
@@ -40,13 +40,54 @@ int BPF_KPROBE(netdata_sync_kprobe)
     return 0;
 }
 
-SEC("tracepoint/syscalls/sys_entry_sync")
+SEC("tracepoint/syscalls/sys_enter_syncfs")
+int netdata_syncfs_entry(struct trace_event_raw_sys_enter *ctx)
+{
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_msync")
+int netdata_msync_entry(struct trace_event_raw_sys_enter *ctx)
+{
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_sync_file_range")
+int netdata_sync_file_range_entry(struct trace_event_raw_sys_enter *ctx)
+{
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_fsync")
+int netdata_fsync_entry(struct trace_event_raw_sys_enter *ctx)
+{
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_fdatasync")
+int netdata_fdatasync_entry(struct trace_event_raw_sys_enter *ctx)
+{
+    libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_sync")
 int netdata_sync_entry(struct trace_event_raw_sys_enter *ctx)
 {
     libnetdata_update_global(&tbl_sync, NETDATA_KEY_SYNC_CALL, 1);
 
     return 0;
 }
+
 
 char _license[] SEC("license") = "GPL";
 

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -46,9 +46,11 @@ static inline int ebpf_load_and_attach(struct sync_bpf *obj, int id, char *name)
 {
     if (id > 0) {
         bpf_program__set_autoload(obj->progs.netdata_sync_kprobe, false);
+        bpf_program__set_autoload(obj->progs.netdata_sync_entry, false);
         bpf_program__set_attach_target(obj->progs.netdata_sync_fentry, 0,
                                        name);
     } else {
+        bpf_program__set_autoload(obj->progs.netdata_sync_entry, false);
         bpf_program__set_autoload(obj->progs.netdata_sync_fentry, false);
     }
 

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -121,7 +121,7 @@ static int ebpf_fcnt_tests(struct btf *bf, int (*fcnt)(int), enum netdata_sync_e
 
     int id = -1;
     if (bf) {
-        id = ebpf_find_function_id(bf, ebpf_sync_syscall[NETDATA_SYNCFS_SYSCALL]);
+        id = ebpf_find_function_id(bf, ebpf_sync_syscall[idx]);
     }
 
     obj = sync_bpf__open();
@@ -218,7 +218,7 @@ static int ebpf_msync_tests(struct btf *bf)
 
     int id = -1;
     if (bf) {
-        id = ebpf_find_function_id(bf, ebpf_sync_syscall[NETDATA_SYNCFS_SYSCALL]);
+        id = ebpf_find_function_id(bf, ebpf_sync_syscall[NETDATA_MSYNC_SYSCALL]);
     }
 
     obj = sync_bpf__open();
@@ -294,7 +294,7 @@ static int ebpf_sync_file_range_tests(struct btf *bf)
 
     int id = -1;
     if (bf) {
-        id = ebpf_find_function_id(bf, ebpf_sync_syscall[NETDATA_SYNCFS_SYSCALL]);
+        id = ebpf_find_function_id(bf, ebpf_sync_syscall[NETDATA_SYNC_FILE_RANGE_SYSCALL]);
     }
 
     obj = sync_bpf__open();

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -430,7 +430,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "sys_syncfs");
+                          ebpf_print_help(argv[0], "sys_syncfs", 1);
                           exit(0);
                       }
             case 'p': {

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -46,15 +46,16 @@ static inline const struct btf_type *netdata_find_bpf_attach_type(struct btf *bf
     return btf__type_by_id(bf, id);
 }
 
-static inline void ebpf_print_help(char *name, char *info) {
+static inline void ebpf_print_help(char *name, char *info, int has_trampoline) {
     fprintf(stdout, "%s tests if it is possible to monitor %s on host\n\n"
                     "The following options are available:\n\n"
                     "--help       (-h): Prints this help.\n"
                     "--probe      (-p): Use probe and do no try to use trampolines (fentry/fexit).\n"
                     "--tracepoint (-r): Use tracepoint.\n"
-                    "--trampoline (-t): Try to use trampoline(fentry/fexit). If this is not possible" 
-                    " probes will be used.\n"
                     , name, info);
+    if (has_trampoline)
+        fprintf(stdout, "--trampoline (-t): Try to use trampoline(fentry/fexit). If this is not possible" 
+                        " probes will be used.\n");
 }
 
 static inline int ebpf_find_function_id(struct btf *bf, char *name)

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -13,6 +13,14 @@
 #include <bpf/libbpf.h>
 #include <bpf/btf.h>
 
+enum netdata_user_controller {
+    NETDATA_CONTROLLER_APPS_ENABLED,
+
+    NETDATA_CONTROLLER_END
+};
+
+// Use __always_inline instead inline to keep compatiblity with old kernels
+
 static inline int netdata_ebf_memlock_limit(void)
 {
     struct rlimit r = { RLIM_INFINITY, RLIM_INFINITY };
@@ -93,6 +101,16 @@ static inline char *ebpf_select_type(int selector)
 
     return NULL;
 }
+
+static inline void update_controller_table(int fd)
+{
+    uint32_t key = NETDATA_CONTROLLER_APPS_ENABLED;
+    uint32_t value = 1;
+    int ret = bpf_map_update_elem(fd, &key, &value, 0);
+    if (ret)
+        fprintf(stderr, "Cannot insert value to control table.");
+}
+
 
 #endif /* _NETDATA_TESTS_H_ */
 

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -60,7 +60,6 @@ enum netdata_modes {
     NETDATA_MODE_TRACEPOINT
 };
 
-
 static inline void ebpf_print_help(char *name, char *info, int has_trampoline) {
     fprintf(stdout, "%s tests if it is possible to monitor %s on host\n\n"
                     "The following options are available:\n\n"
@@ -118,6 +117,22 @@ static inline void update_controller_table(int fd)
         fprintf(stderr, "Cannot insert value to control table.");
 }
 
+static inline int ebpf_find_functions(struct btf *bf, int selector, char *syscalls[], uint32_t end)
+{
+    if (!bf)
+        return selector;
+
+    uint32_t i;
+    for (i = 0; i < end; i++) {
+        if (ebpf_find_function_id(bf, syscalls[i]) < 0 ) {
+            fprintf(stderr, "Cannot find function %s\n", syscalls[i]);
+            selector = NETDATA_MODE_PROBE;
+            break;
+        }
+    }
+
+    return selector;
+}
 
 #endif /* _NETDATA_TESTS_H_ */
 

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -51,6 +51,7 @@ static inline void ebpf_print_help(char *name, char *info) {
                     "The following options are available:\n\n"
                     "--help       (-h): Prints this help.\n"
                     "--probe      (-p): Use probe and do no try to use trampolines (fentry/fexit).\n"
+                    "--tracepoint (-r): Use tracepoint.\n"
                     "--trampoline (-t): Try to use trampoline(fentry/fexit). If this is not possible" 
                     " probes will be used.\n"
                     , name, info);
@@ -72,6 +73,24 @@ static inline int ebpf_find_function_id(struct btf *bf, char *name)
     }
 
     return id;
+}
+
+static inline char *ebpf_select_type(int selector)
+{
+    switch(selector)
+    {
+        case 0: {
+                    return "trampoline";
+                }
+        case 1: {
+                    return "probe";
+                }
+        case 2: {
+                    return "tracepoint";
+                }
+    }
+
+    return NULL;
 }
 
 #endif /* _NETDATA_TESTS_H_ */

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -54,6 +54,13 @@ static inline const struct btf_type *netdata_find_bpf_attach_type(struct btf *bf
     return btf__type_by_id(bf, id);
 }
 
+enum netdata_modes {
+    NETDATA_MODE_TRAMPOLINE,
+    NETDATA_MODE_PROBE,
+    NETDATA_MODE_TRACEPOINT
+};
+
+
 static inline void ebpf_print_help(char *name, char *info, int has_trampoline) {
     fprintf(stdout, "%s tests if it is possible to monitor %s on host\n\n"
                     "The following options are available:\n\n"


### PR DESCRIPTION
### Description

This PR is converting all remaining `syscall` to CO-RE. 
When trampolines are not available, we are converting direct to `kprobe`, but when we merge the code at `netdata/netdata` we will try monitoring according the following order:

1. Trampoline
2. Tracepoint
3. Kprobe

### Test plan

1. Clone branch;
2. Go to `co-re` directory and run `make`;
3. Run the following tests: 

```sh
bash-5.1# ./tests/sync --probe
__x64_sys_syncfs: probe loaded with success
__x64_sys_msync: probe loaded with success
__x64_sys_sync_file_range: probe loaded with success
__x64_sys_fsync: probe loaded with success
__x64_sys_fdatasync: probe loaded with success
__x64_sys_sync: probe loaded with success
bash-5.1# ./tests/sync --trampoline
Cannot find function __x64_sys_sync
__x64_sys_syncfs: probe loaded with success
__x64_sys_msync: probe loaded with success
__x64_sys_sync_file_range: probe loaded with success
__x64_sys_fsync: probe loaded with success
__x64_sys_fdatasync: probe loaded with success
__x64_sys_sync: probe loaded with success
bash-5.1# ./tests/sync --tracepoint
__x64_sys_syncfs: tracepoint loaded with success
__x64_sys_msync: tracepoint loaded with success
__x64_sys_sync_file_range: tracepoint loaded with success
__x64_sys_fsync: tracepoint loaded with success
__x64_sys_fdatasync: tracepoint loaded with success
__x64_sys_sync: tracepoint loaded with success


bash-5.1# ./tests/shm --probe
probe loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/shm --tracepoint
tracepoint loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/shm --trampoline
trampoline loaded with success
Global data stored with success
Apps data stored with success

bash-5.1# ./tests/mount --trampoline
probe loaded with success
Data stored with success
bash-5.1# ./tests/mount --tracepoint
tracepoint loaded with success
Data stored with success
bash-5.1# ./tests/mount --probe
tracepoint loaded with success
Data stored with success
```

### Additional information

On Slackware, and Manjaro `__x64_sys_clone` is not exported, so instead to attach `trampoline`, we use `kprobe`, that is expected to be present for the majority of Linux distributions.

This PR was tested on:

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.15.3  |
| Manjaro 21.1 | 5.10.79-1 |
| CentOS 8.5.2111 | 4.18.0-348 |