### PR TITLE
VFS CO-RE

### DIFF
--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -31,6 +31,7 @@ APPS = cachestat \
        softirq \
        swap \
        sync \
+       vfs \
        #
 
 all: compress

--- a/co-re/vfs.bpf.c
+++ b/co-re/vfs.bpf.c
@@ -1,0 +1,707 @@
+#include "vmlinux.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+
+#include "netdata_core.h"
+#include "netdata_vfs.h"
+
+/************************************************************************************
+ *     
+ *                                 MAPS
+ *     
+ ***********************************************************************************/
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct netdata_vfs_stat_t);
+    __uint(max_entries, PID_MAX_DEFAULT);
+} tbl_vfs_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, NETDATA_VFS_COUNTER);
+} tbl_vfs_stats  SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, NETDATA_CONTROLLER_END);
+} vfs_ctrl SEC(".maps");
+
+/************************************************************************************
+ *     
+ *                               VFS Common
+ *     
+ ***********************************************************************************/
+
+static __always_inline int netdata_common_vfs_write(__u64 tot, ssize_t ret)
+{
+    struct netdata_vfs_stat_t *fill;
+    struct netdata_vfs_stat_t data = { };
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITE, 1);
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->write_call, 1) ;
+
+        if (ret < 0)
+            libnetdata_update_u32(&fill->write_err, 1) ;
+        else
+            libnetdata_update_u64(&fill->write_bytes, tot);
+
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0)
+            data.write_err = 1;
+        else
+            data.write_bytes = tot;
+
+        data.write_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_writev(__u64 tot, ssize_t ret)
+{
+    struct netdata_vfs_stat_t *fill;
+    struct netdata_vfs_stat_t data = { };
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITEV, 1);
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
+
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->writev_call, 1) ;
+
+        if (ret < 0) {
+            libnetdata_update_u32(&fill->writev_err, 1) ;
+        } else {
+            libnetdata_update_u64(&fill->writev_bytes, tot);
+        }
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0) {
+            data.writev_err = 1;
+        } else {
+            data.writev_bytes = (unsigned long)tot;
+        }
+        data.writev_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_read(__u64 tot, ssize_t ret)
+{
+    struct netdata_vfs_stat_t *fill;
+    struct netdata_vfs_stat_t data = { };
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_READ, 1);
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
+
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->read_call, 1) ;
+
+        if (ret < 0) {
+            libnetdata_update_u32(&fill->read_err, 1) ;
+        } else {
+            libnetdata_update_u64(&fill->read_bytes, tot);
+        }
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0) {
+            data.read_err = 1;
+        } else {
+            data.read_bytes = (unsigned long)tot;
+        }
+        data.read_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_readv(__u64 tot, ssize_t ret)
+{
+    struct netdata_vfs_stat_t *fill;
+    struct netdata_vfs_stat_t data = { };
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_READV, 1);
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
+
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->readv_call, 1) ;
+
+        if (ret < 0) {
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
+            libnetdata_update_u32(&fill->readv_err, 1) ;
+        } else {
+            libnetdata_update_u64(&fill->readv_bytes, tot);
+        }
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0) {
+            data.readv_err = 1;
+        } else {
+            data.readv_bytes = (unsigned long)tot;
+        }
+        data.readv_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_unlink(int ret)
+{
+    struct netdata_vfs_stat_t data = { };
+    struct netdata_vfs_stat_t *fill;
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_UNLINK, 1);
+
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->unlink_call, 1) ;
+
+        if (ret < 0)
+            libnetdata_update_u32(&fill->unlink_err, 1) ;
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0)
+            data.unlink_err = 1;
+        else 
+            data.unlink_err = 0;
+        data.unlink_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_fsync(int ret)
+{
+    struct netdata_vfs_stat_t data = { };
+    struct netdata_vfs_stat_t *fill;
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_FSYNC, 1);
+
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->fsync_call, 1) ;
+
+        if (ret < 0) {
+            libnetdata_update_u32(&fill->fsync_err, 1) ;
+        } 
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0) {
+            data.fsync_err = 1;
+        } else {
+            data.fsync_err = 0;
+        }
+        data.fsync_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_open(int ret)
+{
+    struct netdata_vfs_stat_t data = { };
+    struct netdata_vfs_stat_t *fill;
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_OPEN, 1);
+    
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->open_call, 1) ;
+
+        if (ret < 0) {
+            libnetdata_update_u32(&fill->open_err, 1) ;
+        } 
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0) {
+            data.open_err = 1;
+        } else {
+            data.open_err = 0;
+        }
+        data.open_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+static __always_inline int netdata_common_vfs_create(int ret)
+{
+    struct netdata_vfs_stat_t data = { };
+    struct netdata_vfs_stat_t *fill;
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_CREATE, 1);
+
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps)
+        if (*apps == 0)
+            return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    key = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    if (fill) {
+        libnetdata_update_u32(&fill->create_call, 1) ;
+
+        if (ret < 0) {
+            libnetdata_update_u32(&fill->create_err, 1) ;
+        } 
+    } else {
+        data.pid_tgid = pid_tgid;  
+        data.pid = tgid;  
+
+        if (ret < 0) {
+            data.create_err = 1;
+        } else {
+            data.create_err = 0;
+        }
+        data.create_call = 1;
+
+        bpf_map_update_elem(&tbl_vfs_pid, &key, &data, BPF_ANY);
+    }
+
+    return 0;
+}
+
+/************************************************************************************
+ *     
+ *                            VFS Section (kprobe)
+ *     
+ ***********************************************************************************/
+
+SEC("kprobe/vfs_write")
+int BPF_KPROBE(netdata_vfs_write_kprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    return netdata_common_vfs_write(tot, 0);
+}
+
+SEC("kretprobe/vfs_write")
+int BPF_KRETPROBE(netdata_vfs_write_kretprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    ret = (ssize_t)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
+
+    return netdata_common_vfs_write(tot, ret);
+}
+
+SEC("kprobe/vfs_writev")
+int BPF_KPROBE(netdata_vfs_writev_kprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    return netdata_common_vfs_writev(tot, 0);
+}
+
+SEC("kretprobe/vfs_writev")
+int BPF_KRETPROBE(netdata_vfs_writev_kretprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    ret = (ssize_t)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
+
+    return netdata_common_vfs_writev(tot, ret);
+}
+
+SEC("kprobe/vfs_read")
+int BPF_KPROBE(netdata_vfs_read_kprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    return netdata_common_vfs_read(tot, 0);
+}
+
+SEC("kretprobe/vfs_read")
+int BPF_KRETPROBE(netdata_vfs_read_kretprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    ret = (ssize_t)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
+
+    return netdata_common_vfs_read(tot, ret);
+}
+
+SEC("kprobe/vfs_readv")
+int BPF_KPROBE(netdata_vfs_readv_kprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    return netdata_common_vfs_readv(tot, 0);
+}
+
+SEC("kretprobe/vfs_readv")
+int BPF_KRETPROBE(netdata_vfs_readv_kretprobe)
+{
+    ssize_t ret = (ssize_t)PT_REGS_PARM3(ctx);
+    __u64 tot = libnetdata_log2l(ret);
+
+    ret = (ssize_t)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
+
+    return netdata_common_vfs_readv(tot, ret);
+}
+
+SEC("kprobe/vfs_unlink")
+int BPF_KPROBE(netdata_vfs_unlink_kprobe)
+{
+    return netdata_common_vfs_unlink(0);
+}
+
+SEC("kretprobe/vfs_unlink")
+int BPF_KRETPROBE(netdata_vfs_unlink_kretprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
+
+    return netdata_common_vfs_unlink(ret);
+}
+
+SEC("kprobe/vfs_fsync")
+int BPF_KPROBE(netdata_vfs_fsync_kprobe)
+{
+    return netdata_common_vfs_fsync(0);
+}
+
+SEC("kretprobe/vfs_fsync")
+int BPF_KRETPROBE(netdata_vfs_fsync_kretprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
+
+    return netdata_common_vfs_fsync(ret);
+}
+
+SEC("kprobe/vfs_open")
+int BPF_KPROBE(netdata_vfs_open_kprobe)
+{
+    return netdata_common_vfs_open(0);
+}
+
+SEC("kretprobe/vfs_open")
+int BPF_KRETPROBE(netdata_vfs_open_kretprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
+
+    return netdata_common_vfs_open(ret);
+}
+
+SEC("kprobe/vfs_create")
+int BPF_KPROBE(netdata_vfs_create_kprobe)
+{
+    return netdata_common_vfs_create(0);
+}
+
+SEC("kretprobe/vfs_create")
+int BPF_KRETPROBE(netdata_vfs_create_kretprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
+
+    return netdata_common_vfs_create(ret);
+}
+
+/************************************************************************************
+ *     
+ *                            VFS Section (trampoline)
+ *     
+ ***********************************************************************************/
+
+SEC("fentry/vfs_write")
+int BPF_PROG(netdata_vfs_write_fentry, struct file *file, const char *buf, size_t count, loff_t *pos)
+{
+    __u64 tot = libnetdata_log2l((ssize_t)count);
+
+    return netdata_common_vfs_write(tot, 0);
+}
+
+SEC("fexit/vfs_write")
+int BPF_PROG(netdata_vfs_write_fexit, struct file *file, const char *buf, size_t count, loff_t *pos, ssize_t ret)
+{
+    __u64 tot;
+    if (ret > 0)
+        tot = libnetdata_log2l(ret);
+    else
+        tot = 0;
+
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
+
+    return netdata_common_vfs_write(tot, ret);
+}
+
+SEC("fentry/vfs_writev")
+int BPF_PROG(netdata_vfs_writev_fentry, struct file *file, const char *buf, size_t count, loff_t *pos)
+{
+    __u64 tot = libnetdata_log2l((ssize_t)count);
+
+    return netdata_common_vfs_writev(tot, 0);
+}
+
+SEC("fexit/vfs_writev")
+int BPF_PROG(netdata_vfs_writev_fexit, struct file *file, const char *buf, size_t count, loff_t *pos, ssize_t ret)
+{
+    __u64 tot;
+    if (ret > 0)
+        tot = libnetdata_log2l(ret);
+    else
+        tot = 0;
+
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
+
+
+    return netdata_common_vfs_writev(tot, ret);
+}
+
+SEC("fentry/vfs_read")
+int BPF_PROG(netdata_vfs_read_fentry, struct file *file, const char *buf, size_t count, loff_t *pos)
+{
+    __u64 tot = libnetdata_log2l((ssize_t)count);
+
+    return netdata_common_vfs_read(tot, 0);
+}
+
+SEC("fexit/vfs_read")
+int BPF_PROG(netdata_vfs_read_fexit, struct file *file, const char *buf, size_t count, loff_t *pos, ssize_t ret)
+{
+    __u64 tot;
+    if (ret > 0)
+        tot = libnetdata_log2l(ret);
+    else
+        tot = 0;
+
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
+
+
+    return netdata_common_vfs_read(tot, ret);
+}
+
+SEC("fentry/vfs_readv")
+int BPF_PROG(netdata_vfs_readv_fentry, struct file *file, const struct iovec *vec, unsigned long vlen, loff_t *pos, rwf_t flags)
+{
+    __u64 tot = libnetdata_log2l((ssize_t) vlen);
+
+    return netdata_common_vfs_readv(tot, 0);
+}
+
+SEC("fexit/vfs_readv")
+int BPF_PROG(netdata_vfs_readv_fexit, struct file *file, const struct iovec *vec, unsigned long vlen, loff_t *pos, rwf_t flags,
+             ssize_t ret)
+{
+    __u64 tot;
+    if (ret > 0)
+        tot = libnetdata_log2l(ret);
+    else
+        tot = 0;
+
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
+
+
+    return netdata_common_vfs_readv(tot, ret);
+}
+
+SEC("fentry/vfs_unlink")
+int BPF_PROG(netdata_vfs_unlink_fentry)
+{
+    return netdata_common_vfs_unlink(0);
+}
+
+/*
+SEC("fexit/vfs_unlink")
+// KERNEL NEWER THAN 5.11.22
+int BPF_PROG(netdata_vfs_unlink_fexit, struct user_namespace *mnt_userns, struct inode *dir, struct dentry *dentry,
+             struct inode **delegated_inode, int ret)
+// KERNEL OLDER THAN 5.12.0             
+int BPF_PROG(netdata_vfs_unlink_fexit,struct inode *dir, struct dentry *dentry, struct inode **delegated_inode, int ret)
+{
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
+
+    return netdata_common_vfs_unlink(ret);
+}
+*/
+
+SEC("fentry/vfs_fsync")
+int BPF_PROG(netdata_vfs_fsync_fentry)
+{
+    return netdata_common_vfs_fsync(0);
+}
+
+SEC("fexit/vfs_fsync")
+int BPF_PROG(netdata_vfs_fsync_fexit, struct file *file, int datasync, int ret)
+{
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
+
+    return netdata_common_vfs_fsync(ret);
+}
+
+SEC("fentry/vfs_open")
+int BPF_PROG(netdata_vfs_open_fentry)
+{
+    return netdata_common_vfs_open(0);
+}
+
+SEC("fexit/vfs_open")
+int BPF_PROG(netdata_vfs_open_fexit, const struct path *path, struct file *file, int ret)
+{
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
+
+    return netdata_common_vfs_open(ret);
+}
+
+SEC("fentry/vfs_create")
+int BPF_PROG(netdata_vfs_create_fentry)
+{
+    return netdata_common_vfs_create(0);
+}
+
+/*
+SEC("fexit/vfs_create")
+// KERNEL NEWER THAN 5.11.22
+int BPF_PROG(netdata_vfs_create_fexit, struct user_namespace *mnt_userns, struct inode *dir,
+             struct dentry *dentry, umode_t mode, bool want_excl, int ret)
+// KERNEL OLDER THAN 5.12.0             
+int BPF_PROG(netdata_vfs_create_fexit, struct inode *dir, struct dentry *dentry, umode_t mode,
+	     bool want_excl, int ret)
+{
+    if (ret < 0)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
+
+    return netdata_common_vfs_create(ret);
+}
+*/
+
+char _license[] SEC("license") = "GPL";
+

--- a/co-re/vfs.bpf.c
+++ b/co-re/vfs.bpf.c
@@ -401,8 +401,6 @@ int BPF_KRETPROBE(netdata_vfs_write_kretprobe)
     __u64 tot = libnetdata_log2l(ret);
 
     ret = (ssize_t)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
 
     return netdata_common_vfs_write(tot, ret);
 }
@@ -423,8 +421,6 @@ int BPF_KRETPROBE(netdata_vfs_writev_kretprobe)
     __u64 tot = libnetdata_log2l(ret);
 
     ret = (ssize_t)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
 
     return netdata_common_vfs_writev(tot, ret);
 }
@@ -445,8 +441,6 @@ int BPF_KRETPROBE(netdata_vfs_read_kretprobe)
     __u64 tot = libnetdata_log2l(ret);
 
     ret = (ssize_t)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
 
     return netdata_common_vfs_read(tot, ret);
 }
@@ -467,8 +461,6 @@ int BPF_KRETPROBE(netdata_vfs_readv_kretprobe)
     __u64 tot = libnetdata_log2l(ret);
 
     ret = (ssize_t)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
 
     return netdata_common_vfs_readv(tot, ret);
 }
@@ -483,8 +475,6 @@ SEC("kretprobe/vfs_unlink")
 int BPF_KRETPROBE(netdata_vfs_unlink_kretprobe)
 {
     int ret = (int)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
 
     return netdata_common_vfs_unlink(ret);
 }
@@ -499,8 +489,6 @@ SEC("kretprobe/vfs_fsync")
 int BPF_KRETPROBE(netdata_vfs_fsync_kretprobe)
 {
     int ret = (int)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
 
     return netdata_common_vfs_fsync(ret);
 }
@@ -515,8 +503,6 @@ SEC("kretprobe/vfs_open")
 int BPF_KRETPROBE(netdata_vfs_open_kretprobe)
 {
     int ret = (int)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
 
     return netdata_common_vfs_open(ret);
 }
@@ -531,8 +517,6 @@ SEC("kretprobe/vfs_create")
 int BPF_KRETPROBE(netdata_vfs_create_kretprobe)
 {
     int ret = (int)PT_REGS_RC(ctx);
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
 
     return netdata_common_vfs_create(ret);
 }
@@ -560,9 +544,6 @@ int BPF_PROG(netdata_vfs_write_fexit, struct file *file, const char *buf, size_t
     else
         tot = 0;
 
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
-
     return netdata_common_vfs_write(tot, ret);
 }
 
@@ -583,10 +564,6 @@ int BPF_PROG(netdata_vfs_writev_fexit, struct file *file, const char *buf, size_
     else
         tot = 0;
 
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
-
-
     return netdata_common_vfs_writev(tot, ret);
 }
 
@@ -606,10 +583,6 @@ int BPF_PROG(netdata_vfs_read_fexit, struct file *file, const char *buf, size_t 
         tot = libnetdata_log2l(ret);
     else
         tot = 0;
-
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
-
 
     return netdata_common_vfs_read(tot, ret);
 }
@@ -632,10 +605,6 @@ int BPF_PROG(netdata_vfs_readv_fexit, struct file *file, const struct iovec *vec
     else
         tot = 0;
 
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
-
-
     return netdata_common_vfs_readv(tot, ret);
 }
 
@@ -653,9 +622,6 @@ int BPF_PROG(netdata_vfs_unlink_fexit, struct user_namespace *mnt_userns, struct
 // KERNEL OLDER THAN 5.12.0             
 int BPF_PROG(netdata_vfs_unlink_fexit,struct inode *dir, struct dentry *dentry, struct inode **delegated_inode, int ret)
 {
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
-
     return netdata_common_vfs_unlink(ret);
 }
 */
@@ -669,9 +635,6 @@ int BPF_PROG(netdata_vfs_fsync_fentry)
 SEC("fexit/vfs_fsync")
 int BPF_PROG(netdata_vfs_fsync_fexit, struct file *file, int datasync, int ret)
 {
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
-
     return netdata_common_vfs_fsync(ret);
 }
 
@@ -684,9 +647,6 @@ int BPF_PROG(netdata_vfs_open_fentry)
 SEC("fexit/vfs_open")
 int BPF_PROG(netdata_vfs_open_fexit, const struct path *path, struct file *file, int ret)
 {
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
-
     return netdata_common_vfs_open(ret);
 }
 
@@ -705,9 +665,6 @@ int BPF_PROG(netdata_vfs_create_fexit, struct user_namespace *mnt_userns, struct
 int BPF_PROG(netdata_vfs_create_fexit, struct inode *dir, struct dentry *dentry, umode_t mode,
 	     bool want_excl, int ret)
 {
-    if (ret < 0)
-        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
-
     return netdata_common_vfs_create(ret);
 }
 */

--- a/co-re/vfs.bpf.c
+++ b/co-re/vfs.bpf.c
@@ -42,15 +42,16 @@ static __always_inline int netdata_common_vfs_write(__u64 tot, ssize_t ret)
 {
     struct netdata_vfs_stat_t *fill;
     struct netdata_vfs_stat_t data = { };
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITE, 1);
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
+
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps)
         if (*apps == 0)
             return 0;
-
-    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITE, 1);
-
-    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     key = (__u32)(pid_tgid >> 32);

--- a/co-re/vfs.bpf.c
+++ b/co-re/vfs.bpf.c
@@ -60,9 +60,10 @@ static __always_inline int netdata_common_vfs_write(__u64 tot, ssize_t ret)
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
-        if (ret < 0)
+        if (ret < 0) {
             libnetdata_update_u32(&fill->write_err, 1) ;
-        else
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
+        } else
             libnetdata_update_u64(&fill->write_bytes, tot);
 
     } else {
@@ -106,6 +107,7 @@ static __always_inline int netdata_common_vfs_writev(__u64 tot, ssize_t ret)
 
         if (ret < 0) {
             libnetdata_update_u32(&fill->writev_err, 1) ;
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
         } else {
             libnetdata_update_u64(&fill->writev_bytes, tot);
         }
@@ -149,6 +151,7 @@ static __always_inline int netdata_common_vfs_read(__u64 tot, ssize_t ret)
 
         if (ret < 0) {
             libnetdata_update_u32(&fill->read_err, 1) ;
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
         } else {
             libnetdata_update_u64(&fill->read_bytes, tot);
         }
@@ -233,8 +236,10 @@ static __always_inline int netdata_common_vfs_unlink(int ret)
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
-        if (ret < 0)
+        if (ret < 0) {
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
             libnetdata_update_u32(&fill->unlink_err, 1) ;
+        }
     } else {
         data.pid_tgid = pid_tgid;  
         data.pid = tgid;  
@@ -273,6 +278,7 @@ static __always_inline int netdata_common_vfs_fsync(int ret)
 
         if (ret < 0) {
             libnetdata_update_u32(&fill->fsync_err, 1) ;
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
         } 
     } else {
         data.pid_tgid = pid_tgid;  
@@ -313,6 +319,7 @@ static __always_inline int netdata_common_vfs_open(int ret)
 
         if (ret < 0) {
             libnetdata_update_u32(&fill->open_err, 1) ;
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
         } 
     } else {
         data.pid_tgid = pid_tgid;  
@@ -353,6 +360,7 @@ static __always_inline int netdata_common_vfs_create(int ret)
 
         if (ret < 0) {
             libnetdata_update_u32(&fill->create_err, 1) ;
+            libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
         } 
     } else {
         data.pid_tgid = pid_tgid;  

--- a/co-re/vfs.c
+++ b/co-re/vfs.c
@@ -1,0 +1,401 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#define __USE_GNU
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "netdata_tests.h"
+#include "netdata_vfs.h"
+
+#include "vfs.skel.h"
+
+char *function_list[] = { "vfs_write",
+                          "vfs_writev",
+                          "vfs_read", 
+                          "vfs_readv",
+                          "vfs_unlink",
+                          "vfs_fsync",
+                          "vfs_open",
+                          "vfs_create"
+};
+
+static inline void ebpf_disable_probes(struct vfs_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_vfs_write_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_write_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_writev_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_writev_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_read_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_read_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_readv_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_readv_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_unlink_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_unlink_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_fsync_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_fsync_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_open_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_open_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_create_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_create_kretprobe, false);
+}
+
+static inline void ebpf_disable_trampoline(struct vfs_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_vfs_write_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_write_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_writev_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_writev_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_read_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_read_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_readv_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_readv_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_unlink_fentry, false);
+//    bpf_program__set_autoload(obj->progs.netdata_vfs_unlink_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_fsync_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_fsync_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_open_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_open_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_vfs_create_fentry, false);
+//    bpf_program__set_autoload(obj->progs.netdata_vfs_create_fexit, false);
+}
+
+static void ebpf_set_trampoline_target(struct vfs_bpf *obj)
+{
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_write_fentry, 0,
+                                   function_list[NETDATA_VFS_WRITE]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_write_fexit, 0,
+                                   function_list[NETDATA_VFS_WRITE]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_writev_fentry, 0,
+                                   function_list[NETDATA_VFS_WRITEV]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_writev_fexit, 0,
+                                   function_list[NETDATA_VFS_WRITEV]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_read_fentry, 0,
+                                   function_list[NETDATA_VFS_READ]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_read_fexit, 0,
+                                   function_list[NETDATA_VFS_READ]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_readv_fentry, 0,
+                                   function_list[NETDATA_VFS_READV]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_readv_fexit, 0,
+                                   function_list[NETDATA_VFS_READV]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_unlink_fentry, 0,
+                                   function_list[NETDATA_VFS_UNLINK]);
+
+//    bpf_program__set_attach_target(obj->progs.netdata_vfs_unlink_fexit, 0,
+//                                   function_list[NETDATA_VFS_UNLINK]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_fsync_fentry, 0,
+                                   function_list[NETDATA_VFS_FSYNC]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_fsync_fexit, 0,
+                                   function_list[NETDATA_VFS_FSYNC]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_open_fentry, 0,
+                                   function_list[NETDATA_VFS_OPEN]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_open_fexit, 0,
+                                   function_list[NETDATA_VFS_OPEN]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_vfs_create_fentry, 0,
+                                   function_list[NETDATA_VFS_CREATE]);
+
+//    bpf_program__set_attach_target(obj->progs.netdata_vfs_create_fexit, 0,
+//                                   function_list[NETDATA_VFS_CREATE]);
+}
+
+#if (MY_LINUX_VERSION_CODE <= KERNEL_VERSION(5,6,0))
+static void ebpf_disable_specific_trampoline(struct vfs_bpf *obj)
+{
+//    bpf_program__set_autoload(obj->progs.netdata_vfs_unlink_fexit, false);
+//    bpf_program__set_autoload(obj->progs.netdata_vfs_create_fexit, false);
+}
+#endif
+
+static int ebpf_attach_probes(struct vfs_bpf *obj)
+{
+    obj->links.netdata_vfs_write_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_write_kprobe,
+                                                                     false, function_list[NETDATA_VFS_WRITE]);
+    int ret = libbpf_get_error(obj->links.netdata_vfs_write_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_write_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_write_kretprobe,
+                                                                        true, function_list[NETDATA_VFS_WRITE]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_write_kretprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_writev_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_writev_kprobe,
+                                                                      false, function_list[NETDATA_VFS_WRITEV]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_writev_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_writev_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_writev_kretprobe,
+                                                                         true, function_list[NETDATA_VFS_WRITEV]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_writev_kretprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_read_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_read_kprobe,
+                                                                    false, function_list[NETDATA_VFS_READ]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_read_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_read_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_read_kretprobe,
+                                                                       true, function_list[NETDATA_VFS_READ]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_read_kretprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_readv_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_readv_kprobe,
+                                                                     false, function_list[NETDATA_VFS_READV]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_readv_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_readv_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_readv_kretprobe,
+                                                                        true, function_list[NETDATA_VFS_READV]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_readv_kretprobe);
+    if (ret)
+        return -1;
+ 
+    obj->links.netdata_vfs_unlink_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_unlink_kprobe,
+                                                                      false, function_list[NETDATA_VFS_UNLINK]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_unlink_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_unlink_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_unlink_kretprobe,
+                                                                         true, function_list[NETDATA_VFS_UNLINK]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_unlink_kretprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_fsync_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_fsync_kprobe,
+                                                                     false, function_list[NETDATA_VFS_FSYNC]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_fsync_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_fsync_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_fsync_kretprobe,
+                                                                        true, function_list[NETDATA_VFS_FSYNC]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_fsync_kretprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_open_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_open_kprobe,
+                                                                    false, function_list[NETDATA_VFS_OPEN]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_open_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_open_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_open_kretprobe,
+                                                                       true, function_list[NETDATA_VFS_OPEN]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_open_kretprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_create_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_create_kprobe,
+                                                                      false, function_list[NETDATA_VFS_OPEN]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_create_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_vfs_create_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_create_kretprobe,
+                                                                         true, function_list[NETDATA_VFS_OPEN]);
+    ret = libbpf_get_error(obj->links.netdata_vfs_create_kretprobe);
+    if (ret)
+        return -1;
+ 
+    return 0;
+}
+
+static inline int ebpf_load_and_attach(struct vfs_bpf *obj, int selector)
+{
+    if (!selector) { // trampoline
+        ebpf_disable_probes(obj);
+#if (MY_LINUX_VERSION_CODE <= KERNEL_VERSION(5,6,0))
+        ebpf_disable_specific_trampoline(obj);
+#endif
+
+        ebpf_set_trampoline_target(obj);
+    } else if (selector == NETDATA_MODE_PROBE) {  // kprobe
+        ebpf_disable_trampoline(obj);
+    }
+
+    int ret = vfs_bpf__load(obj);
+    if (ret) {
+        fprintf(stderr, "failed to load BPF object: %d\n", ret);
+        return -1;
+    }
+
+    if (!selector) {
+        ret = vfs_bpf__attach(obj);
+    } else {
+        ret = ebpf_attach_probes(obj);
+    }
+    
+    if (!ret) {
+        fprintf(stdout, "VFS loaded with success\n");
+    }
+
+    return ret;
+}
+
+static int vfs_read_apps_array(int fd, int ebpf_nprocs, uint32_t my_pid)
+{
+    struct netdata_vfs_stat_t *stored = calloc((size_t)ebpf_nprocs, sizeof(struct netdata_vfs_stat_t));
+    if (!stored)
+        return 2;
+
+    uint64_t counter = 0;
+    if (!bpf_map_lookup_elem(fd, &my_pid, stored)) {
+        int j;
+        for (j = 0; j < ebpf_nprocs; j++) {
+            counter += (stored[j].pid_tgid + stored[j].pid + stored[j].write_call + stored[j].writev_call +
+                        stored[j].read_call + stored[j].readv_call + stored[j].unlink_call + stored[j].fsync_call +
+                        stored[j].open_call + stored[j].create_call + stored[j].write_bytes + stored[j].writev_bytes +
+                        stored[j].readv_bytes + stored[j].read_bytes + stored[j].write_err + stored[j].writev_err +
+                        stored[j].read_err + stored[j].readv_err + stored[j].unlink_err + stored[j].fsync_err +
+                        stored[j].fsync_err + stored[j].open_err + stored[j].create_err);
+        }
+    }
+
+    free(stored);
+
+    if (counter) {
+        fprintf(stdout, "Apps data stored with success\n");
+        return 0;
+    }
+
+    return 2;
+}
+
+static pid_t ebpf_update_tables(int global, int apps)
+{
+    pid_t pid = ebpf_fill_global(global);
+
+    struct netdata_vfs_stat_t stats = { .pid_tgid = (__u64)pid, .pid = pid, .pad = 0, .write_call = 1,
+                                        .writev_call = 1, .read_call = 1, .readv_call = 1, .unlink_call = 1,
+                                        .fsync_call = 1, .open_call = 1, .create_call = 1, .write_bytes = 1,
+                                        .writev_bytes = 1, .readv_bytes = 1, .read_bytes = 1, .write_err = 1,
+                                        .writev_err = 1, .read_err = 1, .readv_err = 1, .unlink_err = 1,
+                                        .fsync_err = 1, .open_err = 1, .create_err = 1 };
+
+    uint32_t idx = (uint32_t)pid;
+    int ret = bpf_map_update_elem(apps, &idx, &stats, 0);
+    if (ret)
+        fprintf(stderr, "Cannot insert value to apps table.");
+
+    return pid;
+}
+
+static int ebpf_vfs_tests(int selector)
+{
+    struct vfs_bpf *obj = NULL;
+    int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
+
+    obj = vfs_bpf__open();
+    if (!obj) {
+        fprintf(stderr, "Cannot open or load BPF object\n");
+
+        return 2;
+    }
+
+    int ret = ebpf_load_and_attach(obj, selector);
+    if (!ret) {
+        int fd = bpf_map__fd(obj->maps.vfs_ctrl);
+        update_controller_table(fd);
+
+        fd = bpf_map__fd(obj->maps.tbl_vfs_stats);
+        int fd2 = bpf_map__fd(obj->maps.tbl_vfs_pid);
+        pid_t my_pid = ebpf_update_tables(fd, fd2);
+
+        ret =  ebpf_read_global_array(fd, ebpf_nprocs, NETDATA_VFS_COUNTER);
+        if (!ret) {
+            ret = vfs_read_apps_array(fd2, ebpf_nprocs, (uint32_t)my_pid);
+            if (ret)
+                fprintf(stderr, "Cannot read apps table\n");
+        } else
+            fprintf(stderr, "Cannot read global table\n");
+    } else
+        fprintf(stderr ,"%s", NETDATA_CORE_DEFAULT_ERROR);
+
+    vfs_bpf__destroy(obj);
+
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    static struct option long_options[] = {
+        {"help",        no_argument,    0,  'h' },
+        {"probe",       no_argument,    0,  'p' },
+        {"tracepoint",  no_argument,    0,  'r' },
+        {"trampoline",  no_argument,    0,  't' },
+        {0, 0, 0, 0}
+    };
+
+    int selector = NETDATA_MODE_TRAMPOLINE;
+    int option_index = 0;
+    while (1) {
+        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'h': {
+                          ebpf_print_help(argv[0], "vfs", 1);
+                          exit(0);
+                      }
+            case 'p': {
+                          selector = NETDATA_MODE_PROBE;
+                          break;
+                      }
+            case 'r': {
+                          selector = NETDATA_MODE_PROBE;
+                          fprintf(stdout, "This specific software does not have tracepoint, using kprobe instead\n");
+                          break;
+                      }
+            case 't': {
+                          selector = NETDATA_MODE_TRAMPOLINE;
+                          break;
+                      }
+            default: {
+                         break;
+                     }
+        }
+    }
+
+    // Adjust memory
+    int ret = netdata_ebf_memlock_limit();
+    if (ret) {
+        fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
+        return 1;
+    }
+
+    struct btf *bf = NULL;
+    if (!selector) {
+        bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);
+        if (bf) {
+            selector = ebpf_find_functions(bf, selector, function_list, NETDATA_VFS_END_LIST);
+            btf__free(bf);
+        }
+    }
+
+    return ebpf_vfs_tests(selector);
+}
+

--- a/includes/netdata_vfs.h
+++ b/includes/netdata_vfs.h
@@ -68,5 +68,18 @@ enum vfs_counters {
     NETDATA_VFS_COUNTER
 };
 
+enum netdata_vfs_calls_name {
+    NETDATA_VFS_WRITE,
+    NETDATA_VFS_WRITEV,
+    NETDATA_VFS_READ,
+    NETDATA_VFS_READV,
+    NETDATA_VFS_UNLINK,
+    NETDATA_VFS_FSYNC,
+    NETDATA_VFS_OPEN,
+    NETDATA_VFS_CREATE,
+
+    NETDATA_VFS_END_LIST
+};
+
 #endif /* _NETDATA_VFS_H_ */
 


### PR DESCRIPTION
##### Summary
This PR is bringing `co-re` code for `socket` thread.

##### Test Plan
1. Clone this branch
2. Compile the `co-re` codes:

```sh
# cd co-re
# make
```

3. Run the following tests:

```sh
bash-5.1# ./tests/vfs --probe
VFS loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/vfs --trampoline
VFS loaded with success
Global data stored with success
Apps data stored with success
bash-5.1# ./tests/vfs --tracepoint
This specific software does not have tracepoint, using kprobe instead
VFS loaded with success
Global data stored with success
Apps data stored with success
```

##### Additional information

This PR was tested on:

| Linux Distribution | kernel version |
|-------------------|----------------|
| Slackware Current | 5.15.11  |
| Arch Linux        | 5.15.11  |
| Manjaro 21.1 | 5.10.84-1 |
| Rocky 8.5 | 4.18.0-348.7.1 |