### PR TITLE
Use Rocky

### DIFF
--- a/Dockerfile.glibc.centos8
+++ b/Dockerfile.glibc.centos8
@@ -13,7 +13,7 @@ ENV _LIBC=glibc
 
 # hadolint ignore=DL3040,DL3041
 RUN dnf update -y && \
-    dnf groupinstall -y "Development tools" && \
+    dnf install -y gcc make gcc-c++ libtool rpm-build-libs && \
     dnf install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \
                    diffutils elfutils elfutils-devel \
                    elfutils-libelf-devel findutils gawk \

--- a/Dockerfile.glibc.centos8
+++ b/Dockerfile.glibc.centos8
@@ -1,15 +1,15 @@
-FROM centos:8.1.1911 AS build
+FROM rockylinux/rockylinux:8.5 AS build
 
 ARG ARCH=x86
 ENV ARCH=$ARCH
 
-ENV KERNEL_VERSION=4.18.0-147.5.1.el8_1
+ENV KERNEL_VERSION=4.18.0-348.2.1.el8_5
 
 ENV _LIBC=glibc
 
-RUN yum update -y && \
-    yum groupinstall -y "Development tools" && \
-    yum install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \
+RUN dnf update -y && \
+    dnf groupinstall -y "Development tools" && \
+    dnf install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \
                    bison diffutils elfutils elfutils-devel \
                    elfutils-libelf-devel findutils flex gawk gcc gettext \
                    gzip hmaccalc hostname java-devel m4 make \
@@ -20,7 +20,7 @@ RUN yum update -y && \
 
 RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS} && \
     echo '%_topdir %(echo $HOME)/rpmbuild' > ~/.rpmmacros && \
-    rpm -i http://vault.centos.org/8.1.1911/BaseOS/Source/SPackages/kernel-${KERNEL_VERSION}.src.rpm 2>&1 
+    rpm -i https://download.rockylinux.org/pub/rocky/8/BaseOS/source/tree/Packages/k/kernel-${KERNEL_VERSION}.src.rpm 2>&1 
 
 RUN cd ~/rpmbuild/SOURCES && \
     tar -xf linux-${KERNEL_VERSION}.tar.xz && \

--- a/Dockerfile.glibc.centos8
+++ b/Dockerfile.glibc.centos8
@@ -7,16 +7,20 @@ ENV KERNEL_VERSION=4.18.0-348.2.1.el8_5
 
 ENV _LIBC=glibc
 
+# We use "Development tools" to install:
+# gcc c/c++ compiler, redhat-rpm-config, strace, rpm-build, make, pkgconfig, gettext, automake, strace64, gdb, bison,
+# libtool, autoconf, gcc-c++ compiler, binutils and all dependencies
+
 # hadolint ignore=DL3040,DL3041
 RUN dnf update -y && \
     dnf groupinstall -y "Development tools" && \
     dnf install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \
-                   bison diffutils elfutils elfutils-devel \
-                   elfutils-libelf-devel findutils flex gawk gcc gettext \
-                   gzip hmaccalc hostname java-devel m4 make \
+                   diffutils elfutils elfutils-devel \
+                   elfutils-libelf-devel findutils gawk \
+                   gzip hmaccalc hostname java-devel m4 \
                    module-init-tools ncurses-devel net-tools newt-devel \
                    numactl-devel openssl openssl-devel patch pciutils-devel \
-                   perl perl-ExtUtils-Embed pesign redhat-rpm-config \
+                   perl perl-ExtUtils-Embed pesign \
                    rpm-build sh-utils tar xmlto xz zlib-devel clang llvm
 
 RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS} && \

--- a/Dockerfile.glibc.centos8
+++ b/Dockerfile.glibc.centos8
@@ -13,7 +13,7 @@ ENV _LIBC=glibc
 
 # hadolint ignore=DL3040,DL3041
 RUN dnf update -y && \
-    dnf install -y gcc make gcc-c++ libtool rpm-build-libs automake autoconf && \
+    dnf install -y gcc make gcc-c++ libtool rpm-build-libs bison && \
     dnf install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \
                    diffutils elfutils elfutils-devel \
                    elfutils-libelf-devel findutils gawk \

--- a/Dockerfile.glibc.centos8
+++ b/Dockerfile.glibc.centos8
@@ -13,7 +13,7 @@ ENV _LIBC=glibc
 
 # hadolint ignore=DL3040,DL3041
 RUN dnf update -y && \
-    dnf install -y gcc make gcc-c++ libtool rpm-build-libs && \
+    dnf install -y gcc make gcc-c++ libtool rpm-build-libs automake autoconf && \
     dnf install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \
                    diffutils elfutils elfutils-devel \
                    elfutils-libelf-devel findutils gawk \

--- a/Dockerfile.glibc.centos8
+++ b/Dockerfile.glibc.centos8
@@ -7,6 +7,7 @@ ENV KERNEL_VERSION=4.18.0-348.2.1.el8_5
 
 ENV _LIBC=glibc
 
+# hadolint ignore=DL3040,DL3041
 RUN dnf update -y && \
     dnf groupinstall -y "Development tools" && \
     dnf install -y asciidoc audit-libs-devel bash bc binutils binutils-devel \

--- a/Dockerfile.musl.centos8
+++ b/Dockerfile.musl.centos8
@@ -3,7 +3,7 @@ FROM alpine:3.15 AS build
 ARG ARCH=x86
 ENV ARCH=$ARCH
 
-ARG LOCAL_KERNEL_VERSION=4.18.0-147.5.1.el8_1
+ARG LOCAL_KERNEL_VERSION=4.18.0-348.2.1.el8_5
 
 ENV _LIBC=static
 
@@ -15,7 +15,7 @@ RUN apk add --no-cache -U build-base autoconf automake coreutils pkgconfig \
 # hadolint ignore=DL3003,SC3009
 RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS} && \
     echo "%_topdir %(echo $HOME)/rpmbuild" > ~/.rpmmacros && \
-    wget -q https://vault.centos.org/8.1.1911/BaseOS/Source/SPackages/kernel-${LOCAL_KERNEL_VERSION}.src.rpm && \
+    wget -q https://download.rockylinux.org/pub/rocky/8/BaseOS/source/tree/Packages/k/kernel-${LOCAL_KERNEL_VERSION}.src.rpm && \
     rpm -i kernel-${LOCAL_KERNEL_VERSION}.src.rpm && \
     cd ~/rpmbuild/SOURCES && \
     tar -xf linux-${LOCAL_KERNEL_VERSION}.tar.xz && \

--- a/Dockerfile.static.centos8
+++ b/Dockerfile.static.centos8
@@ -3,7 +3,7 @@ FROM alpine:3.15 AS build
 ARG ARCH=x86
 ENV ARCH=$ARCH
 
-ARG LOCAL_KERNEL_VERSION=4.18.0-147.5.1.el8_1
+ARG LOCAL_KERNEL_VERSION=4.18.0-348.2.1.el8_5
 
 ENV _LIBC=static
 
@@ -15,7 +15,7 @@ RUN apk add --no-cache -U build-base autoconf automake coreutils pkgconfig \
 # hadolint ignore=DL3003,SC3009
 RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS} && \
     echo "%_topdir %(echo $HOME)/rpmbuild" > ~/.rpmmacros && \
-    wget -q https://vault.centos.org/8.1.1911/BaseOS/Source/SPackages/kernel-${LOCAL_KERNEL_VERSION}.src.rpm && \
+    wget -q https://download.rockylinux.org/pub/rocky/8/BaseOS/source/tree/Packages/k/kernel-${LOCAL_KERNEL_VERSION}.src.rpm && \
     rpm -i kernel-${LOCAL_KERNEL_VERSION}.src.rpm && \
     cd ~/rpmbuild/SOURCES && \
     tar -xf linux-${LOCAL_KERNEL_VERSION}.tar.xz && \


### PR DESCRIPTION
##### Summary
Considering deadline for CentOS 8.x, this PR is changing the docker image to use Rocky Linux 8.5.

##### Test Plan
1. Check whether nothing is missing inside Dockerfiles.

##### Additional information
The binaries were tested on `CentOS 8.5.2111` running kernel `4.18.0-348.2.1`
