### PR TITLE
PID (other threads)

### DIFF
--- a/includes/netdata_tests.h
+++ b/includes/netdata_tests.h
@@ -62,18 +62,6 @@ enum netdata_modes {
     NETDATA_MODE_TRACEPOINT
 };
 
-static inline void ebpf_print_help(char *name, char *info, int has_trampoline) {
-    fprintf(stdout, "%s tests if it is possible to monitor %s on host\n\n"
-                    "The following options are available:\n\n"
-                    "--help       (-h): Prints this help.\n"
-                    "--probe      (-p): Use probe and do no try to use trampolines (fentry/fexit).\n"
-                    "--tracepoint (-r): Use tracepoint.\n"
-                    , name, info);
-    if (has_trampoline)
-        fprintf(stdout, "--trampoline (-t): Try to use trampoline(fentry/fexit). If this is not possible" 
-                        " probes will be used.\n");
-}
-
 static inline void ebpf_tracepoint_help(char *name) {
     fprintf(stdout, "%s tests if it is possible to use tracepoints on host\n\n"
                     "--help       (-h): Prints this help.\n", name);

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -148,7 +148,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
 SEC("kprobe/release_task")
 int netdata_release_task_dc(struct pt_regs* ctx)
 {
-    netdata_cachestat_t *removeme;
+    netdata_dc_stat_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&dcstat_ctrl ,&key);
     if (apps) {

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -225,7 +225,7 @@ int netdata_close(struct pt_regs* ctx)
 SEC("kprobe/release_task")
 int netdata_release_task_fd(struct pt_regs* ctx)
 {
-    netdata_cachestat_t *removeme;
+    struct netdata_fd_stat_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&fd_ctrl ,&key);
     if (apps) {

--- a/kernel/shm_kern.c
+++ b/kernel/shm_kern.c
@@ -76,9 +76,7 @@ int netdata_syscall_shmget(struct pt_regs *ctx)
         }
     }
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_shm_t *fill = bpf_map_lookup_elem(&tbl_pid_shm, &key);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u64(&fill->get, 1);
     } else {
@@ -105,9 +103,7 @@ int netdata_syscall_shmat(struct pt_regs *ctx)
         }
     }
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_shm_t *fill = bpf_map_lookup_elem(&tbl_pid_shm, &key);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u64(&fill->at, 1);
     } else {
@@ -134,9 +130,7 @@ int netdata_syscall_shmdt(struct pt_regs *ctx)
         }
     }
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_shm_t *fill = bpf_map_lookup_elem(&tbl_pid_shm, &key);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u64(&fill->dt, 1);
     } else {
@@ -163,9 +157,7 @@ int netdata_syscall_shmctl(struct pt_regs *ctx)
         }
     }
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_shm_t *fill = bpf_map_lookup_elem(&tbl_pid_shm, &key);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u64(&fill->ctl, 1);
     } else {

--- a/kernel/shm_kern.c
+++ b/kernel/shm_kern.c
@@ -180,7 +180,7 @@ int netdata_syscall_shmctl(struct pt_regs *ctx)
 SEC("kprobe/release_task")
 int netdata_release_task_shm(struct pt_regs* ctx)
 {
-    netdata_cachestat_t *removeme;
+    netdata_shm_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&shm_ctrl ,&key);
     if (apps) {

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -85,8 +85,6 @@ int netdata_swap_readpage(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
     netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->read, 1);

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -128,5 +128,34 @@ int netdata_swap_writepage(struct pt_regs* ctx)
  *
  ***********************************************************************************/
 
+/**
+ * Release task
+ *
+ * Removing a pid when it's no longer needed helps us reduce the default
+ * size used with our tables.
+ *
+ * When a process stops so fast that apps.plugin or cgroup.plugin cannot detect it, we don't show
+ * the information about the process, so it is safe to remove the information about the table.
+ */
+SEC("kprobe/release_task")
+int netdata_release_task_swap(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *removeme;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&swap_ctrl ,&key);
+    if (apps) {
+        if (*apps == 0)
+            return 0;
+    } else
+        return 0;
+
+    removeme = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
+    if (removeme) {
+        bpf_map_delete_elem(&tbl_pid_swap, &key);
+    }
+
+    return 0;
+}
+
 char _license[] SEC("license") = "GPL";
 

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -87,7 +87,7 @@ int netdata_swap_readpage(struct pt_regs* ctx)
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     key = (__u32)(pid_tgid >> 32);
-    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&key);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->read, 1);
     } else {
@@ -111,9 +111,7 @@ int netdata_swap_writepage(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&key);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->write, 1);
     } else {

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -589,7 +589,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
 SEC("kprobe/release_task")
 int netdata_release_task_vfs(struct pt_regs* ctx)
 {
-    netdata_cachestat_t *removeme;
+    struct netdata_vfs_stat_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
     if (apps) {

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -69,6 +69,21 @@ struct bpf_map_def SEC("maps") vfs_ctrl = {
 #endif
 
 /************************************************************************************
+ *
+ *                                Local Function Section
+ *
+ ***********************************************************************************/
+
+static inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+
+    data->pid_tgid = pid_tgid;
+    data->pid = tgid;
+}
+
+/************************************************************************************
  *     
  *                                   FILE Section
  *     
@@ -106,10 +121,7 @@ int netdata_sys_write(struct pt_regs* ctx)
     tot = libnetdata_log2l(ret);
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
@@ -123,8 +135,7 @@ int netdata_sys_write(struct pt_regs* ctx)
         }
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -176,10 +187,7 @@ int netdata_sys_writev(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->writev_call, 1) ;
 
@@ -193,8 +201,7 @@ int netdata_sys_writev(struct pt_regs* ctx)
         }
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -246,10 +253,7 @@ int netdata_sys_read(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->read_call, 1) ;
 
@@ -263,8 +267,7 @@ int netdata_sys_read(struct pt_regs* ctx)
         }
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -316,10 +319,7 @@ int netdata_sys_readv(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->readv_call, 1) ;
 
@@ -334,8 +334,7 @@ int netdata_sys_readv(struct pt_regs* ctx)
         }
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -381,10 +380,7 @@ int netdata_sys_unlink(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
@@ -394,8 +390,7 @@ int netdata_sys_unlink(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -441,10 +436,7 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->fsync_call, 1) ;
 
@@ -454,8 +446,7 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -501,10 +492,7 @@ int netdata_vfs_open(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
@@ -514,8 +502,7 @@ int netdata_vfs_open(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -561,10 +548,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->create_call, 1) ;
 
@@ -574,8 +558,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
 #if NETDATASEL < 2
         if (ret < 0) {

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -577,5 +577,34 @@ int netdata_vfs_create(struct pt_regs* ctx)
     return 0;
 }
 
+/**
+ * Release task
+ *
+ * Removing a pid when it's no longer needed helps us reduce the default
+ * size used with our tables.
+ *
+ * When a process stops so fast that apps.plugin or cgroup.plugin cannot detect it, we don't show
+ * the information about the process, so it is safe to remove the information about the table.
+ */
+SEC("kprobe/release_task")
+int netdata_release_task_vfs(struct pt_regs* ctx)
+{
+    netdata_cachestat_t *removeme;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&vfs_ctrl ,&key);
+    if (apps) {
+        if (*apps == 0)
+            return 0;
+    } else
+        return 0;
+
+    removeme = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    if (removeme) {
+        bpf_map_delete_elem(&tbl_vfs_pid, &key);
+    }
+
+    return 0;
+}
+
 char _license[] SEC("license") = "GPL";
 


### PR DESCRIPTION
##### Summary
This PR is bringing modifications to monitor PID for File descriptors, Virtual File System, SWAP, and shared memory.

When this code is loaded by `ebpf.plugin`, the plugin must disable these threads by default, unless user enable them to avoid big overload on `release_task`.
This caution won't be necessary with `CO-RE` codes.
We also update our documentation with next PR at `netdata/netdata`.

##### Test Plan
1. Get binaries from [this](https://github.com/netdata/kernel-collector/actions/runs/2836755076) based in your `libc`  and store them inside a `directory`.
2.  Run the following commands to extract all files:
```sh
$ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
$ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```
3. Run next commands:
```sh
#  ./kernel/legacy_test --content --iteration 2 --filedescriptor --vfs --swap --shm --netdata-path ../directory/ --pid 0 --log-path log_5_18_pid0.txt
#  ./kernel/legacy_test --content --iteration 2 --filedescriptor --vfs --swap --shm --netdata-path ../directory/ --pid 1 --log-path log_5_18_pid1.txt
#  ./kernel/legacy_test --content --iteration 2 --filedescriptor --vfs --swap --shm --netdata-path ../directory/ --pid 2 --log-path log_5_18_pid2.txt
```
##### Additional information

This PR was tested on:

| Linux Distribution | kernel version | real parent | parent | all | 
|--------------------|----------------|-------------|--------|-----|
| Slackware Current  |     5.18.16    | [slackware_5_18_pid0.txt](https://github.com/netdata/kernel-collector/files/9312648/slackware_5_18_pid0.txt)  | [slackware_5_18_pid1.txt](https://github.com/netdata/kernel-collector/files/9312649/slackware_5_18_pid1.txt) | [slackware_5_18_pid2.txt](https://github.com/netdata/kernel-collector/files/9312650/slackware_5_18_pid2.txt) |
| Arch Linux         |  5.18.16-arch1 | [arch_5_18_pid0.txt](https://github.com/netdata/kernel-collector/files/9312703/arch_5_18_pid0.txt) | [arch_5_18_pid1.txt](https://github.com/netdata/kernel-collector/files/9312704/arch_5_18_pid1.txt) | [arch_5_18_pid2.txt](https://github.com/netdata/kernel-collector/files/9312705/arch_5_18_pid2.txt) |
| Ubuntu 22.04       | 5.15.0-33-generic   | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/9312707/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/9312708/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/9312709/ubuntu_5_15_pid2.txt) |
| Alma 9             | 5.14.0-70.17.1.el9_0.x86_64 | [alma_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/9312710/alma_5_14_pid0.txt) | [alma_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/9312711/alma_5_14_pid1.txt) | [alma_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/9312712/alma_5_14_pid2.txt) |
| Ubuntu 20.04       |   5.11.0-38-generic    | [ubuntu_5_11_pid0.txt](https://github.com/netdata/kernel-collector/files/9312714/ubuntu_5_11_pid0.txt) | [ubuntu_5_11_pid1.txt](https://github.com/netdata/kernel-collector/files/9312715/ubuntu_5_11_pid1.txt) | [ubuntu_5_11_pid2.txt](https://github.com/netdata/kernel-collector/files/9312716/ubuntu_5_11_pid2.txt) |
| Debian 11          | 5.10.0-16-amd64 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/9312718/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/9312719/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/9312720/debian_5_10_pid2.txt) |          
| Alma 8.6           | 4.18.0-372.19.1.el8_6 | [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/9312726/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/9312727/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/9312728/alma_4_18_pid2.txt) |
| Ubuntu 18.04       |   4.15.0-180   | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/9312732/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/9312733/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/9312734/ubuntu_4_15_pid2.txt)| 

