### PR TITLE
MD and File Descriptor (CO-RE)

### DIFF
--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -18,6 +18,7 @@ _LIBC ?= glibc
 
 APPS = cachestat \
        dc \
+       fd \
        filesystem \
        mdflush \
        mount \

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -19,6 +19,7 @@ _LIBC ?= glibc
 APPS = cachestat \
        dc \
        filesystem \
+       mdflush \
        mount \
        process \
        shm \

--- a/co-re/fd.bpf.c
+++ b/co-re/fd.bpf.c
@@ -1,0 +1,215 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_fd.h"
+
+/************************************************************************************
+ *     
+ *                                 MAPS
+ *     
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct netdata_fd_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_fd_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_FD_COUNTER);
+} tbl_fd_global SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
+} fd_ctrl SEC(".maps");
+
+/************************************************************************************
+ *
+ *                           COMMON SECTION(kprobe)
+ *
+ ***********************************************************************************/
+
+static inline int netdata_are_apps_enabled()
+{
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&fd_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    return 1;
+}
+
+static inline int netdata_apps_do_sys_openat2(int ret)
+{
+    struct netdata_fd_stat_t *fill;
+    struct netdata_fd_stat_t data = { };
+
+    if (!netdata_are_apps_enabled())
+        return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_fd_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->open_call, 1) ;
+        if (ret < 0) 
+            libnetdata_update_u32(&fill->open_err, 1) ;
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+        if (ret < 0)
+            data.open_err = 1;
+
+    }
+
+    data.open_call = 1;
+
+    bpf_map_update_elem(&tbl_fd_pid, &key, &data, BPF_ANY);
+
+    return 0;
+}
+
+static inline void netdata_sys_open_global(int ret)
+{
+    if (ret < 0)
+        libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_ERROR_DO_SYS_OPEN, 1);
+
+    libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_CALLS_DO_SYS_OPEN, 1);
+}
+
+static inline int netdata_apps_close_fd(int ret)
+{
+    struct netdata_fd_stat_t data = { };
+    struct netdata_fd_stat_t *fill;
+
+    if (!netdata_are_apps_enabled())
+        return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_fd_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->close_call, 1) ;
+
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+        data.close_call = 1;
+        if (ret < 0)
+            data.close_err = 1;
+
+        bpf_map_update_elem(&tbl_fd_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static inline void netdata_close_global(int ret)
+{
+    if (ret < 0)
+        libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_ERROR_CLOSE_FD, 1);
+
+    libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_CALLS_CLOSE_FD, 1);
+}
+
+/************************************************************************************
+ *
+ *                           FD SECTION(kprobe)
+ *
+ ***********************************************************************************/
+
+SEC("kretprobe/do_sys_openat2")
+int BPF_KRETPROBE(netdata_sys_open_kretprobe)
+{
+    int ret = (ssize_t)PT_REGS_RC(ctx);
+    netdata_sys_open_global(ret);
+
+    return netdata_apps_do_sys_openat2(ret);
+}
+
+SEC("kprobe/do_sys_openat2")
+int BPF_KPROBE(netdata_sys_open_kprobe)
+{
+    netdata_sys_open_global(0);
+
+    return netdata_apps_do_sys_openat2(0);
+}
+
+SEC("kretprobe/close_fd")
+int BPF_KRETPROBE(netdata_close_fd_kretprobe)
+{
+    int ret = (ssize_t)PT_REGS_RC(ctx);
+    netdata_close_global(ret);
+
+    return netdata_apps_close_fd(ret);
+}
+
+SEC("kprobe/close_fd")
+int BPF_KPROBE(netdata_close_fd_kprobe)
+{
+    netdata_close_global(0);
+
+    return netdata_apps_close_fd(0);
+}
+
+SEC("kretprobe/__close_fd")
+int BPF_KRETPROBE(netdata___close_fd_kretprobe)
+{
+    int ret = (ssize_t)PT_REGS_RC(ctx);
+    netdata_close_global(ret);
+
+    return netdata_apps_close_fd(ret);
+}
+
+SEC("kprobe/__close_fd")
+int BPF_KPROBE(netdata___close_fd_kprobe)
+{
+    netdata_close_global(0);
+
+    return netdata_apps_close_fd(0);
+}
+
+/************************************************************************************
+ *
+ *                           FD SECTION(trampoline)
+ *
+ ***********************************************************************************/
+
+SEC("fentry/do_sys_openat2")
+int BPF_KPROBE(netdata_sys_open_fentry)
+{
+    netdata_sys_open_global(0);
+
+    return netdata_apps_do_sys_openat2(0);
+}
+
+SEC("fexit/do_close")
+int BPF_KPROBE(netdata_do_close_fentry)
+{
+    netdata_close_global(0);
+
+    return netdata_apps_close_fd(0);
+}
+
+SEC("fexit/__do_close")
+int BPF_KPROBE(netdata___do_close_fentry)
+{
+    netdata_close_global(0);
+
+    return netdata_apps_close_fd(0);
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/co-re/fd.c
+++ b/co-re/fd.c
@@ -1,0 +1,246 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#include <linux/version.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "netdata_tests.h"
+#include "netdata_fd.h"
+
+#include "fd.skel.h"
+
+char *function_list[] = { "do_sys_openat2",
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+                          "close_fd" 
+#else
+                          "__close_fd" 
+#endif
+                        };
+
+static inline void ebpf_disable_probes(struct fd_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_sys_open_kprobe, false);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_kprobe, false);
+#else
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_kprobe, false);
+#endif
+}
+
+static inline void ebpf_disable_specific_probes(struct fd_bpf *obj)
+{
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
+#else
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_kprobe, false);
+#endif
+}
+
+static inline void ebpf_disable_trampoline(struct fd_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_sys_open_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_do_close_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata___do_close_fentry, false);
+}
+
+static inline void ebpf_disable_specific_trampoline(struct fd_bpf *obj)
+{
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+    bpf_program__set_autoload(obj->progs.netdata___do_close_fentry, false);
+#else
+    bpf_program__set_autoload(obj->progs.netdata_do_close_fentry, false);
+#endif
+}
+
+static void ebpf_set_trampoline_target(struct fd_bpf *obj)
+{
+    bpf_program__set_attach_target(obj->progs.netdata_sys_open_fentry, 0,
+                                   function_list[NETDATA_FD_OPEN]);
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+    bpf_program__set_attach_target(obj->progs.netdata_do_close_fentry, 0,
+                                   function_list[NETDATA_FD_CLOSE]);
+#else
+    bpf_program__set_attach_target(obj->progs.netdata___do_close_fentry, 0,
+                                   function_list[NETDATA_FD_CLOSE]);
+#endif
+}
+
+static inline int ebpf_load_and_attach(struct fd_bpf *obj, int selector)
+{
+    if (!selector) { // trampoline
+        ebpf_disable_probes(obj);
+        ebpf_disable_specific_trampoline(obj);
+
+        ebpf_set_trampoline_target(obj);
+    } else if (selector == NETDATA_MODE_PROBE) {  // kprobe
+        ebpf_disable_trampoline(obj);
+
+        ebpf_disable_specific_probes(obj);
+    }
+
+    int ret = fd_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    ret = fd_bpf__attach(obj);
+
+    if (!ret) {
+        fprintf(stdout, "File descriptor loaded with success\n");
+    }
+
+    return ret;
+}
+
+static int fd_read_apps_array(int fd, int ebpf_nprocs, uint32_t my_pid)
+{
+    struct netdata_fd_stat_t *stored = calloc((size_t)ebpf_nprocs, sizeof(struct netdata_fd_stat_t));
+    if (!stored)
+        return 2;
+
+    uint64_t counter = 0;
+    if (!bpf_map_lookup_elem(fd, &my_pid, stored)) {
+        int j;
+        for (j = 0; j < ebpf_nprocs; j++) {
+            counter += (stored[j].open_call + stored[j].close_call +
+                        stored[j].open_err + stored[j].close_err);
+        }
+    }
+
+    free(stored);
+
+    if (counter) {
+        fprintf(stdout, "Apps data stored with success\n");
+        return 0;
+    }
+
+    return 2;
+}
+
+static pid_t ebpf_update_tables(int global, int apps)
+{
+    pid_t pid = ebpf_fill_global(global);
+
+    struct netdata_fd_stat_t stats = { .open_call = 1, .close_call = 1,
+                                       .open_err = 1, .close_err = 1};
+
+    uint32_t idx = (uint32_t)pid;
+    int ret = bpf_map_update_elem(apps, &idx, &stats, 0);
+    if (ret)
+        fprintf(stderr, "Cannot insert value to apps table.");
+
+    return pid;
+}
+
+static int ebpf_fd_tests(int selector)
+{
+    struct fd_bpf *obj = NULL;
+    int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
+
+    obj = fd_bpf__open();
+    if (!obj) {
+        fprintf(stderr, "Cannot open or load BPF object\n");
+
+        return 2;
+    }
+
+    int ret = ebpf_load_and_attach(obj, selector);
+    if (!ret) {
+        int fd = bpf_map__fd(obj->maps.fd_ctrl);
+        update_controller_table(fd);
+
+        fd = bpf_map__fd(obj->maps.tbl_fd_global);
+        int fd2 = bpf_map__fd(obj->maps.tbl_fd_pid);
+        pid_t my_pid = ebpf_update_tables(fd, fd2);
+
+        ret =  ebpf_read_global_array(fd, ebpf_nprocs, 1);
+        if (!ret) {
+            ret = fd_read_apps_array(fd2, ebpf_nprocs, (uint32_t)my_pid);
+            if (ret)
+                fprintf(stderr, "Cannot read apps table\n");
+        } else
+            fprintf(stderr, "Cannot read global table\n");
+    } else
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
+
+    fd_bpf__destroy(obj);
+
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"tracepoint",  no_argument,    0,  'r' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = NETDATA_MODE_TRAMPOLINE;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "file_descriptor", 1);
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = NETDATA_MODE_PROBE;
+                          break;
+                      }
+            case 'r': {
+                          selector = NETDATA_MODE_PROBE;
+                          fprintf(stdout, "This specific software does not have tracepoint, using kprobe instead\n");
+                          break;
+                      }
+            case 't': {
+                          selector = NETDATA_MODE_TRAMPOLINE;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+
+    struct btf *bf = NULL;
+    if (!selector) {
+        bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);
+        if (bf) {
+            selector = ebpf_find_functions(bf, selector, function_list, NETDATA_FD_ACTIONS);
+            btf__free(bf);
+        }
+    }
+
+    return ebpf_fd_tests(selector);
+}
+

--- a/co-re/mdflush.bpf.c
+++ b/co-re/mdflush.bpf.c
@@ -1,0 +1,96 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_mdflush.h"
+
+// Copied from https://elixir.bootlin.com/linux/v5.16-rc2/source/include/uapi/linux/major.h
+// that has the same value of https://elixir.bootlin.com/linux/v4.14/source/include/uapi/linux/major.h#L25
+#define NETDATA_MD_MAJOR 9
+
+
+// Preprocessors copied from https://elixir.bootlin.com/linux/v4.14/source/include/linux/kdev_t.h#L10
+// they are the same in https://elixir.bootlin.com/linux/v5.16-rc2/source/include/linux/kdev_t.h
+#define NETDATA_MINORBITS	20
+#define NETDATA_MINORMASK	((1U << NETDATA_MINORBITS) - 1)
+
+#define NETDATA_MAJOR(dev)	((unsigned int) ((dev) >> NETDATA_MINORBITS))
+#define NETDATA_MINOR(dev)	((unsigned int) ((dev) & NETDATA_MINORMASK))
+
+// Preprocessor copied from https://elixir.bootlin.com/linux/v5.16-rc2/source/include/uapi/linux/raid/md_u.h#L69
+// Like the previous value is not changing between versions
+/* 63 partitions with the alternate major number (mdp) */
+#define Netdata_MdpMinorShift 6
+
+/************************************************************************************
+ *
+ *                                 MAPS
+ *
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __type(key, mdflush_key_t);
+    __type(value, mdflush_val_t);
+    __uint(max_entries, 1024);
+} tbl_mdflush SEC(".maps");
+
+/************************************************************************************
+ *
+ *                              COMMON SECTION
+ *
+ ***********************************************************************************/
+
+static int netdata_md_common(struct mddev *mddev)
+{
+    mdflush_key_t key = 0;
+    mdflush_val_t *valp, val;
+
+    // get correct key.
+    // this essentially does the logic here:
+    // https://elixir.bootlin.com/linux/v4.14/source/drivers/md/md.c#L5256
+    bpf_probe_read(&key, sizeof(key), &mddev->unit);
+    int partitioned = (NETDATA_MAJOR(key) != NETDATA_MD_MAJOR);
+    int shift = partitioned ? Netdata_MdpMinorShift : 0;
+    key = NETDATA_MINOR(key) >> shift;
+
+    valp = bpf_map_lookup_elem(&tbl_mdflush, &key);
+    if (valp) {
+        *valp += 1;
+    } else {
+        val = 1;
+        bpf_map_update_elem(&tbl_mdflush, &key, &val, BPF_ANY);
+    }
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                           MDFLUSH SECTION(kprobe)
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/md_flush_request")
+int BPF_KPROBE(netdata_md_flush_request_kprobe)
+{
+    struct mddev *mddev = (struct mddev *)PT_REGS_PARM1(ctx);
+
+    return netdata_md_common(mddev);
+}
+
+/************************************************************************************
+ *
+ *                           MDFLUSH SECTION(trampoline)
+ *
+ ***********************************************************************************/
+
+SEC("fentry/md_flush_request")
+int BPF_PROG(netdata_md_flush_request_fentry, struct mddev *mddev)
+{
+    return netdata_md_common(mddev);
+}
+
+char _license[] SEC("license") = "GPL";
+

--- a/co-re/mdflush.c
+++ b/co-re/mdflush.c
@@ -1,0 +1,182 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "netdata_tests.h"
+
+#include "mdflush.skel.h"
+
+enum netdata_md_function_list {
+    NETDATA_MD_FLUSH_REQUEST,
+
+    // Always insert before this value 
+    NETDATA_MD_END
+};
+
+char *function_list[] = { "md_flush_request" };
+
+static inline void ebpf_disable_probes(struct mdflush_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_md_flush_request_kprobe, false);
+}
+
+static inline void ebpf_disable_trampoline(struct mdflush_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_md_flush_request_fentry, false);
+}
+
+static void ebpf_set_trampoline_target(struct mdflush_bpf *obj)
+{
+    bpf_program__set_attach_target(obj->progs.netdata_md_flush_request_fentry, 0,
+                                   function_list[NETDATA_MD_FLUSH_REQUEST]);
+}
+
+static int ebpf_load_probes(struct mdflush_bpf *obj)
+{
+    obj->links.netdata_md_flush_request_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_md_flush_request_kprobe,
+                                                                            false, function_list[NETDATA_MD_FLUSH_REQUEST]);
+    int ret = libbpf_get_error(obj->links.netdata_md_flush_request_kprobe);
+    if (ret)
+        return -1;
+
+    return 0;
+}
+
+static inline int ebpf_load_and_attach(struct mdflush_bpf *obj, int selector)
+{
+    if (!selector) { // trampoline
+        ebpf_disable_probes(obj);
+
+        ebpf_set_trampoline_target(obj);
+    } else if (selector == NETDATA_MODE_PROBE) {  // kprobe
+        ebpf_disable_trampoline(obj);
+    }
+
+    int ret = mdflush_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    if (!selector)
+        ret = mdflush_bpf__attach(obj);
+    else
+        ret = ebpf_load_probes(obj);
+
+    if (!ret) {
+        fprintf(stdout, "md_flush_request loaded with success\n");
+    }
+
+    return ret;
+}
+
+static void ebpf_update_tables(int global)
+{
+    (void)ebpf_fill_global(global);
+}
+
+static int ebpf_mdflush_tests(int selector)
+{
+    struct mdflush_bpf *obj = NULL;
+    int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
+
+    obj = mdflush_bpf__open();
+    if (!obj) {
+        fprintf(stderr, "Cannot open or load BPF object\n");
+
+        return 2;
+    }
+
+    int ret = ebpf_load_and_attach(obj, selector);
+    if (!ret) {
+        int fd = bpf_map__fd(obj->maps.tbl_mdflush);
+        ebpf_update_tables(fd);
+
+        ret =  ebpf_read_global_array(fd, ebpf_nprocs, 1);
+        if (ret) 
+            fprintf(stderr, "Cannot read global table\n");
+    } else
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
+
+    mdflush_bpf__destroy(obj);
+
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"tracepoint",  no_argument,    0,  'r' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = NETDATA_MODE_TRAMPOLINE;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "mdflush", 1);
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = NETDATA_MODE_PROBE;
+                          break;
+                      }
+            case 'r': {
+                          selector = NETDATA_MODE_PROBE;
+                          fprintf(stdout, "This specific software does not have tracepoint, using kprobe instead\n");
+                          break;
+                      }
+            case 't': {
+                          selector = NETDATA_MODE_TRAMPOLINE;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+
+    char *md_flush_request = netdata_update_name(function_list[NETDATA_MD_FLUSH_REQUEST]);
+    if (!md_flush_request) {
+        fprintf(stderr, "Module `md` is not loaded, so it is not possible to monitor calls for md_flush_request.\n");
+        return -1;
+    }
+    function_list[NETDATA_MD_FLUSH_REQUEST] = md_flush_request;
+
+    struct btf *bf = NULL;
+    if (!selector) {
+        bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);
+        if (bf) {
+            selector = ebpf_find_functions(bf, selector, function_list, NETDATA_MD_END);
+            btf__free(bf);
+        }
+    }
+
+    ret = ebpf_mdflush_tests(selector);
+
+    free(md_flush_request);
+
+    return ret;
+}
+

--- a/includes/netdata_fd.h
+++ b/includes/netdata_fd.h
@@ -27,5 +27,12 @@ enum fd_counters {
     NETDATA_FD_COUNTER
 };
 
+enum fd_actions {
+    NETDATA_FD_OPEN,
+    NETDATA_FD_CLOSE,
+
+    NETDATA_FD_ACTIONS
+};
+
 #endif /* _NETDATA_EBPF_FD_H_ */
 


### PR DESCRIPTION
##### Summary
This PR is converting more two legacy code to CO-RE.

##### Test Plan
1. Clone branch;
2. Go to `co-re` directory and run `make`;
3. Load `md` module or create MD array before to test `mdflush`.
4. Run the following tests: 

```sh
bash-5.1# ./tests/mdflush --probe
md_flush_request loaded with success
Global data stored with success
bash-5.1# ./tests/mdflush --tracepoint
This specific software does not have tracepoint, using kprobe instead
md_flush_request loaded with success
Global data stored with success
bash-5.1# ./tests/mdflush --trampoline
md_flush_request loaded with success
Global data stored with success

bash-5.1# ./tests/fd --probe
File descriptor loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/fd --trampoline
File descriptor loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/fd --tracepoint
This specific software does not have tracepoint, using kprobe instead
File descriptor loaded with success
Global data stored with success
Apps data stored with success
````

##### Additional information

This PR was tested on:

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.15.6  |
| Arch Linux        | 5.15.5  |
| CentOS 8.5.2111 | 4.18.0-348.2.1 |

On `Arch LInux` the module did not have BTF information, so for trampoline the message  `Cannot find function md_flush_request` was shown.