### PR TITLE
Process CO-RE

### DIFF
--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -16,6 +16,7 @@ _LIBC ?= glibc
 
 APPS = filesystem \
        mount \
+       process \
        shm \
        sync \
        #

--- a/co-re/process.bpf.c
+++ b/co-re/process.bpf.c
@@ -1,0 +1,194 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_process.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS
+ *
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct netdata_pid_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_pid_stats SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_GLOBAL_COUNTER);
+} tbl_total_stats SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
+} process_ctrl SEC(".maps");
+
+/************************************************************************************
+ *
+ *                     PROCESS SECTION (tracepoints must be enabled)
+ *
+ ***********************************************************************************/
+
+SEC("tracepoint/sched/sched_process_exit")
+int netdata_tracepoint_sched_process_exit(struct netdata_sched_process_exit *ptr)
+{
+    struct netdata_pid_stat_t *fill;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_EXIT, 1);
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->exit_call, 1) ;
+    } 
+
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exec")
+int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr)
+{
+    struct netdata_pid_stat_t data = { };
+    struct netdata_pid_stat_t *fill;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    // This is necessary, because it represents the main function to start a thread
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
+
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl, &key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_pid_stats, &key);
+    if (fill) {
+        fill->release_call = 0;
+        libnetdata_update_u32(&fill->create_process, 1) ;
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+        data.create_process = 1;
+
+        bpf_map_update_elem(&tbl_pid_stats, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_fork")
+int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr)
+{
+    struct netdata_pid_stat_t data = { };
+    struct netdata_pid_stat_t *fill;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
+
+    // Parent ID = 1 means that init called process/thread creation
+    int thread = 0;
+    if (ptr->parent_pid != ptr->child_pid && ptr->parent_pid != 1) {
+        thread = 1;
+        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_THREAD, 1);
+    }
+
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
+    if (fill) {
+        fill->release_call = 0;
+        libnetdata_update_u32(&fill->create_process, 1);
+        if (thread)
+            libnetdata_update_u32(&fill->create_thread, 1);
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+        data.create_process = 1;
+        if (thread)
+            data.create_thread = 1;
+
+        bpf_map_update_elem(&tbl_pid_stats, &key, &data, BPF_ANY);
+    }
+
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                     COMMON SECTION (kprobe and trampoline)
+ *
+ ***********************************************************************************/
+
+static inline int netdata_common_release_task()
+{
+    struct netdata_pid_stat_t *fill;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_RELEASE_TASK, 1);
+    __u32 *apps = bpf_map_lookup_elem(&process_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_pid_stats ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->release_call, 1) ;
+        fill->removeme = 1;
+    }
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                     PROCESS SECTION (kprobe)
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/release_task")
+int BPF_KPROBE(netdata_release_task_probe)
+{
+    return netdata_common_release_task();
+}
+
+/************************************************************************************
+ *
+ *                     PROCESS SECTION (trampoline)
+ *
+ ***********************************************************************************/
+
+SEC("fentry/release_task")
+int BPF_PROG(netdata_release_task_fentry)
+{
+    return netdata_common_release_task();
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/co-re/process.c
+++ b/co-re/process.c
@@ -1,0 +1,183 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+#include <sys/wait.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "netdata_tests.h"
+#include "netdata_process.h"
+
+#include "process.skel.h"
+
+static inline int ebpf_load_and_attach(struct process_bpf *obj, int selector)
+{
+    char *release_task = { "release_task" };
+    if (!selector) { // trampoline
+        bpf_program__set_autoload(obj->progs.netdata_release_task_probe, false);
+
+        bpf_program__set_attach_target(obj->progs.netdata_release_task_fentry, 0,
+                                       release_task);
+    } else { 
+        bpf_program__set_autoload(obj->progs.netdata_release_task_fentry, false);
+    }
+
+    int ret = process_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    ret = process_bpf__attach(obj);
+
+    if (!ret) {
+        fprintf(stdout, "Process loaded with success\n");
+    }
+
+    return ret;
+}
+
+static pid_t ebpf_create_threads()
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("Fork");
+        return 0;
+    } else if (!pid) {
+        fprintf(stdout, "I'm the child\n");
+        sleep(1);
+        exit(0);
+    } else {
+        fprintf(stdout, "I'm a proud dad!\n");
+        wait(NULL);
+    }
+
+    return pid;
+}
+
+static int process_read_specific_app(struct netdata_pid_stat_t *stored, int fd, int ebpf_nprocs, uint32_t idx)
+{
+    uint64_t counter = 0;
+    if (!bpf_map_lookup_elem(fd, &idx, stored)) {
+        int j;
+        for (j = 0; j < ebpf_nprocs; j++) {
+            counter += (stored[j].exit_call + stored[j].release_call +
+                        stored[j].create_process +stored[j].create_thread);
+        }
+    }
+
+    return counter;
+}
+
+static int process_read_apps_array(int fd, int ebpf_nprocs, uint32_t child)
+{
+    struct netdata_pid_stat_t *stored = calloc((size_t)ebpf_nprocs, sizeof(struct netdata_pid_stat_t));
+    if (!stored)
+        return 2;
+
+    uint32_t my_pid = (uint32_t) getpid();
+
+    uint64_t counter = 0;
+    counter += process_read_specific_app(stored, fd, ebpf_nprocs, my_pid);
+    memset(stored, 0, (size_t)ebpf_nprocs * sizeof(struct netdata_pid_stat_t));
+    counter += process_read_specific_app(stored, fd, ebpf_nprocs, child);
+
+    free(stored);
+
+    if (counter) {
+        fprintf(stdout, "Apps data stored with success\n");
+        return 0;
+    }
+
+    return 2;
+}
+
+
+static int ebpf_process_tests(int selector)
+{
+    struct process_bpf *obj = NULL;
+    int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
+
+    obj = process_bpf__open();
+    if (!obj) {
+        fprintf(stderr, "Cannot open or load BPF object\n");
+
+        return 2;
+    }
+
+    int ret = ebpf_load_and_attach(obj, selector);
+    if (!ret) {
+        int fd = bpf_map__fd(obj->maps.process_ctrl);
+        update_controller_table(fd);
+
+        pid_t child = ebpf_create_threads();
+        // Wait data from more processes
+        sleep(10);
+
+        fd = bpf_map__fd(obj->maps.tbl_total_stats);
+        ret =  ebpf_read_global_array(fd, ebpf_nprocs, NETDATA_GLOBAL_COUNTER);
+        if (!ret) {
+            fd = bpf_map__fd(obj->maps.tbl_pid_stats);
+            ret = process_read_apps_array(fd, ebpf_nprocs, (uint32_t)child);
+        }
+    }
+
+    process_bpf__destroy(obj);
+
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"tracepoint",  no_argument,    0,  'r' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = NETDATA_MODE_TRAMPOLINE;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "mount", 1);
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = NETDATA_MODE_PROBE;
+                          break;
+                      }
+            case 'r': {
+                          selector = NETDATA_MODE_TRACEPOINT;
+                          break;
+                      }
+            case 't': {
+                          selector = NETDATA_MODE_TRAMPOLINE;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+
+    return ebpf_process_tests(selector);
+}
+

--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -134,5 +134,35 @@ static inline int ebpf_find_functions(struct btf *bf, int selector, char *syscal
     return selector;
 }
 
+static inline int ebpf_read_global_array(int fd, int ebpf_nprocs, uint32_t end)
+{
+    uint64_t *stored = calloc((size_t)ebpf_nprocs, sizeof(uint64_t));
+    if (!stored)
+        return 2;
+
+    size_t length = (size_t)ebpf_nprocs * sizeof(uint64_t);
+    uint32_t idx;
+    uint64_t counter = 0;
+    for (idx = 0; idx < end; idx++) {
+        if (!bpf_map_lookup_elem(fd, &idx, stored)) {
+            int j;
+            for (j = 0; j < ebpf_nprocs; j++) {
+                counter += stored[j];
+            }
+        }
+
+        memset(stored, 0, length);
+    }
+
+    free(stored);
+
+    if (counter >= 4) {
+        fprintf(stdout, "Global data stored with success\n");
+        return 0;
+    }
+
+    return 2;
+}
+
 #endif /* _NETDATA_TESTS_H_ */
 


### PR DESCRIPTION
### Description
This PR is bringing process monitoring using latest libbpf and CO-RE.
It also expands the monitored functions according the method used giving flexibility to `eBPF.plugin`.

### Test plan

1. Clone branch;
2. Go to `co-re` directory and run `make`;
3. Run the following tests: 

```sh
bash-5.1# ./tests/process --tramṕoline
./tests/process: unrecognized option '--tramṕoline'
Process loaded with success
I'm a proud dad!
I'm the child.
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/process --tracepoint
Process loaded with success
I'm a proud dad!
I'm the child.
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/process --probe
Process loaded with success
I'm a proud dad!
I'm the child.
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/shm --probe
probe loaded with success
Global data stored with success
Apps data stored with success
```

### Additional information

This PR was tested on:

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.15.3  |
| Manjaro 21.1 | 5.10.79-1 |
| CentOS 8.5.2111 | 4.18.0-348 |