### PR TITLE
Update merged code

### DIFF
--- a/.dockerfiles/build_core.sh
+++ b/.dockerfiles/build_core.sh
@@ -6,7 +6,7 @@ build() {
   echo "[XXX]: Building against Kernel 5.15 for libc ${_LIBC} ..."
   (
     cd co-re
-    make
+    make CC=clang
   ) || return 1
 }
 

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -47,10 +47,10 @@ libbpf:
 $(patsubst %,%.o,$(APPS)): %.o: %.skel.h
 
 %.o: %.c 
-	$(CLANG) $(CFLAGS) -DMY_LINUX_VERSION_CODE=$(RUNNING_VERSION_CODE) $(INCLUDES) -c $(filter %.c,$^) -o $@
+	$(CC) $(CFLAGS) -DMY_LINUX_VERSION_CODE=$(RUNNING_VERSION_CODE) $(INCLUDES) -c $(filter %.c,$^) -o $@
 
 $(APPS): %: %.o 
-	$(CLANG) $(CFLAGS) -L. $^ -lelf -lz -lbpf -o $(OUTPUT)$@
+	$(CC) $(CFLAGS) -L. $^ -lelf -lz -lbpf -o $(OUTPUT)$@
 
 compress: $(APPS)
 	tar -cf ../artifacts/netdata_ebpf-CO-RE-$(_LIBC).tar includes/*

--- a/co-re/cachestat.c
+++ b/co-re/cachestat.c
@@ -186,7 +186,8 @@ static int ebpf_cachestat_tests(int selector)
                 fprintf(stderr, "Cannot read apps table\n");
         } else
             fprintf(stderr, "Cannot read global table\n");
-    }
+    } else
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
 
     cachestat_bpf__destroy(obj);
 

--- a/co-re/dc.c
+++ b/co-re/dc.c
@@ -19,17 +19,22 @@ char *function_list[] = { "lookup_fast",
 static inline void ebpf_disable_probes(struct dc_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_lookup_fast_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_d_lookup_kretprobe, false);
 }
 
 static inline void ebpf_disable_trampoline(struct dc_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_lookup_fast_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_d_lookup_fexit, false);
 }
 
 static void ebpf_set_trampoline_target(struct dc_bpf *obj)
 {
     bpf_program__set_attach_target(obj->progs.netdata_lookup_fast_fentry, 0,
                                    function_list[NETDATA_LOOKUP_FAST]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_d_lookup_fexit, 0,
+                                   function_list[NETDATA_D_LOOKUP]);
 }
 
 static int ebpf_attach_probes(struct dc_bpf *obj)
@@ -41,7 +46,7 @@ static int ebpf_attach_probes(struct dc_bpf *obj)
         return -1;
 
     obj->links.netdata_lookup_fast_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_lookup_fast_kprobe,
-                                                                       false, function_list[NETDATA_D_LOOKUP]);
+                                                                       false, function_list[NETDATA_LOOKUP_FAST]);
     ret = libbpf_get_error(obj->links.netdata_lookup_fast_kprobe);
     if (ret)
         return -1;
@@ -174,7 +179,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "swap", 1);
+                          ebpf_print_help(argv[0], "dc", 1);
                           exit(0);
                       }
             case 'p': {

--- a/co-re/fd.c
+++ b/co-re/fd.c
@@ -54,16 +54,21 @@ static inline void ebpf_disable_specific_probes(struct fd_bpf *obj)
 static inline void ebpf_disable_trampoline(struct fd_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_sys_open_fentry, false);
-    bpf_program__set_autoload(obj->progs.netdata_do_close_fentry, false);
-    bpf_program__set_autoload(obj->progs.netdata___do_close_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_sys_open_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_fexit, false);
 }
 
 static inline void ebpf_disable_specific_trampoline(struct fd_bpf *obj)
 {
 #if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-    bpf_program__set_autoload(obj->progs.netdata___do_close_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata___close_fd_fexit, false);
 #else
-    bpf_program__set_autoload(obj->progs.netdata_do_close_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_close_fd_fexit, false);
 #endif
 }
 
@@ -72,11 +77,18 @@ static void ebpf_set_trampoline_target(struct fd_bpf *obj)
     bpf_program__set_attach_target(obj->progs.netdata_sys_open_fentry, 0,
                                    function_list[NETDATA_FD_OPEN]);
 
+    bpf_program__set_attach_target(obj->progs.netdata_sys_open_fexit, 0,
+                                   function_list[NETDATA_FD_OPEN]);
+
 #if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-    bpf_program__set_attach_target(obj->progs.netdata_do_close_fentry, 0,
+    bpf_program__set_attach_target(obj->progs.netdata_close_fd_fentry, 0,
+                                   function_list[NETDATA_FD_CLOSE]);
+    bpf_program__set_attach_target(obj->progs.netdata_close_fd_fexit, 0,
                                    function_list[NETDATA_FD_CLOSE]);
 #else
-    bpf_program__set_attach_target(obj->progs.netdata___do_close_fentry, 0,
+    bpf_program__set_attach_target(obj->progs.netdata___close_fd_fentry, 0,
+                                   function_list[NETDATA_FD_CLOSE]);
+    bpf_program__set_attach_target(obj->progs.netdata___close_fd_fexit, 0,
                                    function_list[NETDATA_FD_CLOSE]);
 #endif
 }

--- a/co-re/mount.c
+++ b/co-re/mount.c
@@ -191,7 +191,8 @@ static int ebpf_mount_tests(int selector)
             int fd = bpf_map__fd(obj->maps.tbl_mount);
             ret = mount_read_array(fd);
         }
-    }
+    } else
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
 
     mount_bpf__destroy(obj);
 

--- a/co-re/process.c
+++ b/co-re/process.c
@@ -50,7 +50,7 @@ static void ebpf_set_trampoline_target(struct process_bpf *obj)
                                    "__x64_sys_clone3");
 }
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5,3,0))
+#if (MY_LINUX_VERSION_CODE <= KERNEL_VERSION(5,3,0))
 // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8f6ccf6159aed1f04c6d179f61f6fb2691261e84
 static inline void ebpf_disable_clone3(struct process_bpf *obj)
 {
@@ -70,7 +70,7 @@ static inline int ebpf_load_and_attach(struct process_bpf *obj, int selector)
         ebpf_disable_tracepoints(obj);
         ebpf_disable_trampoline(obj);
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5,9,16))
+#if (MY_LINUX_VERSION_CODE <= KERNEL_VERSION(5,9,16))
     bpf_program__set_autoload(obj->progs.netdata_kernel_clone_probe, false);
 #else
     bpf_program__set_autoload(obj->progs.netdata_do_fork_probe, false);
@@ -80,7 +80,7 @@ static inline int ebpf_load_and_attach(struct process_bpf *obj, int selector)
         ebpf_disable_trampoline(obj);
     }
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5,3,0))
+#if (MY_LINUX_VERSION_CODE <= KERNEL_VERSION(5,3,0))
     ebpf_disable_clone3(obj);
 #endif
 

--- a/co-re/shm.c
+++ b/co-re/shm.c
@@ -208,6 +208,7 @@ int ebpf_shm_tests(struct btf *bf, int selector)
     if (!ret) {
         int fd = bpf_map__fd(obj->maps.shm_ctrl);
         update_controller_table(fd);
+
         ret = call_syscalls();
         if (!ret) {
             fd = bpf_map__fd(obj->maps.tbl_shm);
@@ -217,7 +218,8 @@ int ebpf_shm_tests(struct btf *bf, int selector)
                 ret = shm_read_apps_array(fd, ebpf_nprocs);
             }
         }
-    }
+    } else
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
 
     shm_bpf__destroy(obj);
 

--- a/co-re/swap.c
+++ b/co-re/swap.c
@@ -149,8 +149,8 @@ int ebpf_load_swap(int selector)
                 fprintf(stderr, "Cannot read apps table\n");
         } else
             fprintf(stderr, "Cannot read global table\n");
-     } else 
-         fprintf(stderr, "Cannot read global table\n");
+    } else 
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
 
     swap_bpf__destroy(obj);
 

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -166,7 +166,7 @@ static int ebpf_fcnt_tests(int (*fcnt)(int), enum netdata_sync_enum idx, int sel
         int fd = bpf_map__fd(obj->maps.tbl_sync) ;
         ret = common_fcnt_tests(fd, fcnt);
     } else
-        fprintf(stderr, "Failed to attach BPF program\n");
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
 
     sync_bpf__destroy(obj);
 


### PR DESCRIPTION
##### Summary
This PR is bringing following updates for codes  already merged:

1. Common error message when it is not possible to load eBPF programs;
2. Use `MY_LINUX_VERSION_CODE` instead `LINUX_VERSION_CODE`;
3. To prepare the integration with `eBPF.plugin` in `netdata/netdata`, we are also allowing other compilers to be used for final compilation steps.
4. This PR also update codes for file descriptor and directory cache

##### Test Plan
1. Clone branch
2. Go to directory `co-re` and run `make CC=clang`
3. Run the following tests:

```sh
 bash-5.1# ./tests/dc --probe
Directory Cache loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/dc --trampoline
Directory Cache loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/dc --tracepoint
This specific software does not have tracepoint, using kprobe instead
Directory Cache loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/fd --probe
File descriptor loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/fd --trampoline
File descriptor loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/fd --tracepoint
This specific software does not have tracepoint, using kprobe instead
File descriptor loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/process --probe
Process loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/process --tracepoint
Process loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/process --trampoline
Process loaded with success
Global data stored with success
Apps data stored with success
```
4. Now recompile the branch using `gcc`: `make clean; make CC=gcc`
5. Repeat the tests

##### Additional information
This PR  was tested on:

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.15.7  |
| Arch Linux        | 5.15.7  |
| CentOS 8.5.2111 | 4.18.0-348.2.1 |

I also tested other software that were compiled with `GCC`, but considering that they do not have codes affected by this PR, I am not suggesting tests with them.