### PR TITLE
Fix cachestat on kernels 5.16 and newer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         kernel_version:
+          - '5.16.4'
           - '5.15.4'
           - '5.15.0'
           - '5.11.2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         kernel_version:
+          - '5.16.4'
           - '5.15.4'
           - '5.15.0'
           - '5.11.2'

--- a/co-re/cachestat.bpf.c
+++ b/co-re/cachestat.bpf.c
@@ -149,6 +149,14 @@ int BPF_KPROBE(netdata_mark_page_accessed_kprobe)
     return netdata_common_page_accessed();
 }
 
+// When kernel 5.16.0 was released the function __set_page_dirty became static
+// and a new function was created.
+SEC("kprobe/__folio_mark_dirty")
+int BPF_KPROBE(netdata_folio_mark_dirty_kprobe)
+{
+    return netdata_common_page_dirtied();
+}
+
 // When kernel 5.15.0 was released the function account_page_dirtied became static
 // https://elixir.bootlin.com/linux/v5.15/source/mm/page-writeback.c#L2441
 // as consequence of this, we are monitoring the function from caller.
@@ -192,6 +200,14 @@ SEC("fentry/mark_page_accessed")
 int BPF_PROG(netdata_mark_page_accessed_fentry)
 {
     return netdata_common_page_accessed();
+}
+
+// When kernel 5.16.0 was released the function __set_page_dirty became static
+// and a new function was created.
+SEC("fentry/__folio_mark_dirty")
+int BPF_PROG(netdata_folio_mark_dirty_fentry)
+{
+    return netdata_common_page_dirtied();
 }
 
 // When kernel 5.15.0 was released the function account_page_dirtied became static

--- a/co-re/cachestat.c
+++ b/co-re/cachestat.c
@@ -19,7 +19,9 @@
 
 char *syscalls[] = { "add_to_page_cache_lru",
                      "mark_page_accessed",
-#if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+#if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
+                     "__folio_mark_dirty",
+#elif (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
                      "__set_page_dirty",
 #else
                      "account_page_dirtied",
@@ -31,6 +33,7 @@ static inline void netdata_ebpf_disable_probe(struct cachestat_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_add_to_page_cache_lru_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_page_accessed_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_folio_mark_dirty_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_buffer_dirty_kprobe, false);
@@ -38,9 +41,14 @@ static inline void netdata_ebpf_disable_probe(struct cachestat_bpf *obj)
 
 static inline void netdata_ebpf_disable_specific_probe(struct cachestat_bpf *obj)
 {
-#if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+#if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
+    bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_kprobe, false);
+#elif (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+    bpf_program__set_autoload(obj->progs.netdata_folio_mark_dirty_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_kprobe, false);
 #else
+    bpf_program__set_autoload(obj->progs.netdata_folio_mark_dirty_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_kprobe, false);
 #endif
 }
@@ -49,6 +57,7 @@ static inline void netdata_ebpf_disable_trampoline(struct cachestat_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_add_to_page_cache_lru_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_page_accessed_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_folio_mark_dirty_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_buffer_dirty_fentry, false);
@@ -56,9 +65,14 @@ static inline void netdata_ebpf_disable_trampoline(struct cachestat_bpf *obj)
 
 static inline void netdata_ebpf_disable_specific_trampoline(struct cachestat_bpf *obj)
 {
-#if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+#if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
+    bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_fentry, false);
+#elif (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+    bpf_program__set_autoload(obj->progs.netdata_folio_mark_dirty_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_fentry, false);
 #else
+    bpf_program__set_autoload(obj->progs.netdata_folio_mark_dirty_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_fentry, false);
 #endif
 }
@@ -71,7 +85,10 @@ static inline void netdata_set_trampoline_target(struct cachestat_bpf *obj)
     bpf_program__set_attach_target(obj->progs.netdata_mark_page_accessed_fentry, 0,
                                    syscalls[NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED]);
 
-#if (MY_LINUX_VERSION_CODE > KERNEL_VERSION(5,15,0))
+#if (MY_LINUX_VERSION_CODE > KERNEL_VERSION(5,16,0))
+    bpf_program__set_attach_target(obj->progs.netdata_folio_mark_dirty_fentry, 0,
+                                   syscalls[NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED]);
+#elif (MY_LINUX_VERSION_CODE > KERNEL_VERSION(5,15,0))
     bpf_program__set_attach_target(obj->progs.netdata_set_page_dirty_fentry, 0,
                                    syscalls[NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED]);
 #else

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -67,7 +67,7 @@ ifeq ($(shell test $(CURRENT_KERNEL) -ge 331776 ; echo $$?),0)
 NETDATA_APPS= cachestat \
 	      #
 # Kernel newer than 5.14.256 ( 331520 = 5 * 65536 + 15 * 256)
-ifeq ($(shell test $(CURRENT_KERNEL) -ge 331520 ; echo $$?),0)
+else ifeq ($(shell test $(CURRENT_KERNEL) -ge 331520 ; echo $$?),0)
 NETDATA_APPS= cachestat \
 	      #
 # Kernel newer than 5.10.256 ( 330496 = 5 * 65536 + 11 * 256)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -62,6 +62,10 @@ NETDATA_ALL_APPS= btrfs \
     		  zfs \
     		  #
 
+# Kernel newer than 5.15.256 ( 331776 = 5 * 65536 + 16 * 256)
+ifeq ($(shell test $(CURRENT_KERNEL) -ge 331776 ; echo $$?),0)
+NETDATA_APPS= cachestat \
+	      #
 # Kernel newer than 5.14.256 ( 331520 = 5 * 65536 + 15 * 256)
 ifeq ($(shell test $(CURRENT_KERNEL) -ge 331520 ; echo $$?),0)
 NETDATA_APPS= cachestat \

--- a/kernel/rename_binaries.sh
+++ b/kernel/rename_binaries.sh
@@ -16,6 +16,7 @@ parse_kernel_version() {
 select_kernel_version() {
     KVER=$(parse_kernel_version "${1}" "${2}")
 
+    VER5_16_0="005016"
     VER5_15_0="005015"
     VER5_11_0="005011"
     VER5_10_0="005010"
@@ -29,6 +30,8 @@ select_kernel_version() {
         KSELECTED="3.10";
     elif [ "${KVER}" -eq "${VER4_18_0}" ]; then
         KSELECTED="4.18";
+    elif [ "${KVER}" -ge "${VER5_16_0}" ]; then
+        KSELECTED="5.16";
     elif [ "${KVER}" -ge "${VER5_15_0}" ]; then
         KSELECTED="5.15";
     elif [ "${KVER}" -ge "${VER5_11_0}" ]; then

--- a/kernel/tester.c
+++ b/kernel/tester.c
@@ -29,7 +29,7 @@ static ebpf_specify_name_t dc_optional_name[] = { {.program_name = "netdata_look
 ebpf_module_t ebpf_modules[] = {
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_10,
       .flags = NETDATA_FLAG_BTRFS, .name = "btrfs", .update_names = NULL, .ctrl_table = NULL },
-    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_15,
+    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_15 | NETDATA_V5_16,
       .flags = NETDATA_FLAG_CACHESTAT, .name = "cachestat", .update_names = NULL, .ctrl_table = "cstat_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4,
       .flags = NETDATA_FLAG_DC, .name = "dc", .update_names = dc_optional_name, .ctrl_table = "dcstat_ctrl" },

--- a/kernel/tester.h
+++ b/kernel/tester.h
@@ -43,7 +43,8 @@ enum netdata_ebpf_kernel_versions {
     NETDATA_EBPF_KERNEL_5_0  = 327680,  //  327680 = 5 * 65536 +  0 * 256
     NETDATA_EBPF_KERNEL_5_10 = 330240,  //  330240 = 5 * 65536 + 10 * 256
     NETDATA_EBPF_KERNEL_5_11 = 330496,  //  330240 = 5 * 65536 + 11 * 256
-    NETDATA_EBPF_KERNEL_5_15 = 331520   //  331520 = 5 * 65536 + 15 * 256
+    NETDATA_EBPF_KERNEL_5_15 = 331520,  //  331520 = 5 * 65536 + 15 * 256
+    NETDATA_EBPF_KERNEL_5_16 = 331776   //  331776 = 5 * 65536 + 16 * 256
 };
 
 /**
@@ -60,7 +61,8 @@ enum netdata_kernel_flag {
     NETDATA_V5_4  = 1 << 4,
     NETDATA_V5_10 = 1 << 5,
     NETDATA_V5_11 = 1 << 6,
-    NETDATA_V5_15 = 1 << 7
+    NETDATA_V5_15 = 1 << 7,
+    NETDATA_V5_16 = 1 << 8
 };
 
 enum netdata_kernel_counter {
@@ -72,6 +74,7 @@ enum netdata_kernel_counter {
     NETDATA_5_10,
     NETDATA_5_11,
     NETDATA_5_15,
+    NETDATA_5_16,
 
     NETDATA_VERSION_END
 };


### PR DESCRIPTION
##### Summary
When kernel `5.16` was released, kernel team changed again the function used to mark a page cache as `dirty`. This generates the following error fixed with this PR: 

```conf
libbpf: kprobe perf_event_open() failed: No such file or directory
libbpf: prog 'netdata_set_page_dirty': failed to create kprobe '__set_page_dirty+0x0' perf event: No such file or directory
```
##### Test Plan
1. Clone this branch.
2. Access this [link](https://github.com/netdata/kernel-collector/actions/runs/1781430831) and get a file named artifacts-5.16.4-LIBC, where LIBC is the lib you have on your computer.  **This step is necessary only for hosts running kernel 5.16.x.**
3. Compile the legacy tester:

```sh
# make clean; make tester
``` 

4. Run the following tests and verify that output is `Success`:

```sh
# ./kernel/legacy_test --load-binary ../artifacts/rnetdata_ebpf_cachestat.5.16.o --log-path return.txt
# ./kernel/legacy_test --load-binary ../artifacts/pnetdata_ebpf_cachestat.5.16.o --log-path entry_arch.txt
```

5. Go to `co-re` directory and compile the binaries:
```sh
# make clean; make
```
6. Run `cachestat` tester on host:

```sh
bash-5.1# ./tests/cachestat --probe >> core_attach.txt
bash-5.1# ./tests/cachestat --trampoline >> core_attach.txt
bash-5.1# ./tests/cachestat --tracepoint >> core_attach.txt
```
7. Repeat steps `4`, `5` and `6` on hosts with different kernel version using binaries present at `/usr/libexec/netdata/plugins.d/ebpf.d/`.
8. We should not have any error independent of the kernel you are testing.

##### Additional information

This PR was tested on the following distributions with the respective results:

| Linux Distribution | kernel version | Legacy Files | Legacy Result (entry) | Legacy Result (return) | CO-RE result |
|--------------------|----------------|--------------|------------------------|-----------------------|--------------|
| Arch Linux         | 5.16.4-arch    | Github       | [entry_arch.txt](https://github.com/netdata/kernel-collector/files/7983184/entry_arch.txt)  | [return_arch.txt](https://github.com/netdata/kernel-collector/files/7983185/return_arch.txt)  |  [core_arch.txt](https://github.com/netdata/kernel-collector/files/7983186/core_arch.txt) |
| Slackware Current  | 5.15.16        | /usr/libexec/netdata/plugins.d/ebpf.d/ | [entry_slackware.txt](https://github.com/netdata/kernel-collector/files/7983195/entry_slackware.txt)  | [return_slackware.txt](https://github.com/netdata/kernel-collector/files/7983194/return_slackware.txt)  | [core_slackware.txt](https://github.com/netdata/kernel-collector/files/7983196/core_slackware.txt)  |
| Ubuntu 21.04 | 5.11.0-49 | /usr/libexec/netdata/plugins.d/ebpf.d/ | [entry_ubuntu.txt](https://github.com/netdata/kernel-collector/files/7983202/entry_ubuntu.txt) | [return_ubuntu.txt](https://github.com/netdata/kernel-collector/files/7983203/return_ubuntu.txt)  | [core_ubuntu.txt](https://github.com/netdata/kernel-collector/files/7983204/core_ubuntu.txt) |
| Rocky 8.5          | 4.18.0-348.12.2.el8_5 | /usr/libexec/netdata/plugins.d/ebpf.d/ |  [entry_rocky.txt](https://github.com/netdata/kernel-collector/files/7983206/entry_rocky.txt)  |  [return_rocky.txt](https://github.com/netdata/kernel-collector/files/7983207/return_rocky.txt)  |  [core_rocky.txt](https://github.com/netdata/kernel-collector/files/7983208/core_rocky.txt) |