### PR TITLE
Update libbpf disk

### DIFF
--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -1,6 +1,8 @@
 #define KBUILD_MODNAME "btrfs_netdata"
-#include <linux/genhd.h>
 #include <linux/version.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
+#include <linux/genhd.h>
+#endif
 // Condition added because struct kiocb was moved when 4.1.0 was released
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0))
 #include <linux/aio.h>

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -1,5 +1,8 @@
 #define KBUILD_MODNAME "disk_netdata"
+#include <linux/version.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 #include <linux/genhd.h>
+#endif
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -1,5 +1,8 @@
 #define KBUILD_MODNAME "ext4_netdata"
+#include <linux/version.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 #include <linux/genhd.h>
+#endif
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -1,6 +1,5 @@
 #define KBUILD_MODNAME "hardirq_netdata"
 #include <linux/ptrace.h>
-#include <linux/genhd.h>
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -1,5 +1,8 @@
 #define KBUILD_MODNAME "nfs_netdata"
+#include <linux/version.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 #include <linux/genhd.h>
+#endif
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>

--- a/kernel/softirq_kern.c
+++ b/kernel/softirq_kern.c
@@ -1,6 +1,5 @@
 #define KBUILD_MODNAME "softirq_netdata"
 #include <linux/ptrace.h>
-#include <linux/genhd.h>
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -1,6 +1,9 @@
 #define KBUILD_MODNAME "xfs_netdata"
 #include <linux/ptrace.h>
+#include <linux/version.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 #include <linux/genhd.h>
+#endif
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -1,5 +1,8 @@
 #define KBUILD_MODNAME "zfs_netdata"
+#include <linux/version.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 #include <linux/genhd.h>
+#endif
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>


### PR DESCRIPTION
##### Summary
This PR is currently blocked by https://github.com/netdata/kernel-collector/pull/309

This PR is bringing the latest `libbpf` for this repo and we are also adjusting our codes related to disk and filesystem giving conditions for them to be compiled on kernels newer or equal than `5.18.0`.

We are not modifying tester and github files, because current codes are working on different kernel versions, so we are only addressing the issue that compilation could not be completed.
##### Test Plan
1. Clone branch
2. Run the following commands:
```sh
# make clean; make dev
```
3. Verify that compilation will end with success . 
##### Additional information
Considering that main issue is created when we have kernel `5.18` or newer, I suggest to compile at least on a distribution that have it, for other kernels to take a look in CI results is enough.

This PR was tested on:

| Linux Distribution | kernel version | With CO-RE| Logs |
|--------------------|----------------|---------|--------|
| Slackware Current  |     5.18.12    | Yes     | [slackware_co_re_5_18.txt](https://github.com/netdata/kernel-collector/files/9136536/slackware_co_re_5_18.txt) |
| Slackware Current  |     5.18.12    | No      | [slackware_5_18.txt](https://github.com/netdata/kernel-collector/files/9136539/slackware_5_18.txt) |
| Arch Linux         |  5.18.12-arch1 | Yes     | [arch_co_re_5_18.txt](https://github.com/netdata/kernel-collector/files/9136540/arch_co_re_5_18.txt) |
| Arch Linux         |  5.18.12-arch1 | No      | [arch_5_18.txt](https://github.com/netdata/kernel-collector/files/9136542/arch_5_18.txt) |
| Ubuntu 22.04       | 5.15.0-33-generic   | Yes| [ubuntu_co_re_5_15.txt](https://github.com/netdata/kernel-collector/files/9136544/ubuntu_co_re_5_15.txt) |
| Ubuntu 22.04       | 5.15.0-33-generic   | No|  [ubuntu_5_15.txt](https://github.com/netdata/kernel-collector/files/9136545/ubuntu_5_15.txt) |
| Ubuntu 20.04       |   5.11.0-38-generic    |  Yes       | [ubuntu_co_re_5_11.txt](https://github.com/netdata/kernel-collector/files/9136547/ubuntu_co_re_5_11.txt) |
| Ubuntu 20.04       |   5.11.0-38-generic    |  No       | [ubuntu_5_11.txt](https://github.com/netdata/kernel-collector/files/9136548/ubuntu_5_11.txt) |
| Ubuntu 18.04       |   4.15.0-180   | No      | [unbuntu_4_15.txt](https://github.com/netdata/kernel-collector/files/9136556/unbuntu_4_15.txt) |
| Alma 8.5           | kernel-core-4.18.0-372.16.1 | No | [alma_4_18.txt](https://github.com/netdata/kernel-collector/files/9136787/alma_4_18.txt) |
| CentOS 7.9         | 3.10.0-1160.71.1.el7.x86_64. | No | [centos_3_10.txt](https://github.com/netdata/kernel-collector/files/9136782/centos_3_10.txt)|