### PR TITLE
Sync libbpf

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -23,6 +23,7 @@ LINUXINCLUDE += -include $(KERNELSOURCE)/include/linux/kconfig.h
 LINUXINCLUDE += -I../includes
 
 CLANG_VERSION := $(shell clang --version | grep -o -E 'clang version [0-9]+\.[0-9]+\.[0-9]' | cut -f 3 -d ' ')
+CLANG_MAJOR_VERSION := $(shell echo $(CLANG_VERSION) | cut -d. -f1 )
 LLVM_INCLUDES = $(shell [ -d /usr/lib/clang ] && echo "-I/usr/lib/clang/$(CLANG_VERSION)/include" || echo "-I/usr/lib64/clang/$(CLANG_VERSION)/include")
 LLVM_INCLUDES += -I/opt/rh/llvm-toolset-7.0/root/usr/lib64/clang/$(CLANG_VERSION)/include
 
@@ -86,13 +87,19 @@ else
 NETDATA_APPS= ${NETDATA_ALL_APPS}
 endif
 
+ifeq ($(shell test $(CLANG_MAJOR_VERSION) -ge 8 ; echo $$?),0)
+CC_LIBBPF = clang
+else
+CC_LIBBPF = gcc
+endif
+
 all: $(NETDATA_APPS)
 
 dev: ${NETDATA_ALL_APPS}
 
 libbpf:
 	# -fPIE added to be compatible with olders clang/gcc
-	cd $(LIBBPF)/src && /bin/bash ../../.dockerfiles/change_libbpf.sh $(VER_MAJOR) $(VER_MINOR) && $(MAKE) CC=clang CFLAGS="-fPIE" BUILD_STATIC_ONLY=1 DESTDIR=../../.local_libbpf INCLUDEDIR= LIBDIR= UAPIDIR= install \
+	cd $(LIBBPF)/src && /bin/bash ../../.dockerfiles/change_libbpf.sh $(VER_MAJOR) $(VER_MINOR) && $(MAKE) CC=$(CC_LIBBPF) CFLAGS="-fPIE" BUILD_STATIC_ONLY=1 DESTDIR=../../.local_libbpf INCLUDEDIR= LIBDIR= UAPIDIR= install \
 
 %_kern.o: %_kern.c libbpf
 	if [ -w $(KERNELSOURCE)/include/generated/autoconf.h ]; then  if [ "$(CURRENT_KERNEL)" -ge 328448 ]; then sed -i -e 's/\(#define CONFIG_CC_HAS_ASM_INLINE 1\)/\/\/\1/' $(KERNELSOURCE)/include/generated/autoconf.h; fi ; fi


### PR DESCRIPTION
##### Summary
More details after tests....
##### Test Plan
1. Clone this branch and run:
```sh
# make clean; make tester
```
2. Get binaries from this [link](https://github.com/netdata/kernel-collector/actions/runs/3751127189), and store inside a directory, for example, `artifacts`.
3. Extract them inside a directory:
```sh
$ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
$ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
```
4. Run the tests:
```sh
# for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../artifacts/ --content --iteration --pid $i --log-path file_pid$i.txt; done
``` 
5.  Verify that everything ran as expected:
 ```sh
# grep libbpf file_pid*
# grep Fail file_pid*

```

##### Additional information

This PR was tested on:

| Distribution | Kernel | Real Parent | Parent | All PIDs |
|-----------------|----------|------------------|----------|-------------|
| Slackware Current  |     5.19.17     |[slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/10280004/slackware_pid0.txt)| [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/10280005/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/10280006/slackware_pid2.txt)|
| Arch Linux | 6.0.12-arch1-1 | [arch_pid0.txt](https://github.com/netdata/kernel-collector/files/10280266/arch_pid0.txt) | [arch_pid1.txt](https://github.com/netdata/kernel-collector/files/10280267/arch_pid1.txt) | [arch_pid2.txt](https://github.com/netdata/kernel-collector/files/10280268/arch_pid2.txt) |
| Ubuntu 22.04 | 5.15.0-33-generic| [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/10280459/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/10280460/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/10280461/ubuntu_5_15_pid2.txt) | 
| Alma 9 | 5.14.0-162.6.1.el9_1.x86_64 | [alma_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/10280669/alma_5_14_pid0.txt) | [alma_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/10280670/alma_5_14_pid1.txt) | [alma_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/10280671/alma_5_14_pid2.txt) |
| Debian | 5.10.0-20-amd64 | [debian_pid0.txt](https://github.com/netdata/kernel-collector/files/10280864/debian_pid0.txt) | [debian_pid1.txt](https://github.com/netdata/kernel-collector/files/10280865/debian_pid1.txt) | [debian_pid2.txt](https://github.com/netdata/kernel-collector/files/10280866/debian_pid2.txt) | 
| Oracle | 5.4.17-2136.314.6.3.el8uek.x86_64 | [oracle_pid0.txt](https://github.com/netdata/kernel-collector/files/10281040/oracle_pid0.txt)  | [oracle_pid1.txt](https://github.com/netdata/kernel-collector/files/10281041/oracle_pid1.txt) | [oracle_pid2.txt](https://github.com/netdata/kernel-collector/files/10281042/oracle_pid2.txt)  |
| Alma 8 | 4.18.0-425.3.1.el8.x86_64 | [Alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/10281604/Alma_4_18_pid0.txt) | [Alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/10281605/Alma_4_18_pid1.txt) | [Alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/10281606/Alma_4_18_pid2.txt) | 
| Ubuntu 18.04 | 4.15.0-180-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/10282122/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/10282123/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/10282124/ubuntu_4_15_pid2.txt) | 
| Slackware current | 4.14.290 | [slackware_4_14_0.txt](https://github.com/netdata/kernel-collector/files/10282345/slackware_4_14_0.txt) | [slackware_4_14_1.txt](https://github.com/netdata/kernel-collector/files/10282346/slackware_4_14_1.txt)  | [slackware_4_14_2.txt](https://github.com/netdata/kernel-collector/files/10282347/slackware_4_14_2.txt) |
| CentOS 7.9 | 3.10.0-1160.71.1.el7.x86_64. |[centos_pid0.txt](https://github.com/netdata/kernel-collector/files/10282918/centos_pid0.txt) | [centos_pid1.txt](https://github.com/netdata/kernel-collector/files/10282919/centos_pid1.txt) | [centos_pid2.txt](https://github.com/netdata/kernel-collector/files/10282920/centos_pid2.txt) |
