### PR TITLE
Update socket to use latest functions

### DIFF
--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -290,7 +290,7 @@ static inline void update_pid_bandwidth(__u64 sent, __u64 received, __u8 protoco
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
 
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
-    if (!apps || (apps && *apps == 0))
+    if (!apps || *apps == 0)
         return;
 
     b = netdata_get_pid_structure(&key, &socket_ctrl, &tbl_bandwidth);
@@ -354,7 +354,7 @@ static inline void update_pid_cleanup(__u64 drop, __u64 close)
 
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
-    if (!apps || (apps && *apps == 0))
+    if (!apps || *apps == 0)
         return;
 
     b = netdata_get_pid_structure(&key, &socket_ctrl, &tbl_bandwidth);
@@ -417,7 +417,7 @@ static inline void update_pid_connection(__u8 version)
 
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&socket_ctrl ,&key);
-    if (!stored || (apps && *apps == 0))
+    if (!apps || *apps == 0)
         return;
 
     stored = netdata_get_pid_structure(&key, &socket_ctrl, &tbl_bandwidth);


### PR DESCRIPTION
##### Summary
This PR is bringing necessary changes in socket program allowing it to monitor PID better.

##### Test Plan
1. Get binaries from this [link](https://github.com/netdata/kernel-collector/actions/runs/2899854912) and save inside a `directory`.
2. Compile this branch: `make clean; make`
3. Run the following tests:
```sh
# for i in `seq 0 2`; do ./kernel/legacy_test --content --iteration 2 --socket --netdata-path directory --pid $i --log-path pid$i.txt ; sleep 1; done
```

##### Additional information
This PR was tested on:

| Linux Distribution | kernel version | real parent | parent |  all |
|--------------------|----------------|---------|---------|---------|
| Slackware Current  |     5.19.2     | [slackware_5_19_pid0.txt](https://github.com/netdata/kernel-collector/files/9397716/slackware_5_19_pid0.txt) | [slackware_5_19_pid1.txt](https://github.com/netdata/kernel-collector/files/9397717/slackware_5_19_pid1.txt) | [slackware_5_19_pid2.txt](https://github.com/netdata/kernel-collector/files/9397718/slackware_5_19_pid2.txt) |
| Arch Linux         |  5.19.2-arch1-2 | [arch_5_19_pid0.txt](https://github.com/netdata/kernel-collector/files/9397722/arch_5_19_pid0.txt) | [arch_5_19_pid1.txt](https://github.com/netdata/kernel-collector/files/9397723/arch_5_19_pid1.txt) | [arch_5_19_pid2.txt](https://github.com/netdata/kernel-collector/files/9398995/arch_5_19_pid2.txt) |
| Ubuntu 22.04       |    5.15.0-33-generic   | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/9397796/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/9397797/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/9397798/ubuntu_5_15_pid2.txt) |
| Alma 9             | 5.14.0-70.17.1.el9_0.x86_64 |[alma_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/9397799/alma_5_14_pid0.txt) | [alma_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/9397800/alma_5_14_pid1.txt) | [alma_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/9397802/alma_5_14_pid2.txt) | 
| Debian 11          | 5.10.0-16-amd64 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/9397808/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/9397809/debian_5_10_pid1.txt) |[debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/9397811/debian_5_10_pid2.txt)|    
| Alma 8.6           | 4.18.0-372.19.1.el8_6 | [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/9397815/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/9397816/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/9397817/alma_4_18_pid2.txt) |

I tested on ancient kernels, and I observed issues for kernels older than `4.16`  that will be fixed with this https://github.com/netdata/kernel-collector/pull/314 .