### PR TITLE
Fix bash script for Ubuntu 20.04 and typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ KERNEL_DIR = kernel/
 KERNEL_PROGRAM = $(KERNEL_DIR)process_kern.o
 
 KERNEL_VERSION="$(shell if [ -f /usr/src/linux/include/config/kernel.release ]; then cat /usr/src/linux/include/config/kernel.release; else cat /proc/sys/kernel/osrelease; fi)"
-FIRST_KERNEL_VERSION=$(shell sh tools/complement.sh "$(KERNEL_VERSION)")
+FIRST_KERNEL_VERSION=$(shell tools/complement.sh "$(KERNEL_VERSION)")
 
 NETDATA_KERNEL_VERSION=$(shell echo $(KERNEL_VERSION) | tr -s "." "_")
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ packages:
 
 #### Initializing Submodules
 
-`libbpf` directory is included as an git submodule and it is necessary to fetch contents with the git command below;
+`libbpf` directory is included as a git submodule and it is necessary to fetch contents with the git command below:
 ```bash
 cd libbpf
 git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ packages:
 - LLVM/Clang; this is because GCC prior to 10.0 cannot compile eBPF code.
 - Kernel headers
 
+#### Initializing Submodules
+
+`libbpf` directory is included as an git submodule and it is necessary to fetch contents with the git command below;
+```bash
+cd libbpf
+git submodule update --init --recursive
+```
 #### Generating Headers
 
 Kernel headers can be extracted directly from the kernel source doing the
@@ -82,12 +89,12 @@ the Linux Kernel.
 The build environments are:
 
 - `musl`  => `Dockerfile.musl` (_based on Alpine 3.11_)
-- `glibc` => `Dockerfile.glibc` (_based on Ubuntu 20.04_)
+- `glibc` => `Dockerfile.glibc.generic` (_based on Ubuntu 20.04_)
 
 ### glibc
 
 ```sh
-$ docker build -f Dockerfile.glibc -t kernel-collector:glibc ./
+$ docker build -f Dockerfile.glibc.generic -t kernel-collector:glibc ./
 $ docker run --rm -v $PWD:/kernel-collector kernel-collector:glibc
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ packages:
 
 `libbpf` directory is included as a git submodule and it is necessary to fetch contents with the git command below:
 ```bash
-cd libbpf
 git submodule update --init --recursive
 ```
 #### Generating Headers

--- a/kernel-patches/README.md
+++ b/kernel-patches/README.md
@@ -7,4 +7,4 @@ patches on these kernels in order to use them.
 The structure of our Dockerfile forces us to have a directory for every kernel
 that we are compiling for, even if a patch is not needed. If you'd like to add
 a new kernel version, please make the directory here as well and insert an
-empty `.gitclean` file.
+empty `.gitkeep` file.


### PR DESCRIPTION
##### Summary

- Fix of bash script for Ubuntu 20.04 support
- Fix of minor typos
- Added submodule initializing section into README.md

##### Test Plan

- Regular compiling process
- Reading README.md in the root and kernel-patches folder


