### PR TITLE
Compatibility test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ co-re/tests/*
 kernel/legacy_test
 .local_libbpf/bpf
 .local_libbpf/pkgconfig
+!co-re/tests/*.sh
+

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -11,8 +11,8 @@ KERNEL_VERSION="$(shell cat /proc/sys/kernel/osrelease)"
 FIRST_KERNEL_VERSION=$(shell sh ../tools/complement.sh "$(KERNEL_VERSION)")
 VER_MAJOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f1)
 VER_MINOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f2)
-VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3)
-RUNNING_VERSION_CODE=$(shell echo $$(( $(VER_MAJOR) * 65536 + $(VER_MINOR) * 256 + $(VER_PATCH) )) )
+VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3 | cut -d\- -f1)
+RUNNING_VERSION_CODE=$(shell echo $$(( $(VER_MAJOR) * 65536 + $(VER_MINOR) * 256 + $(VER_MINOR))) )
 
 _LIBC ?= glibc
 

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -12,7 +12,7 @@ FIRST_KERNEL_VERSION=$(shell sh ../tools/complement.sh "$(KERNEL_VERSION)")
 VER_MAJOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f1)
 VER_MINOR=$(shell echo $(KERNEL_VERSION) | cut -d. -f2)
 VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3 | cut -d\- -f1)
-RUNNING_VERSION_CODE=$(shell echo $$(( $(VER_MAJOR) * 65536 + $(VER_MINOR) * 256 + $(VER_MINOR))) )
+RUNNING_VERSION_CODE=$(shell echo $$(( $(VER_MAJOR) * 65536 + $(VER_MINOR) * 256 + $(VER_PATCH))) )
 
 _LIBC ?= glibc
 

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -52,7 +52,7 @@ $(patsubst %,%.o,$(APPS)): %.o: %.skel.h
 	$(CC) $(CFLAGS) -DMY_LINUX_VERSION_CODE=$(RUNNING_VERSION_CODE) $(INCLUDES) -c $(filter %.c,$^) -o $@
 
 $(APPS): %: %.o 
-	$(CC) $(CFLAGS) -L../.local_libbpf $^ -lelf -lz -lbpf -o $(OUTPUT)$@
+	$(CC) $(CFLAGS) -L../.local_libbpf $^ -lbpf -lelf -lz -o $(OUTPUT)$@
 
 compress: $(APPS)
 	tar -cf ../artifacts/netdata_ebpf-CO-RE-$(_LIBC).tar includes/*

--- a/co-re/Makefile
+++ b/co-re/Makefile
@@ -64,4 +64,5 @@ clean:
 	rm -f ../artifacts/netdata_ebpf-CO-RE-*.tar.xz
 	rm -f ../artifacts/netdata_ebpf-CO-RE-*.tar.xz.sha256sum
 	cd $(LIBBPF)/src/ && make clean
-	rm -f *.o $(OUTPUT)* libbpf.a includes/*
+	cd $(OUTPUT) && find . -type f ! -name '*.sh' ! -name '.git*'  -delete
+	rm -f *.o includes/*

--- a/co-re/cachestat.c
+++ b/co-re/cachestat.c
@@ -242,6 +242,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     struct btf *bf = NULL;
     if (!selector) {
         bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);

--- a/co-re/dc.c
+++ b/co-re/dc.c
@@ -207,6 +207,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     char *lookup_fast = netdata_update_name(function_list[NETDATA_LOOKUP_FAST]);
     if (!lookup_fast) {
         return -1;

--- a/co-re/disk.c
+++ b/co-re/disk.c
@@ -126,6 +126,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     return ebpf_disk_tests();
 }
 

--- a/co-re/fd.c
+++ b/co-re/fd.c
@@ -291,6 +291,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
 #if (MY_LINUX_VERSION_CODE <= KERNEL_VERSION(5, 5, 19))
     function_list[NETDATA_FD_OPEN] = "do_sys_open";
 #endif

--- a/co-re/filesystem.c
+++ b/co-re/filesystem.c
@@ -358,6 +358,8 @@ int main(int argc, char **argv)
         return 2;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     if (!selector) {
         ret = ebpf_load_btf_file(fs);
         if (!ret) {

--- a/co-re/hardirq.c
+++ b/co-re/hardirq.c
@@ -135,6 +135,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     return ebpf_hardirq_tests();
 }
 

--- a/co-re/mdflush.c
+++ b/co-re/mdflush.c
@@ -157,6 +157,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     char *md_flush_request = netdata_update_name(function_list[NETDATA_MD_FLUSH_REQUEST]);
     if (!md_flush_request) {
         fprintf(stderr, "Module `md` is not loaded, so it is not possible to monitor calls for md_flush_request.\n");

--- a/co-re/mount.c
+++ b/co-re/mount.c
@@ -246,6 +246,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     struct btf *bf = NULL;
     if (!selector) {
         bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);

--- a/co-re/oomkill.c
+++ b/co-re/oomkill.c
@@ -120,6 +120,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     return ebpf_oomkill_tests();
 }
 

--- a/co-re/process.c
+++ b/co-re/process.c
@@ -238,6 +238,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     return ebpf_process_tests(selector);
 }
 

--- a/co-re/shm.c
+++ b/co-re/shm.c
@@ -273,6 +273,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
         return 1;
     }
+
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
     
     struct btf *bf = NULL;
     if (!selector) {

--- a/co-re/socket.c
+++ b/co-re/socket.c
@@ -400,6 +400,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     return ebpf_socket_tests(selector);
 }
 

--- a/co-re/softirq.c
+++ b/co-re/softirq.c
@@ -131,6 +131,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     return ebpf_softirq_tests();
 }
 

--- a/co-re/swap.c
+++ b/co-re/swap.c
@@ -205,6 +205,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     struct btf *bf = NULL;
     if (!selector) {
         bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);

--- a/co-re/sync.c
+++ b/co-re/sync.c
@@ -436,6 +436,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "Cannot increase memory: error = %d\n", ret);
         return 1;
     }
+
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
     
     struct btf *bf = NULL;
     if (!selector) {

--- a/co-re/tests/run_tests.sh
+++ b/co-re/tests/run_tests.sh
@@ -5,23 +5,38 @@ one_test=( "disk" "hardirq" "oomkill" "softirq" )
 
 echo "Running all tests with three options"
 for i in "${three_tests[@]}" ; do
-    echo "================  Running $i  ================" >> success.log
-    echo "---> Probe: " >> success.log
-    ./$i --probe >> success.log 2>> error.log
-    echo "---> Tracepoint: " >> success.log
-    ./$i --tracepoint >> success.log 2>> error.log
-    echo "---> Trampoline: " >> success.log
-    ./$i --trampoline >> success.log 2>> error.log
-    echo "  " >>  success.log
+    {
+        echo "================  Running $i  ================"
+        echo "---> Probe: "
+        "./$i" --probe
+        echo "---> Tracepoint: "
+        "./$i" --tracepoint
+        echo "---> Trampoline: "
+        "./$i" --trampoline
+        echo "  "
+    }  >> success.log 2>> error.log
+    #echo "================  Running $i  ================" >> success.log
+    #echo "---> Probe: " >> success.log
+    #"./$i" --probe >> success.log 2>> error.log
+    #echo "---> Tracepoint: " >> success.log
+    #"./$i" --tracepoint >> success.log 2>> error.log
+    #echo "---> Trampoline: " >> success.log
+    #"./$i" --trampoline >> success.log 2>> error.log
+    #echo "  " >>  success.log
 done
 
 echo "Running all tests with single option"
 for i in "${one_test[@]}" ; do
-    echo "================  Running $i  ================" >> success.log
-    ./$i >> success.log 2>> error.log
-    echo "  " >>  success.log
+    {
+        echo "================  Running $i  ================"
+        "./$i"
+        echo "  "
+    }
+    #echo "================  Running $i  ================" >> success.log
+    #"./$i" >> success.log 2>> error.log
+    #echo "  " >>  success.log
 done
 
 echo "We are not running filesystem or mdflush, because they can generate error, please run them."
 
-ls -lh *.log
+ls -lh error.log success.log

--- a/co-re/tests/run_tests.sh
+++ b/co-re/tests/run_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+three_tests=( "cachestat" "dc" "fd" "mount" "process" "shm" "socket" "swap" "sync" "vfs" )
+one_test=( "disk" "hardirq" "oomkill" "softirq" )
+
+echo "Running all tests with three options"
+for i in "${three_tests[@]}" ; do
+    echo "================  Running $i  ================" >> success.log
+    echo "---> Probe: " >> success.log
+    ./$i --probe >> success.log 2>> error.log
+    echo "---> Tracepoint: " >> success.log
+    ./$i --tracepoint >> success.log 2>> error.log
+    echo "---> Trampoline: " >> success.log
+    ./$i --trampoline >> success.log 2>> error.log
+    echo "  " >>  success.log
+done
+
+echo "Running all tests with single option"
+for i in "${one_test[@]}" ; do
+    echo "================  Running $i  ================" >> success.log
+    ./$i >> success.log 2>> error.log
+    echo "  " >>  success.log
+done
+
+echo "We are not running filesystem or mdflush, because they can generate error, please run them."
+
+ls -lh *.log

--- a/co-re/vfs.c
+++ b/co-re/vfs.c
@@ -387,6 +387,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
     struct btf *bf = NULL;
     if (!selector) {
         bf = netdata_parse_btf_file((const char *)NETDATA_BTF_FILE);


### PR DESCRIPTION
##### Summary
As  described in this [commit](https://lore.kernel.org/netdev/20210521234227.1286058-1-andrii@kernel.org/T/), when `libbpf 1.0` is  released, `libbpf` will work with `LIBBPF_STRICT_ALL`, we are adding a call for all functional testers that we have to be sure we are already prepared for changes that are coming. 

We are also adding a script that help us to test everything.
##### Test Plan

1. Clone branch
2. Go to `co-re` directory and compile: 
```sh
# cd co-re
# make clean; make
```
3. Enter to `tests` directory  inside `co-re` and run the script that we are adding with this PR.

```sh
# bash run_tests.sh
``` 

4. Test at least one `fiilesystem` running manually:

```sh
# ./filesystem --ext4
``` 

##### Additional information

Run the script [`tools/check-kernel-core.sh`](https://raw.githubusercontent.com/netdata/kernel-collector/master/tools/check-kernel-core.sh)

On kernel `5.16.x` this PR will have one failure, because we need to bring a bug fix for it, this will come next days.

| Distribution | Kernel version | Expected result | Standard Output | Standard Error | File System |Info |
|----------------|----------------------|----------------------|------------------------| ------------------- | --------------- | -------|
|Slackware current | 5.15.15 |  Error to find `sys_sync` | [success_slack.txt](https://github.com/netdata/kernel-collector/files/7919224/success_slack.txt) | [error_slack.txt](https://github.com/netdata/kernel-collector/files/7919228/error_slack.txt) | [slack_fs.txt](https://github.com/netdata/kernel-collector/files/7919230/slack_fs.txt) | Successful  result. |
| Arch Linux 2021.04 | 5.16.1-arch1 | Error to find `sys_sync` and `__set_page_dirty` |  [success_arch.txt](https://github.com/netdata/kernel-collector/files/7919238/success_arch.txt) | [error_arch.txt](https://github.com/netdata/kernel-collector/files/7919240/error_arch.txt) |  [arch_fs.txt](https://github.com/netdata/kernel-collector/files/7919241/arch_fs.txt) | Successful  result. |
| Arch Linux 2021.04 | 5.16.2-arch1 | Error to find `sys_sync` and `__set_page_dirty` | [arch_success.txt](https://github.com/netdata/kernel-collector/files/7928649/arch_success.txt) | [arch_error.txt](https://github.com/netdata/kernel-collector/files/7928651/arch_error.txt) |  [arch_fs.txt](https://github.com/netdata/kernel-collector/files/7928652/arch_fs.txt) |  Successful  result. |
| Ubuntu 21.04 | 5.11.0-49 | Error to find `sys_sync` | [success_ubuntu.txt](https://github.com/netdata/kernel-collector/files/7928659/success_ubuntu.txt) | [error_ubuntu.txt](https://github.com/netdata/kernel-collector/files/7928661/error_ubuntu.txt) |  [ubuntu_fs.txt](https://github.com/netdata/kernel-collector/files/7928662/ubuntu_fs.txt) | Successful result |
| Rocky 8.5 | 4.18.0-348.12.2.el8_5 | It is not expected any error. | [sucess_rocky.txt](https://github.com/netdata/kernel-collector/files/7919256/sucess_rocky.txt) | [error_rocky.txt](https://github.com/netdata/kernel-collector/files/7919260/error_rocky.txt) | [arch_fs.txt](https://github.com/netdata/kernel-collector/files/7919261/arch_fs.txt) | Successful  result. |



