### PR TITLE
Reduce binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ all: $(KERNEL_PROGRAM)
 	xz artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar
 	( cd artifacts; sha256sum netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar.xz > netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)-$(_LIBC).tar.xz.sha256sum )
 
+dev:
+	cd $(KERNEL_DIR) && $(MAKE) dev;
+
 $(KERNEL_PROGRAM):
 	cd $(KERNEL_DIR) && $(MAKE) all;
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -81,6 +81,8 @@ endif
 
 all: $(NETDATA_APPS)
 
+dev: ${NETDATA_ALL_APPS}
+
 libbpf:
 	cd $(LIBBPF)/src && $(MAKE) BUILD_STATIC_ONLY=1 DESTDIR=../../.local_libbpf INCLUDEDIR= LIBDIR= UAPIDIR= install \
 
@@ -113,6 +115,8 @@ libbpf:
 	/bin/bash rename_binaries.sh "$(VER_MAJOR)" "$(VER_MINOR)" "$@"
 
 $(NETDATA_APPS): %: %_kern.o
+
+${NETDATA_ALL_APPS}: %: %_kern.o
 
 tester: libbpf
 	$(CC) -I../.local_libbpf -I$(LIBBPF)/src -I$(LIBBPF)/include -I$(LIBBPF)/include/uapi -L../.local_libbpf -o legacy_test tester.c -lbpf -lz -lelf

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -71,7 +71,7 @@ else ifeq ($(shell test $(CURRENT_KERNEL) -ge 330496 ; echo $$?),0)
 NETDATA_APPS= fd \
 	      #
 # Kernel newer than 5.9.256  ( 330240 = 5 * 65536 + 10 * 256)
-else ifeq ($(shell test $(CURRENT_KERNEL) -ge 330496 ; echo $$?),0)
+else ifeq ($(shell test $(CURRENT_KERNEL) -ge 330240 ; echo $$?),0)
 NETDATA_APPS= btrfs \
 	      process \
 	      #

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -45,7 +45,7 @@ NETDATA_ALL_APPS= btrfs \
     		  fsync \
     		  hardirq \
     		  mdflush \
-		  mount \
+    		  mount \
     		  msync \
     		  nfs \
     		  oomkill \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -35,6 +35,20 @@ VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3)
 
 CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATCH) |bc)
 
+# Kernel newer than 5.14.256 ( 331520 = 5 * 65536 + 15 * 256)
+ifeq ($(shell test $(CURRENT_KERNEL) -ge 331520 ; echo $$?),0)
+NETDATA_APPS= cachestat \
+	      #
+# Kernel newer than 5.10.256 ( 330496 = 5 * 65536 + 11 * 256)
+else ifeq ($(shell test $(CURRENT_KERNEL) -ge 330496 ; echo $$?),0)
+NETDATA_APPS= fd \
+	      #
+# Kernel newer than 5.9.256  ( 330240 = 5 * 65536 + 10 * 256)
+else ifeq ($(shell test $(CURRENT_KERNEL) -ge 330496 ; echo $$?),0)
+NETDATA_APPS= btrfs \
+	      process \
+	      #
+else
 NETDATA_APPS= btrfs \
 	      cachestat \
 	      dc \
@@ -61,6 +75,7 @@ NETDATA_APPS= btrfs \
 	      xfs \
 	      zfs \
 	      #
+endif
 
 all: $(NETDATA_APPS)
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -35,6 +35,33 @@ VER_PATCH=$(shell echo $(KERNEL_VERSION) | cut -d. -f3)
 
 CURRENT_KERNEL=$(shell echo $(VER_MAJOR)\*65536 + $(VER_MINOR)\*256 + $(VER_PATCH) |bc)
 
+NETDATA_ALL_APPS= btrfs \
+    		  cachestat \
+    		  dc \
+    		  disk \
+    		  ext4 \
+    		  fd \
+    		  fdatasync \
+    		  fsync \
+    		  hardirq \
+    		  mdflush \
+		  mount \
+    		  msync \
+    		  nfs \
+    		  oomkill \
+    		  process \
+    		  shm \
+    		  socket \
+    		  softirq \
+    		  sync \
+    		  syncfs \
+    		  sync_file_range \
+    		  swap \
+    		  vfs \
+    		  xfs \
+    		  zfs \
+    		  #
+
 # Kernel newer than 5.14.256 ( 331520 = 5 * 65536 + 15 * 256)
 ifeq ($(shell test $(CURRENT_KERNEL) -ge 331520 ; echo $$?),0)
 NETDATA_APPS= cachestat \
@@ -49,32 +76,7 @@ NETDATA_APPS= btrfs \
 	      process \
 	      #
 else
-NETDATA_APPS= btrfs \
-	      cachestat \
-	      dc \
-	      disk \
-	      ext4 \
-	      fd \
-	      fdatasync \
-	      fsync \
-	      hardirq \
-	      mdflush \
-	      mount \
-	      msync \
-	      nfs \
-	      oomkill \
-	      process \
-	      shm \
-	      socket \
-	      softirq \
-	      sync \
-	      syncfs \
-	      sync_file_range \
-	      swap \
-	      vfs \
-	      xfs \
-	      zfs \
-	      #
+NETDATA_APPS= ${NETDATA_ALL_APPS}
 endif
 
 all: $(NETDATA_APPS)


### PR DESCRIPTION
##### Summary
This PR is adjusting our Makefiles to remove compilation of unnecessary binaries. Our users are already using Netdata without them. The steps to disable them were:

- Create PR #285 used to test the idea.
- Create PR https://github.com/netdata/netdata/pull/11992 that forced eBPF plugin to ignore these binaries.
- This PR that will remove them.
- A future PR that will be created after next code freeze ends, but this PR will be at `netdata/netdata`.

We are not removing the possibility to compile all binaries in more recent kernels, instead we are moving for another option called `dev`.

##### Test Plan
The next test describes what it was done to confirm that this PR  works:

1. Get all binaries compiled with a specific lib (I used GLIBC/GCC) from this [link](https://github.com/netdata/kernel-collector/actions/runs/1747858953) and save inside an unique directory.
2. Extract files using next commands:
```sh
$ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
$ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```
3. Check if the final result match next table with command:

```sh
$ for i in "3.10" "4.14" "4.16" "4.18" "5.4" "5.10" "5.11" "5.15" ; do TEST=`ls -l *$i.o| wc -l`; echo "$i   $TEST" ; done
``` 

Expected result:

| Kernel  | # Expected Binaries | # Compiled Binaries |  Status  |
|---------|-----------------------------------------------------|------| -----------|
| 3.10    |        50          |          50         | Success  |
| 4.14    |        50          |          50         | Success  |
| 4.16.18 |        50          |          50         | Success  |
| 4.18    |        50          |          50         | Success  |
| 5.4.85  |        50          |          50         | Success  |
| 5.10.3  |         4          |           4         | Success  |
| 5.11.2  |         2          |           2         | Success  |
| 5.15.4  |         2          |           2         | Success  |

##### Additional information

We are keeping all binaries for ancient kernels, because there were important commits when they were released that affects all binaries.
Red Hat family we are also keeping isolated to be sure we won't break plugin.