### PR TITLE
Fix HARDIRQ on Debian family

### DIFF
--- a/includes/netdata_hardirq.h
+++ b/includes/netdata_hardirq.h
@@ -35,7 +35,11 @@ typedef struct hardirq_val {
     u64 ts;
 
     // identifies the IRQ with a human-readable string.
-    char name[NETDATA_HARDIRQ_NAME_LEN];
+    // We are reading it direct from /proc avoiding in some kernels:
+    //  #0  0x000055f9729eb725 in libbpf_err_errno ()
+    // #1  0x000055f9729ec8a0 in bpf_map_lookup_elem ()
+    // #2  0x000055f97298be21 in hardirq_read_latency_map (mapfd=69) at collectors/ebpf.plugin/ebpf_hardirq.c:259
+ //   char name[NETDATA_HARDIRQ_NAME_LEN];
 } hardirq_val_t;
 
 /************************************************************************************

--- a/includes/netdata_hardirq.h
+++ b/includes/netdata_hardirq.h
@@ -25,6 +25,7 @@ typedef struct hardirq_key {
     int irq;
 } hardirq_key_t;
 
+/*
 typedef struct hardirq_val {
     // incremental counter storing the total latency so far.
     u64 latency;
@@ -41,6 +42,7 @@ typedef struct hardirq_val {
     // #2  0x000055f97298be21 in hardirq_read_latency_map (mapfd=69) at collectors/ebpf.plugin/ebpf_hardirq.c:259
  //   char name[NETDATA_HARDIRQ_NAME_LEN];
 } hardirq_val_t;
+*/
 
 /************************************************************************************
  *                                HARDIRQ STATIC
@@ -76,7 +78,7 @@ enum netdata_hardirq_static {
     NETDATA_HARDIRQ_STATIC_END
 };
 
-typedef struct hardirq_static_val {
+typedef struct hardirq_val {
     // incremental counter storing the total latency so far.
     u64 latency;
 
@@ -84,6 +86,6 @@ typedef struct hardirq_static_val {
     // timestamp at the IRQ exit handler, to get the latency to add to the
     // `latency` field.
     u64 ts;
-} hardirq_static_val_t;
+} hardirq_val_t;
 
 #endif /* _NETDATA_HARDIRQ_H_ */

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -102,7 +102,7 @@ int netdata_irq_handler_exit(struct netdata_irq_handler_exit *ptr)
 int netdata_irq_ ##__type(struct netdata_irq_vectors_entry *ptr)              \
 {                                                                             \
     u32 idx;                                                                  \
-    hardirq_static_val_t *valp, val = {};                                     \
+    hardirq_val_t *valp, val = {};                                     \
                                                                               \
     idx = __enum_idx;                                                         \
     valp = bpf_map_lookup_elem(&tbl_hardirq_static, &idx);                    \
@@ -121,7 +121,7 @@ int netdata_irq_ ##__type(struct netdata_irq_vectors_entry *ptr)              \
 int netdata_irq_ ##__type(struct netdata_irq_vectors_exit *ptr)               \
 {                                                                             \
     u32 idx;                                                                  \
-    hardirq_static_val_t *valp;                                               \
+    hardirq_val_t *valp;                                               \
                                                                               \
     idx = __enum_idx;                                                         \
     valp = bpf_map_lookup_elem(&tbl_hardirq_static, &idx);                    \

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -68,7 +68,7 @@ int netdata_irq_handler_entry(struct netdata_irq_handler_entry *ptr)
     } else {
         val.latency = 0;
         val.ts = bpf_ktime_get_ns();
-        TP_DATA_LOC_READ_CONST(val.name, ptr, ptr->data_loc_name, NETDATA_HARDIRQ_NAME_LEN);
+        // TP_DATA_LOC_READ_CONST(val.name, ptr, ptr->data_loc_name, NETDATA_HARDIRQ_NAME_LEN);
         bpf_map_update_elem(&tbl_hardirq, &key, &val, BPF_ANY);
     }
 

--- a/kernel/hardirq_kern.c
+++ b/kernel/hardirq_kern.c
@@ -30,7 +30,7 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __type(key, __u32);
-    __type(value, hardirq_static_val_t);
+    __type(value, hardirq_val_t);
     __uint(max_entries, NETDATA_HARDIRQ_STATIC_END);
 } tbl_hardirq_static SEC(".maps");
 
@@ -46,7 +46,7 @@ struct bpf_map_def SEC("maps") tbl_hardirq = {
 struct bpf_map_def SEC("maps") tbl_hardirq_static = {
     .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
-    .value_size = sizeof(hardirq_static_val_t),
+    .value_size = sizeof(hardirq_val_t),
     .max_entries = NETDATA_HARDIRQ_STATIC_END
 };
 #endif


### PR DESCRIPTION
##### Summary
More details after tests..

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/4622606766) link and extract them inside a `directory`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/11163014/artifacts.zip).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../directory --content --iteration --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution | kernel version | real parent | parent |  all |
|--------------------|----------------|-------------|--------|------|
| Slackware Currentt  | 6.1.22       | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/11163255/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/11163256/slackware_6_1_pid1.txt) | [slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/11163257/slackware_6_1_pid2.txt) |
| Gentoo | 6.1.19-gentoo | [gentoo_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/11171947/gentoo_6_1_pid0.txt) | [gentoo_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/11171948/gentoo_6_1_pid1.txt) | [gentoo_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/11171949/gentoo_6_1_pid2.txt) | 
| Arch | 6.2.9-arch | [arch_2_9_pid0.txt](https://github.com/netdata/kernel-collector/files/11163426/arch_2_9_pid0.txt) | [arch_2_9_pid1.txt](https://github.com/netdata/kernel-collector/files/11163427/arch_2_9_pid1.txt) | [arch_2_9_pid2.txt](https://github.com/netdata/kernel-collector/files/11163428/arch_2_9_pid2.txt) | 
| Gentoo | 5.15.88-gentoo | [gentoo_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/11163865/gentoo_5_15_pid0.txt) | [gentoo_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/11163866/gentoo_5_15_pid1.txt) | [gentoo_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/11163867/gentoo_5_15_pid2.txt) |
| Ubuntu 22.04 | 5.15.0-56-generic |  [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/11164999/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/11165001/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/11165002/ubuntu_5_15_pid2.txt) | 
| Alma 9 | 5.14.0-162.22.2.el9_1.x86_64 | [alma_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/11165224/alma_5_14_pid0.txt) | [alma_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/11165226/alma_5_14_pid1.txt) | [alma_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/11165227/alma_5_14_pid2.txt) |
| Debian 11 | 5.10.0-21-amd64 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/11165323/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/11165324/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/11165325/debian_5_10_pid2.txt) | 
| Oracle 8.6 | 5.4.17-2136.317.5.3.el8uek.x86_64 | [oracle_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/11165518/oracle_5_4_pid0.txt) | [oracle_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/11165519/oracle_5_4_pid1.txt) | [oracle_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/11165520/oracle_5_4_pid2.txt) | 
| Alma 8.6 | 4.18.0-425.13.1.el8_7.x86_64 |  [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/11166018/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/11166020/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/11166021/alma_4_18_pid2.txt) | 
| Ubuntu 18.04 | 4.15.0-204-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/11165684/ubuntu_4_15_pid0.txt)  |  [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/11165685/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/11165686/ubuntu_4_15_pid2.txt) | 
| CentOS 7.9 | 3.10.0-1160.88.1.el7.x86_64  | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/11165813/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/11165814/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/11165815/centos_3_10_pid2.txt) | 

You can get all results in [this](https://github.com/netdata/kernel-collector/files/11166034/logs.zip) link.