### PR TITLE
Memory PID

### DIFF
--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -187,5 +187,26 @@ static inline __u32 netdata_get_current_pid()
     return pid;
 }
 
+static inline void *netdata_get_pid_structure(__u32 *store_pid, void *ctrl_tbl, void *pid_tbl)
+{
+    __u32 pid, key = NETDATA_CONTROLLER_APPS_LEVEL;
+
+    __u32 *level = bpf_map_lookup_elem(ctrl_tbl ,&key);
+    if (level) {
+        if (*level == NETDATA_APPS_LEVEL_REAL_PARENT)
+            pid = netdata_get_real_parent_pid();
+        else if (*level == NETDATA_APPS_LEVEL_PARENT)
+            pid = netdata_get_parent_pid();
+        else
+            pid = netdata_get_current_pid();
+    } else
+        pid = netdata_get_real_parent_pid();
+
+    *store_pid = pid;
+
+    return bpf_map_lookup_elem(pid_tbl, store_pid);
+}
+
+
 #endif /* _NETDATA_COMMON_ */
 

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -205,5 +205,34 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
     return 0;
 }
 
+/**
+ * Release task
+ *
+ * Removing a pid when it's no longer needed helps us reduce the default
+ * size used with our tables.
+ *
+ * When a process stops so fast that apps.plugin or cgroup.plugin cannot detect it, we don't show
+ * the information about the process, so it is safe to remove the information about the table.
+ */
+SEC("kprobe/release_task")
+int netdata_release_task_dc(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *removeme;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
+    if (apps) {
+        if (*apps == 0)
+            return 0;
+    } else
+        return 0;
+
+    removeme = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    if (removeme) {
+        bpf_map_delete_elem(&cstat_pid, &key);
+    }
+
+    return 0;
+}
+
 char _license[] SEC("license") = "GPL";
 

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -82,9 +82,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->add_to_page_cache_lru, 1);
     } else {
@@ -107,9 +105,7 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->mark_page_accessed, 1);
     } else {
@@ -151,9 +147,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->account_page_dirtied, 1);
     } else {
@@ -176,9 +170,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->account_page_dirtied, 1);
     } else {
@@ -202,9 +194,7 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->mark_buffer_dirty, 1);
     } else {

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -136,5 +136,35 @@ int netdata_d_lookup(struct pt_regs* ctx)
     return 0;
 }
 
+/**
+ * Release task
+ *
+ * Removing a pid when it's no longer needed helps us reduce the default
+ * size used with our tables.
+ *
+ * When a process stops so fast that apps.plugin or cgroup.plugin cannot detect it, we don't show
+ * the information about the process, so it is safe to remove the information about the table.
+ */
+SEC("kprobe/release_task")
+int netdata_release_task_dc(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *removeme;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&key);
+    if (apps) {
+        if (*apps == 0)
+            return 0;
+    } else
+        return 0;
+
+    removeme = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+    if (removeme) {
+        bpf_map_delete_elem(&dcstat_pid, &key);
+    }
+
+    return 0;
+}
+
+
 char _license[] SEC("license") = "GPL";
 

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -85,9 +85,7 @@ int netdata_lookup_fast(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->references, 1);
     } else {
@@ -112,9 +110,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
         return 0;
 
     if (*apps == 1) {
-        __u64 pid_tgid = bpf_get_current_pid_tgid();
-        key = (__u32)(pid_tgid >> 32);
-        fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
+        fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
             libnetdata_update_u64(&fill->slow, 1);
         } else {
@@ -127,7 +123,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
     if (ret == 0) {
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
         if (*apps == 1) {
-            fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
+            fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
             if (fill) {
                 libnetdata_update_u64(&fill->missed, 1);
             } else {


### PR DESCRIPTION
##### Summary
This PR is moving a function from `process` to another file, because it is useful for different eBPF programs.

It also brings changes for `directory cache` and `cachestat`.
##### Test Plan
1. Get files from [link](https://github.com/netdata/kernel-collector/actions/runs/2367320678) and store in a specific directory, for example, `~/PATH_TO_ARTIFACTS`
2. Extract the files running

```sh
for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```

3.  Compile current branch:
```sh
# make clean ; make tester

```

4. Run tests:
```sh
$ ./kernel/legacy_test --content --iteration 2 --process --cachestat --dc --netdata-path ../artifacts/ --log-path pid0.txt --pid 0
$ ./kernel/legacy_test --content --iteration 2 --process --cachestat --dc --netdata-path ../artifacts/ --log-path pid1.txt --pid 1
$ ./kernel/legacy_test --content --iteration 2 --process --cachestat --dc --netdata-path ../artifacts/ --log-path pid2.txt --pid 2
```
5. Run the next command and verify all tests were successful : 
```sh
bash-5.1$ grep Status *.txt | sort -u
arch_5_17_9_pid0.txt:    "Status" :  "Success"
arch_5_17_9_pid1.txt:    "Status" :  "Success"
arch_5_17_9_pid2.txt:    "Status" :  "Success"
rocky_4_18_pid0.txt:    "Status" :  "Success"
rocky_4_18_pid1.txt:    "Status" :  "Success"
rocky_4_18_pid2.txt:    "Status" :  "Success"
slackware_4_14_266_pid0.txt:    "Status" :  "Success"
slackware_4_14_266_pid1.txt:    "Status" :  "Success"
slackware_4_14_266_pid2.txt:    "Status" :  "Success"
slackware_5_15_38_pid0.txt:    "Status" :  "Success"
slackware_5_15_38_pid1.txt:    "Status" :  "Success"
slackware_5_15_38_pid2.txt:    "Status" :  "Success"
slackware_5_17_5_pid0.txt:    "Status" :  "Success"
slackware_5_17_5_pid1.txt:    "Status" :  "Success"
slackware_5_17_5_pid2.txt:    "Status" :  "Success"
ubuntu_4_15_pid0.txt:    "Status" :  "Success"
ubuntu_4_15_pid1.txt:    "Status" :  "Success"
ubuntu_4_15_pid2.txt:    "Status" :  "Success"
ubuntu_5_11_pid0.txt:    "Status" :  "Success"
ubuntu_5_11_pid1.txt:    "Status" :  "Success"
ubuntu_5_11_pid2.txt:    "Status" :  "Success"
ubuntu_5_4_pid0.txt:    "Status" :  "Success"
ubuntu_5_4_pid1.txt:    "Status" :  "Success"
ubuntu_5_4_pid2.txt:    "Status" :  "Success"
```

You can also observe that when we run with the option `--pid 0` we will have less PID stored when compared with option `--pid 2`.

##### Additional information
Finally, this PR was tested on:

| Linux Distribution | kernel version | 
|--------------------|----------------|
| Slackware Current  |     5.17.9     |
| Arch Linux         |  5.17.9-arch1 |
| Slackware 15.0     |     5.15.38   |
| Ubuntu 21.04       |    5.11.0-49-generic   |
| Ubuntu 18.04       |    5.4.0-110   |
| Rocky 8.5          | 4.18.0-372.9.1.el8.x86_64 |
| Ubuntu 18.04       |   4.15.0-177   |
| Slackware 15.0     | 4.14.266 |