### PR TITLE
Reorganize socket

### DIFF
--- a/co-re/socket.bpf.c
+++ b/co-re/socket.bpf.c
@@ -104,7 +104,7 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
     return family;
 }
 
-static __always_inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u16 retransmitted)
+static __always_inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u32 retransmitted)
 {
     ptr->ct = bpf_ktime_get_ns();
 
@@ -118,8 +118,7 @@ static __always_inline void update_socket_stats(netdata_socket_t *ptr, __u64 sen
         libnetdata_update_u64(&ptr->recv_bytes, received);
     }
 
-    // 16 bit cannot be used with __sync_fetch_and_add
-    ptr->retransmit += retransmitted;
+    libnetdata_update_u32(&ptr->ptr->retransmit, retransmitted);
 }
 
 // Use __always_inline instead inline to keep compatiblity with old kernels
@@ -357,6 +356,7 @@ static inline int netdata_common_tcp_close(struct inet_sock *is)
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_TCP_CLOSE, 1);
 
     update_pid_cleanup();
+
     family =  set_idx_value(&idx, is);
     if (!family)
         return 0;

--- a/co-re/socket.bpf.c
+++ b/co-re/socket.bpf.c
@@ -118,7 +118,7 @@ static __always_inline void update_socket_stats(netdata_socket_t *ptr, __u64 sen
         libnetdata_update_u64(&ptr->recv_bytes, received);
     }
 
-    libnetdata_update_u32(&ptr->ptr->retransmit, retransmitted);
+    libnetdata_update_u32(&ptr->retransmit, retransmitted);
 }
 
 // Use __always_inline instead inline to keep compatiblity with old kernels
@@ -352,6 +352,7 @@ static inline int netdata_common_tcp_close(struct inet_sock *is)
     netdata_socket_t *val;
     __u16 family;
     netdata_socket_idx_t idx = { };
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
 
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_TCP_CLOSE, 1);
 

--- a/co-re/socket.bpf.c
+++ b/co-re/socket.bpf.c
@@ -163,7 +163,7 @@ static __always_inline void update_socket_table(struct inet_sock *is,
     }
 }
 
-static __always_inline void update_pid_stats(__u64 sent, __u64 received, __u8 protocol)
+static __always_inline void update_pid_bandwidth(__u64 sent, __u64 received, __u8 protocol)
 {
     netdata_bandwidth_t *b;
     netdata_bandwidth_t data = { };
@@ -226,7 +226,7 @@ static __always_inline void update_pid_table(__u64 sent, __u64 received, __u8 pr
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
         if (*apps == 1)
-            update_pid_stats((__u64)sent, received, protocol);
+            update_pid_bandwidth((__u64)sent, received, protocol);
 }
 
 static __always_inline int common_tcp_send_message(struct inet_sock *is, size_t sent, int ret)

--- a/co-re/socket.bpf.c
+++ b/co-re/socket.bpf.c
@@ -355,7 +355,10 @@ static inline int netdata_common_tcp_close(struct inet_sock *is)
 
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_TCP_CLOSE, 1);
 
-    update_pid_cleanup();
+    __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
+    if (apps)
+        if (*apps == 1)
+            update_pid_cleanup();
 
     family =  set_idx_value(&idx, is);
     if (!family)

--- a/co-re/socket.c
+++ b/co-re/socket.c
@@ -324,7 +324,7 @@ int ebpf_socket_tests(int selector)
 
         netdata_socket_idx_t common_idx = { .saddr.addr64 = { 1, 1 }, .sport = 1, .daddr.addr64 = {1 , 1}, .dport = 1 };
         netdata_socket_t values = { .recv_packets = 1, .sent_packets = 1, .recv_bytes = 1, .sent_bytes = 1,
-                                    .first = 123456789, .ct = 123456790, .retransmit = 1, .protocol = 6, .removeme = 0,
+                                    .first = 123456789, .ct = 123456790, .retransmit = 1, .protocol = 6,
                                     .reserved = 1 }; 
         pid_t my_pid = ebpf_update_tables(obj, &common_idx, &values);
 

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -37,6 +37,7 @@ typedef struct netdata_bandwidth {
     __u64 retransmit;
     __u64 call_udp_sent;
     __u64 call_udp_received;
+    __u64 close;
 } netdata_bandwidth_t;
 
 // Index used together previous structure

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -20,10 +20,9 @@ typedef struct netdata_socket {
     __u64 sent_bytes;
     __u64 first; //First timestamp
     __u64 ct;   //Current timestamp
-    __u16 retransmit; //It is never used with UDP
-    __u8 protocol;
-    __u8 removeme;
-    __u32 reserved;
+    __u32 retransmit; //It is never used with UDP
+    __u16 protocol;
+    __u16 reserved;
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -266,9 +266,9 @@ static inline void update_socket_table(struct pt_regs* ctx,
 }
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))
-static __always_inline void update_pid_stats(__u64 sent, __u64 received, __u8 protocol)
+static __always_inline void update_pid_bandwidth(__u64 sent, __u64 received, __u8 protocol)
 #else
-static inline void update_pid_stats(__u64 sent, __u64 received, __u8 protocol)
+static inline void update_pid_bandwidth(__u64 sent, __u64 received, __u8 protocol)
 #endif
 {
     netdata_bandwidth_t *b;
@@ -385,7 +385,7 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
         if (*apps == 1)
-            update_pid_stats((__u64)sent, 0, IPPROTO_TCP);
+            update_pid_bandwidth((__u64)sent, 0, IPPROTO_TCP);
 
     return 0;
 }
@@ -401,7 +401,7 @@ int netdata_tcp_retransmit_skb(struct pt_regs* ctx)
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
         if (*apps == 1)
-            update_pid_stats(0, 0, IPPROTO_TCP);
+            update_pid_bandwidth(0, 0, IPPROTO_TCP);
 
     return 0;
 }
@@ -428,7 +428,7 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
         if (*apps == 1)
-            update_pid_stats(0, received, IPPROTO_TCP);
+            update_pid_bandwidth(0, received, IPPROTO_TCP);
 
     return 0;
 }
@@ -500,7 +500,7 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
         if (*apps == 1)
-            update_pid_stats(0, received, IPPROTO_UDP);
+            update_pid_bandwidth(0, received, IPPROTO_UDP);
 
     return 0;
 }
@@ -540,7 +540,7 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
         if (*apps == 1)
-            update_pid_stats((__u64) sent, 0, IPPROTO_UDP);
+            update_pid_bandwidth((__u64) sent, 0, IPPROTO_UDP);
 
     return 0;
 }

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -251,8 +251,6 @@ static inline void update_socket_table(struct pt_regs* ctx,
     val = (netdata_socket_t *) bpf_map_lookup_elem(tbl, &idx);
     if (val) {
         update_socket_stats(val, sent, received, retransmitted);
-        if (protocol == IPPROTO_UDP)
-            bpf_map_delete_elem(tbl, &idx);
     } else {
         data.first = bpf_ktime_get_ns();
         data.protocol = protocol;
@@ -260,6 +258,10 @@ static inline void update_socket_table(struct pt_regs* ctx,
 
         bpf_map_update_elem(tbl, &idx, &data, BPF_ANY);
     }
+
+    // TO-DO: When Network Viewer is available, we cannot discard UDP like this.
+    if (protocol == IPPROTO_UDP)
+        bpf_map_delete_elem(tbl, &idx);
 }
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -211,9 +211,7 @@ static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 
         libnetdata_update_u64(&ptr->recv_bytes, received);
     }
 
-    // We can use update_u64, it was overwritten
-    // the values
-    ptr->retransmit += retransmitted;
+    libnetdata_update_u32(&ptr->retransmit, retransmitted);
 }
 
 // Use __always_inline instead inline to keep compatiblity with old kernels

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -350,9 +350,9 @@ static inline void update_pid_bandwidth(__u64 sent, __u64 received, __u8 protoco
 }
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))
-static __always_inline void update_pid_cleanup(__u64 close)
+static __always_inline void update_pid_cleanup()
 #else
-static inline void update_pid_cleanup(__u64 close)
+static inline void update_pid_cleanup()
 #endif
 {
     netdata_bandwidth_t *b;
@@ -497,7 +497,7 @@ int netdata_tcp_close(struct pt_regs* ctx)
 
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_TCP_CLOSE, 1);
 
-    update_pid_cleanup(1);
+    update_pid_cleanup();
 
     family =  set_idx_value(&idx, is);
     if (!family)

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -224,14 +224,14 @@ static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 
 static __always_inline  void update_socket_table(struct pt_regs* ctx,
                                                 __u64 sent,
                                                 __u64 received,
-                                                __u16 retransmitted,
-                                                __u8 protocol)
+                                                __u32 retransmitted,
+                                                __u16 protocol)
 #else
 static inline void update_socket_table(struct pt_regs* ctx,
                                                 __u64 sent,
                                                 __u64 received,
-                                                __u16 retransmitted,
-                                                __u8 protocol)
+                                                __u32 retransmitted,
+                                                __u16 protocol)
 #endif
 {
     __u16 family;
@@ -376,7 +376,7 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
     sent = (size_t)PT_REGS_PARM3(ctx);
 #endif
 
-    update_socket_table(ctx, sent, 0, 0, IPPROTO_TCP);
+    update_socket_table(ctx, sent, 0, 0, (__u16)IPPROTO_TCP);
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_BYTES_TCP_SENDMSG, sent);
 
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_TCP_SENDMSG, 1);
@@ -395,7 +395,7 @@ int netdata_tcp_retransmit_skb(struct pt_regs* ctx)
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_TCP_RETRANSMIT, 1);
 
-    update_socket_table(ctx, 0, 0, 1, IPPROTO_TCP);
+    update_socket_table(ctx, 0, 0, 1, (__u16)IPPROTO_TCP);
 
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
     if (apps)
@@ -421,7 +421,7 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
 
     __u64 received = (__u64) PT_REGS_PARM2(ctx);
 
-    update_socket_table(ctx, 0, (__u64)copied, 1, IPPROTO_TCP);
+    update_socket_table(ctx, 0, (__u64)copied, 1, (__u16)IPPROTO_TCP);
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_BYTES_TCP_CLEANUP_RBUF, received);
 
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
@@ -491,7 +491,7 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
     }
 
     bpf_map_delete_elem(&tbl_nv_udp, &pid_tgid);
-    update_socket_table(ctx, 0, 0, 1, IPPROTO_TCP);
+    update_socket_table(ctx, 0, 0, 1, (__u16)IPPROTO_UDP);
 
     __u64 received = (__u64) PT_REGS_RC(ctx);
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_BYTES_UDP_RECVMSG, received);

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -194,9 +194,9 @@ static inline __u16 set_idx_value(netdata_socket_idx_t *nsi, struct inet_sock *i
 
 // Update time and bytes sent and received
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0))
-static __always_inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u16 retransmitted)
+static __always_inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u32 retransmitted)
 #else
-static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u16 retransmitted)
+static inline void update_socket_stats(netdata_socket_t *ptr, __u64 sent, __u64 received, __u32 retransmitted)
 #endif
 {
     ptr->ct = bpf_ktime_get_ns();

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -252,7 +252,7 @@ static inline void update_socket_table(struct pt_regs* ctx,
     if (val) {
         update_socket_stats(val, sent, received, retransmitted);
         if (protocol == IPPROTO_UDP)
-            val->removeme = 1;
+            bpf_map_delete_elem(tbl, &idx);
     } else {
         data.first = bpf_ktime_get_ns();
         data.protocol = protocol;
@@ -449,8 +449,7 @@ int netdata_tcp_close(struct pt_regs* ctx)
     tbl = (family == AF_INET6)?(void *)&tbl_conn_ipv6:(void *)&tbl_conn_ipv4;
     val = (netdata_socket_t *) bpf_map_lookup_elem(tbl, &idx);
     if (val) {
-        //The socket information needs to be removed after read on user ring
-        val->removeme = 1;
+        bpf_map_delete_elem(tbl, &idx);
     }
 
     return 0;


### PR DESCRIPTION
##### Summary
As it was described in issue https://github.com/netdata/netdata/issues/12027 a specific `k(ret)probe`  was crashing an eBPF Virtual Machine and creating problems when eBPF.plugin was running on specific kernels. This PR is changing the socket internally to remove race condition that was present.

##### Test Plan
See `Additional information` for some results.

1. Get binaries from this [link](https://github.com/netdata/kernel-collector/actions/runs/1813038788) an extract them:
```sh
for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```
2. Compile the branch
```sh
# make clean; make tester
```

3. Run legacy tester for entry and return codes:
```sh
# ./kernel/legacy_test --load-binary ./rnetdata_ebpf_socket.5.4.o --content --iteration 2 --log-path slackware_socket_return.txt 
# ./kernel/legacy_test --load-binary ./pnetdata_ebpf_socket.5.4.o --content --iteration 2 --log-path slackware_socket_entry.txt
```

4. Go to `co-re` directory and compile functional testers.

```sh
# make clean; make
# ./tests/socket --probe >> core.txt
# ./tests/socket --trampoline >> core.txt
# ./tests/socket --tracepoint >> core.txt
```

##### Additional information
This PR was tested on:

| Linux Distribution | kernel version  | Legacy Entry | Legacy Return | CO-RE |
|--------------------|-----------------|--------------|---------------|-------|
| Slackware Current  |     5.15.19     | [slackware_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032331/slackware_socket_entry.txt) | [slackware_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032330/slackware_socket_return.txt) |  [slackware_core.txt](https://github.com/netdata/kernel-collector/files/8032332/slackware_core.txt) |
| Arch Linux         | 5.16.7-arch1    | [arch_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032335/arch_socket_entry.txt)  | [arch_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032336/arch_socket_return.txt) |  [arch_core.txt](https://github.com/netdata/kernel-collector/files/8032340/arch_core.txt) |
| Ubuntu 21.04       | 5.11.0-49       | [ubuntu_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032489/ubuntu_socket_entry.txt) | [ubuntu_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032490/ubuntu_socket_return.txt) | [ubuntu_core.txt](https://github.com/netdata/kernel-collector/files/8032491/ubuntu_core.txt) |
| Manjaro 21.1       | 5.10.89-1       | [manjaro_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032494/manjaro_socket_entry.txt) | [manjaro_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032495/manjaro_socket_return.txt) | [manjaro_core.txt](https://github.com/netdata/kernel-collector/files/8032496/manjaro_core.txt) |
| Ubuntu 18.04       | 5.4.0-94        | [ubuntu1804_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032505/ubuntu1804_socket_entry.txt) | [ubuntu1804_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032506/ubuntu1804_socket_return.txt) |   Not present  |
| Rocky 8.5          | 4.18.0-348.12.2.el8_5 | [rocky_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032511/rocky_socket_entry.txt) | [rocky_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032513/rocky_socket_return.txt) | [rocky_socket.txt](https://github.com/netdata/kernel-collector/files/8032515/rocky_socket.txt) |
| Ubuntu 18.04       | 4.15.0-166      |  [ubuntu1804_4_15_socket_entry.txt](https://github.com/netdata/kernel-collector/files/8032523/ubuntu1804_4_15_socket_entry.txt) | [ubuntu1804_4_15_socket_return.txt](https://github.com/netdata/kernel-collector/files/8032524/ubuntu1804_4_15_socket_return.txt) |   Not present  |
| CentOS 7.9         | 3.10.0-1160.49.1.el7 | [centos7_entry.txt](https://github.com/netdata/kernel-collector/files/8032532/centos7_entry.txt) | [centos7_return.txt](https://github.com/netdata/kernel-collector/files/8032533/centos7_return.txt)  |   Not present  |