### PR TITLE
FD and FS

### DIFF
--- a/includes/netdata_fd.h
+++ b/includes/netdata_fd.h
@@ -4,9 +4,6 @@
 #define _NETDATA_EBPF_FD_H_ 1
 
 struct netdata_fd_stat_t {
-    __u64 pid_tgid;                     //Unique identifier
-    __u32 pid;                          //process id
-
     //Counter
     __u32 open_call;                    //open syscalls (open and openat)
     __u32 close_call;                   //Close syscall (close)

--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -81,13 +81,7 @@ struct bpf_map_def SEC("maps") tmp_btrfs = {
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_btrfs_entry()
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
 static __always_inline int netdata_btrfs_entry()
-#else
-static inline int netdata_btrfs_entry()
-#endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -62,13 +62,7 @@ struct bpf_map_def SEC("maps") tmp_ext4 = {
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_ext4_entry()
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
 static __always_inline int netdata_ext4_entry()
-#else
-static inline int netdata_ext4_entry()
-#endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -71,21 +71,6 @@ struct bpf_map_def SEC("maps") fd_ctrl = {
 #endif
 
 /************************************************************************************
- *
- *                                Local Function Section
- *
- ***********************************************************************************/
-
-static inline void netdata_fill_common_fd_data(struct netdata_fd_stat_t *data)
-{
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-
-    data->pid_tgid = pid_tgid;
-    data->pid = tgid;
-}
-
-/************************************************************************************
  *     
  *                                   Probe Section
  *     
@@ -135,8 +120,6 @@ int netdata_sys_open(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        netdata_fill_common_fd_data(&data);
-
 #if NETDATASEL < 2
         if (ret < 0) {
             data.open_err = 1;
@@ -198,7 +181,6 @@ int netdata_close(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        netdata_fill_common_fd_data(&data);
         data.close_call = 1;
 #if NETDATASEL < 2
         if (ret < 0) {

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -62,13 +62,7 @@ struct bpf_map_def SEC("maps") tmp_nfs = {
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_nfs_entry()
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
 static __always_inline int netdata_nfs_entry()
-#else
-static inline int netdata_nfs_entry()
-#endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -60,13 +60,7 @@ struct bpf_map_def SEC("maps") tmp_xfs = {
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_xfs_entry()
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
 static __always_inline int netdata_xfs_entry()
-#else
-static inline int netdata_xfs_entry()
-#endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -59,13 +59,7 @@ struct bpf_map_def SEC("maps") tmp_zfs = {
  *     
  ***********************************************************************************/
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0))
-static int netdata_zfs_entry()
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)) 
 static __always_inline int netdata_zfs_entry()
-#else
-static inline int netdata_zfs_entry()
-#endif
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);


### PR DESCRIPTION
##### Summary
This PR is fixing issue https://github.com/netdata/netdata/issues/13751 and also bringing same adjusts done for socket to filesystem threads.

##### Test Plan
1. Get binaries from [this](https://github.com/netdata/kernel-collector/actions/runs/3554154065) link and store it inside a directory, for example, `artifacts`, and extract them:
```sh
$ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
$ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```
2. Create environment to test (create device; format it; make mout point; mount device):
```sh
#  FS=("btrfs ext4 xfs") ; for i in ${FS[@]}; do dd if=/dev/zero of=/tmp/dev_$i bs=1024 count=256000; mkfs.$i /tmp/dev_$i; mkdir /tmp/netdata_$i; mount /tmp/dev_$i /tmp/netdata_$i; done
```
3. Compile branch:
```sh
# make clean; make tester
```
4. Take a look if your OS has all modules and support all FS:
```sh
bash-5.2# mount| grep netdata
/tmp/dev_btrfs on /tmp/netdata_btrfs type btrfs (rw,relatime,ssd,space_cache=v2,subvolid=5,subvol=/)
/tmp/dev_ext4 on /tmp/netdata_ext4 type ext4 (rw,relatime)
/tmp/dev_xfs on /tmp/netdata_xfs type xfs (rw,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota)
```
5. Run tests on FS successful mounted, if you were able to mount everything you need to run next command:
```sh
for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../artifacts/ --content --iteration 2 --filedescriptor --ext4 --btrfs --xfs --log-path file_pid$i.txt ; done
```

If some filesystem is not present, hide argument for the specific filesystem.
6. Verify that you did not have errors:
```sh
#  grep Fail file_pid*
```
7. Umount and cleanup environment:
```sh
FS=("btrfs ext4 xfs") ; for i in ${FS[@]}; do umount /tmp/netdata_$i; rm -rf /tmp/dev_$i /tmp/netdata_$i ; done
```
##### Additional information
This PR was tested on:

| Linux Distribution | kernel version | real parent | parent |  all |
|--------------------|----------------|---------|---------|---------|
| Slackware Current  |     5.19.17     |[slackware_5_19_pid0.txt](https://github.com/netdata/kernel-collector/files/10096862/slackware_5_19_pid0.txt)|[slackware_5_19_pid1.txt](https://github.com/netdata/kernel-collector/files/10096863/slackware_5_19_pid1.txt) | [slackware_5_19_pid2.txt](https://github.com/netdata/kernel-collector/files/10096864/slackware_5_19_pid2.txt)  |
| Arch Linux         |  6.0.9-arch1-1 |[arch_6_0_0.txt](https://github.com/netdata/kernel-collector/files/10096884/arch_6_0_0.txt)| [arch_6_0_1.txt](https://github.com/netdata/kernel-collector/files/10096885/arch_6_0_1.txt) | [arch_6_0_2.txt](https://github.com/netdata/kernel-collector/files/10096886/arch_6_0_2.txt)|
| Ubuntu 22.04       |  5.15.0-33-generic   |[ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/10096943/ubuntu_5_15_pid0.txt) |[ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/10096944/ubuntu_5_15_pid1.txt) |[ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/10096945/ubuntu_5_15_pid2.txt)|
| Alma 9             | 5.14.0-162.6.1.el9_1.x86_64 | [alma_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/10097060/alma_5_14_pid0.txt)|[alma_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/10097062/alma_5_14_pid1.txt)| [alma_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/10097063/alma_5_14_pid2.txt) | 
| Debian 11          | 5.10.0-19-amd64 |[debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/10097152/debian_5_10_pid0.txt) |[debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/10097153/debian_5_10_pid1.txt)| [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/10097154/debian_5_10_pid2.txt) |   
| Oracle 8.6         | 5.4.17-2136.313.6.el8uek.x86_64 | [oracle_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/10097249/oracle_5_4_pid0.txt) |[oracle_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/10097250/oracle_5_4_pid1.txt) |[oracle_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/10097251/oracle_5_4_pid2.txt) |
| Ubuntu 18.04       |  4.15.0-180-generic    | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/10097339/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/10097340/ubuntu_4_15_pid1.txt) |[ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/10097341/ubuntu_4_15_pid2.txt)|
| Slackware Current  |     4.14.290   | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/10097354/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/10097355/slackware_4_14_pid1.txt) |[slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/10097356/slackware_4_14_pid2.txt)|