### PR TITLE
Socket next steps

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -38,6 +38,9 @@ typedef struct netdata_bandwidth {
     __u64 call_udp_sent;
     __u64 call_udp_received;
     __u64 close;
+    __u64 drop;
+    __u32 ipv4_connect;
+    __u32 ipv6_connect;
 } netdata_bandwidth_t;
 
 // Index used together previous structure
@@ -47,6 +50,17 @@ typedef struct netdata_socket_idx {
     union netdata_ip daddr;
     __u16 dport;
 } netdata_socket_idx_t;
+
+typedef struct netdata_passive_connection {
+    __u32 tgid;
+    __u32 pid;
+    __u64 counter;
+} netdata_passive_connection_t;
+
+typedef struct netdata_passive_connection_idx {
+    __u16 protocol;
+    __u16 port;
+} netdata_passive_connection_idx_t;
 
 enum socket_counters {
     NETDATA_KEY_CALLS_TCP_SENDMSG,
@@ -69,6 +83,14 @@ enum socket_counters {
 
     NETDATA_KEY_TCP_RETRANSMIT,
 
+    NETDATA_KEY_TCP_DROP,
+
+    NETDATA_KEY_CALLS_TCP_CONNECT_IPV4,
+    NETDATA_KEY_ERROR_TCP_CONNECT_IPV4,
+
+    NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
+    NETDATA_KEY_ERROR_TCP_CONNECT_IPV6,
+
     // Keep this as last and don't skip numbers as it is used as element counter
     NETDATA_SOCKET_COUNTER
 };
@@ -81,6 +103,9 @@ enum socket_functions {
     NETDATA_FCNT_UDP_RECEVMSG,
     NETDATA_FCNT_TCP_SENDMSG,
     NETDATA_FCNT_UDP_SENDMSG,
+    NETDATA_FCNT_TCP_DROP,
+    NETDATA_FCNT_TCP_V4_CONNECT,
+    NETDATA_FCNT_TCP_V6_CONNECT,
 
     NETDATA_SOCKET_FCNT_END
 };

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -79,9 +79,9 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __type(key, __u16);
-    __type(value, __u8);
-    __uint(max_entries, 65536);
+    __type(key, netdata_passive_connection_idx_t);
+    __type(value, netdata_passive_connection_t);
+    __uint(max_entries, 1024);
 } tbl_lports SEC(".maps");
 
 struct {
@@ -130,9 +130,9 @@ struct bpf_map_def SEC("maps") tbl_nv_udp = {
 
 struct bpf_map_def SEC("maps") tbl_lports = {
     .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u16),
-    .value_size = sizeof(__u8),
-    .max_entries =  65536
+    .key_size = sizeof(netdata_passive_connection_idx_t),
+    .value_size = sizeof(netdata_passive_connection_t),
+    .max_entries =  1024
 };
 
 struct bpf_map_def SEC("maps") socket_ctrl = {
@@ -396,17 +396,41 @@ static inline void update_pid_cleanup()
 SEC("kretprobe/inet_csk_accept")
 int netdata_inet_csk_accept(struct pt_regs* ctx)
 {
-    struct sock *sk = (struct sock*)PT_REGS_RC(ctx);
+    netdata_passive_connection_t data = { };
+    netdata_passive_connection_idx_t idx = { };
+    struct sock *sk = (struct sock *)PT_REGS_RC(ctx);
+    u16 protocol;
     if (!sk)
         return 0;
 
-    __u16 dport;
-    bpf_probe_read(&dport, sizeof(u16), &sk->__sk_common.skc_num);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0))
+    protocol = 0;
+    bpf_probe_read(&protocol, sizeof(u16), &sk->sk_protocol);
+#else
+    protocol = (u16) select_protocol(sk);
+#endif
 
-    __u8 *value = (__u8 *)bpf_map_lookup_elem(&tbl_lports, &dport);
-    if (!value) {
-        __u8 value = 1;
-        bpf_map_update_elem(&tbl_lports, &dport, &value, BPF_ANY);
+    if (protocol != IPPROTO_TCP && protocol != IPPROTO_UDP)
+        return 0;
+
+    idx.protocol = protocol;
+    bpf_probe_read(&idx.port, sizeof(u16), &sk->__sk_common.skc_num);
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid);
+    __u32 pid = (__u32)(pid_tgid >> 32);
+
+    netdata_passive_connection_t *value = (netdata_passive_connection_t *)bpf_map_lookup_elem(&tbl_lports, &idx);
+    if (value) {
+        // Update PID, because process can die.
+        value->tgid = tgid;
+        value->pid = pid;
+        libnetdata_update_u64(&value->counter, 1);
+    } else {
+        data.tgid = tgid;
+        data.pid = pid;
+        data.counter = 1;
+        bpf_map_update_elem(&tbl_lports, &idx, &data, BPF_ANY);
     }
 
     return 0;

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -543,6 +543,32 @@ int netdata_tcp_close(struct pt_regs* ctx)
     return 0;
 }
 
+SEC("kprobe/__kfree_skb")
+int netdata_tcp_drop(struct pt_regs* ctx)
+{
+    struct sk_buff *skb = (struct sk_buff *) PT_REGS_PARM1(ctx);
+    struct sock *sk = _(skb->sk);
+    if (!sk)
+        return 0;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0))
+    u16 protocol = 0;
+    bpf_probe_read(&protocol, sizeof(u16), &sk->sk_protocol);
+#else
+    u16 protocol = (u16) select_protocol(sk);
+#endif
+
+    // We want to monitor calls for static function tcp_drop
+    if (protocol != IPPROTO_TCP)
+        return 0;
+
+    libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_TCP_DROP, 1);
+
+    update_pid_cleanup(1, 0);
+
+    return 0;
+}
+
 /************************************************************************************
  *
  *                                 UDP Section


### PR DESCRIPTION
##### Summary
This PR is bringing three new features for socket collector:

1. Monitoring for passive connections
2. Monitoring for active connections
3. Monitor for calls to `tcp_drop`.

##### Test Plan

1. Clone this Branch.
4. Get binaries compiled from this [link](https://github.com/netdata/kernel-collector/actions/runs/1954546015)
5. Extract the files in a specific directory:

```bash
# for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
# for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```
6. Compile tester 
```bash
# make tester
```
7. Run the tester for socket:

```bash
# ./kernel/legacy_test --netdata-path PATH_TO_ARTIFACTS --content --iteration 2 --socket --log-path FILE.txt
````

##### Additional information
This PR was tested on:

| Linux Distribution | kernel version | Socket log |
|--------------------|----------------|---------|
| Slackware Current  |     5.16.12    | [slackware_5_16.txt](https://github.com/netdata/kernel-collector/files/8211287/slackware_5_16.txt) |
| Arch Linux         |  5.16.11-arch1 | [arch_5_16.txt](https://github.com/netdata/kernel-collector/files/8211285/arch_5_16.txt) | 
| Ubuntu 21.04       |    5.11.0-49   | [ubuntu_5_11.txt](https://github.com/netdata/kernel-collector/files/8211288/ubuntu_5_11.txt) |
| Ubuntu 18.04       |    5.4.0-100   | [ubuntu_5_4.txt](https://github.com/netdata/kernel-collector/files/8211289/ubuntu_5_4.txt) |
| Rocky Linux        | 4.18.0-348.12.2.el8_5 | [rocky_4_18.txt](https://github.com/netdata/kernel-collector/files/8211284/rocky_4_18.txt) |
| Ubuntu 18.04       |   4.18.0-25.26 | [ubuntu_4_18.txt](https://github.com/netdata/kernel-collector/files/8211456/ubuntu_4_18.txt) |
| Ubuntu 18.04       |   4.15.0-169   | [ubuntu_4_15.txt](https://github.com/netdata/kernel-collector/files/8211455/ubuntu_4_15.txt) |
| Slackware Current  |     4.14.239   | [slackware_4_14.txt](https://github.com/netdata/kernel-collector/files/8211283/slackware_4_14.txt) |
| CentOS 7.9         | 3.10.0-1160.53.1.el7.x86_64. | [centos_3_10.txt](https://github.com/netdata/kernel-collector/files/8211286/centos_3_10.txt) |

The CentOS 7.x cannot run the current tester, so we loaded the binary using `eBPF.plugin` overwritten all eBPF programs with made with this PR.