### PR TITLE
Fix libbpf build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Run buil.sh
+      - name: Run build.sh
         run: |
           if [ ${{ matrix.kernel_version }} = "4.18.0" ]; then
             os=centos8

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.a
 
 co-re/tests/*
+co-re/bpf
+co-re/pkgconfig

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -1,6 +1,6 @@
 LIBBPF = ../libbpf
 CFLAGS = -Wall -ggdb
-INCLUDES = -I../includes/ -I$(LIBBPF)/src/ -I./includes/ -I$(LIBBPF) -I$(LIBBPF)/include/uapi/
+INCLUDES = -I. -I../includes/ -I$(LIBBPF)/src/ -I./includes/ -I. -I$(LIBBPF)/include/uapi/
 CLANG ?= clang 
 LLVM_STRIP ?= llvm-strip
 OUTPUT = tests/

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -47,7 +47,7 @@ $(APPS): %: %.o
 compress: $(APPS)
 	tar -cf ../artifacts/netdata_ebpf-CO-RE-$(_LIBC).tar includes/*
 	if [ "$${DEBUG:-0}" -eq 1 ]; then tar -uvf ../artifacts/netdata_ebpf-CO-RE-$(_LIBC).tar ../tools/check-kernel-core.sh; fi
-	xz ../artifacts/netdata_ebpf-CO-RE-$(_LIBC).tar
+	xz -f ../artifacts/netdata_ebpf-CO-RE-$(_LIBC).tar
 	( cd ../artifacts; sha256sum netdata_ebpf-CO-RE-$(_LIBC).tar.xz > netdata_ebpf-CO-RE-$(_LIBC).tar.xz.sha256sum )
 
 clean:

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -51,5 +51,8 @@ compress: $(APPS)
 	( cd ../artifacts; sha256sum netdata_ebpf-CO-RE-$(_LIBC).tar.xz > netdata_ebpf-CO-RE-$(_LIBC).tar.xz.sha256sum )
 
 clean:
+	rm -rf bpf pkgconfig
+	rm -f ../artifacts/netdata_ebpf-CO-RE-*.tar.xz
+	rm -f ../artifacts/netdata_ebpf-CO-RE-*.tar.xz.sha256sum
 	cd $(LIBBPF)/src/ && make clean
-	rm *.o $(OUTPUT)* libbpf.a includes/*
+	rm -f *.o $(OUTPUT)* libbpf.a includes/*

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -1,6 +1,6 @@
 LIBBPF = ../libbpf
 CFLAGS = -Wall -ggdb
-INCLUDES = -I../includes/ -I../libbpf/src/ -I./includes/ -I../libbpf -I../libbpf/include/uapi/
+INCLUDES = -I../includes/ -I$(LIBBPF)/src/ -I./includes/ -I$(LIBBPF) -I$(LIBBPF)/include/uapi/
 CLANG ?= clang 
 LLVM_STRIP ?= llvm-strip
 OUTPUT = tests/
@@ -27,8 +27,7 @@ APPS = cachestat \
 all: compress
 
 libbpf:
-	cd ../libbpf/src && mkdir -p root build && $(MAKE) BUILD_STATIC_ONLY=1 OBJDIR=build DESTDIR=.. INCLUDEDIR= LIBDIR= UAPIDIR= install \
-	&& cp build/*.a ../../co-re/	
+	cd $(LIBBPF)/src && $(MAKE) BUILD_STATIC_ONLY=1 DESTDIR=../../co-re/ INCLUDEDIR= LIBDIR= UAPIDIR= install \
 
 %.bpf.o: %.bpf.c libbpf
 	$(CLANG) $(INCLUDES) -ggdb -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
@@ -52,5 +51,5 @@ compress: $(APPS)
 	( cd ../artifacts; sha256sum netdata_ebpf-CO-RE-$(_LIBC).tar.xz > netdata_ebpf-CO-RE-$(_LIBC).tar.xz.sha256sum )
 
 clean:
-	cd ../libbpf/src/ && make clean && rm -rf build root
+	cd $(LIBBPF)/src/ && make clean
 	rm *.o $(OUTPUT)* libbpf.a includes/*


### PR DESCRIPTION
## Summary
There are a lot of untracked files in the `libbpf` directory after CO-RE programs are built. The PR fixes that.
We are also doing a minor cleanup for `make` and `make clean` for CO-RE.

## Test plan
1.
```
cd libbpf
git clean -dxf
cd ../co-re
make
cd ../libbpf
git status
```
There shouldn't be any untracked files.

2.
```
cd co-re
make
make clean
```
You shouldn't see any errors and the output of `git clean -dxf` should be clean.