### PR TITLE
Fix Disk and Socket changes

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -28,8 +28,6 @@ typedef struct netdata_socket {
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {
-    __u32 tgid;
-
     __u64 first;
     __u64 ct;
     __u64 bytes_sent;

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -18,11 +18,13 @@ typedef struct netdata_socket {
     __u64 sent_packets;
     __u64 recv_bytes;
     __u64 sent_bytes;
-    __u64 first; //First timestamp
-    __u64 ct;   //Current timestamp
-    __u32 retransmit; //It is never used with UDP
+    __u64 first;        //First timestamp
+    __u64 ct;           //Current timestamp
+    __u32 close;        //It is never used with UDP
+    __u32 retransmit;   //It is never used with UDP
     __u16 protocol;
     __u16 family;
+    __u32 reserved;
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {
@@ -38,7 +40,6 @@ typedef struct netdata_bandwidth {
     __u64 call_udp_sent;
     __u64 call_udp_received;
     __u64 close;
-    __u64 drop;
     __u32 ipv4_connect;
     __u32 ipv6_connect;
 } netdata_bandwidth_t;

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -22,7 +22,7 @@ typedef struct netdata_socket {
     __u64 ct;   //Current timestamp
     __u32 retransmit; //It is never used with UDP
     __u16 protocol;
-    __u16 reserved;
+    __u16 family;
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -28,7 +28,7 @@ typedef struct netdata_socket {
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {
-    __u32 pid;
+    __u32 tgid;
 
     __u64 first;
     __u64 ct;

--- a/kernel/disk_kern.c
+++ b/kernel/disk_kern.c
@@ -4,6 +4,10 @@
 #include <linux/genhd.h>
 #endif
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6,0,0))
+#include <linux/kdev_t.h>
+#endif
+
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 #include <uapi/linux/bpf.h>
 #else

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -27,11 +27,7 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u32);
     __type(value, netdata_bandwidth_t);
     __uint(max_entries, PID_MAX_DEFAULT);
@@ -45,33 +41,21 @@ struct {
 } tbl_global_sock SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, netdata_socket_idx_t);
     __type(value, netdata_socket_t);
     __uint(max_entries, 65536);
 } tbl_conn_ipv4 SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, netdata_socket_idx_t);
     __type(value, netdata_socket_t);
     __uint(max_entries, 65536);
 } tbl_conn_ipv6 SEC(".maps");
 
 struct {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
-    __uint(type, BPF_MAP_TYPE_HASH);
-#else
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-#endif
     __type(key, __u64);
     __type(value, void *);
     __uint(max_entries, 8192);

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -628,35 +628,5 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     return 0;
 }
 
-/************************************************************************************
- *
- *                           CLEAN UP SECTION
- *
- ***********************************************************************************/
-
-/**
- * Release task socket
- *
- * Removing a socket when it's no longer needed helps us reduce the default
- * size used with our tables.
- *
- * When a process stops so fast that apps.plugin or cgroup.plugin cannot detect it, we don't show
- * the information about the process, so it is safe to remove the information about the socket.
- */
-SEC("kprobe/release_task")
-int netdata_release_task_socket(struct pt_regs* ctx)
-{
-    netdata_bandwidth_t *removeme;
-    __u32 key = 0;
-    if (!monitor_apps(&socket_ctrl))
-        return 0;
-
-    removeme = (netdata_bandwidth_t *) netdata_get_pid_structure(&key, &socket_ctrl, &tbl_bandwidth);
-    if (removeme)
-        bpf_map_delete_elem(&tbl_bandwidth, &key);
-
-    return 0;
-}
-
 char _license[] SEC("license") = "GPL";
 

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -216,7 +216,7 @@ static __always_inline  void update_socket_table(struct pt_regs* ctx,
 static __always_inline void ebpf_socket_reset_bandwidth(__u32 pid, __u32 tgid)
 {
     netdata_bandwidth_t data = { };
-    data.pid = tgid;
+    data.tgid = tgid;
     data.first = bpf_ktime_get_ns();
 
     bpf_map_update_elem(&tbl_bandwidth, &pid, &data, BPF_ANY);
@@ -237,7 +237,7 @@ static __always_inline void update_pid_bandwidth(__u64 sent, __u64 received, __u
 
     b = (netdata_bandwidth_t *) bpf_map_lookup_elem(&tbl_bandwidth, &pid);
     if (b) {
-        if (b->pid != tgid)
+        if (b->tgid != tgid)
             ebpf_socket_reset_bandwidth(pid, tgid);
 
         b->ct = bpf_ktime_get_ns();
@@ -253,7 +253,7 @@ static __always_inline void update_pid_bandwidth(__u64 sent, __u64 received, __u
         } else
             libnetdata_update_u64(&b->retransmit, 1);
     } else {
-        data.pid = tgid;
+        data.tgid = tgid;
         data.first = bpf_ktime_get_ns();
         data.ct = data.first;
         if (sent) {
@@ -314,7 +314,7 @@ static __always_inline void update_pid_connection(__u8 version)
 
     stored = (netdata_bandwidth_t *) bpf_map_lookup_elem(&tbl_bandwidth, &key);
     if (stored) {
-        if (stored->pid != tgid)
+        if (stored->tgid != tgid)
             ebpf_socket_reset_bandwidth(key, tgid);
 
         stored->ct = bpf_ktime_get_ns();
@@ -324,7 +324,7 @@ static __always_inline void update_pid_connection(__u8 version)
         else
             libnetdata_update_u32(&stored->ipv6_connect, 1);
     } else {
-        data.pid = tgid;
+        data.tgid = tgid;
         data.first = bpf_ktime_get_ns();
         data.ct = data.first;
         if (version == 4)
@@ -351,12 +351,12 @@ static __always_inline void update_pid_cleanup(__u16 family)
 
     b = (netdata_bandwidth_t *) bpf_map_lookup_elem(&tbl_bandwidth, &pid);
     if (b) {
-        if (b->pid != tgid)
+        if (b->tgid != tgid)
             ebpf_socket_reset_bandwidth(pid, tgid);
 
         libnetdata_update_u64(&b->close, 1);
     } else {
-        data.pid = tgid;
+        data.tgid = tgid;
         data.first = bpf_ktime_get_ns();
         data.ct = data.first;
         data.close = 1;


### PR DESCRIPTION
##### Summary
This is the first PR modifying our eBPF programs to match product goals to have independent functions for all eBPF programs.

More details after tests.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/5514902934) link and extract them inside a `directory`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/12013800/artifacts.zip).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../directory --content --iteration --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution | kernel version | real parent | parent |  all |
|--------------------|----------------|-------------|--------|------|
| Slackware current | 6.1.38       |  [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12013949/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12013951/slackware_6_1_pid1.txt) | [slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12013952/slackware_6_1_pid2.txt) | 
| Arch Linux | 6.4.2-arch1-1 |  [arch_6_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12015315/arch_6_4_pid0.txt) | [arch_6_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12015316/arch_6_4_pid1.txt) | [arch_6_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12015317/arch_6_4_pid2.txt) | 
|Ubuntu 22.04 | 5.15.0-69-generic  | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12016052/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12016053/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12016054/ubuntu_5_15_pid2.txt) | 
| Alma 9 | 5.14.0-284.11.1.el9_2.x86_64 |  [alma9_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12017072/alma9_5_14_pid0.txt) | [alma9_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12017073/alma9_5_14_pid1.txt) | [alma9_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12017074/alma9_5_14_pid2.txt) |
| Oracle 9 | 5.14.0-284.11.1.el9_2.x86_64 | [oracle_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12018092/oracle_5_14_pid0.txt) | [oracle_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12018093/oracle_5_14_pid1.txt) | [oracle_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12018094/oracle_5_14_pid2.txt) | 
| Debian 11 | 5.10.179-1 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12018568/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12018569/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12018570/debian_5_10_pid2.txt) | 
| Ubuntu 20.04 | 5.4.0-146-generic | [ubuntu_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12021716/ubuntu_5_4_pid0.txt) | [ubuntu_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12021718/ubuntu_5_4_pid1.txt) | [ubuntu_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12021719/ubuntu_5_4_pid2.txt) |
| Debian 10 |  4.19.269-1 | [debian_4_19_pid0.txt](https://github.com/netdata/kernel-collector/files/12021957/debian_4_19_pid0.txt) | [debian_4_19_pid1.txt](https://github.com/netdata/kernel-collector/files/12021958/debian_4_19_pid1.txt) | [debian_4_19_pid2.txt](https://github.com/netdata/kernel-collector/files/12021959/debian_4_19_pid2.txt) |
|Ubuntu 18.04 | 4.15.0-208-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12022485/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12022486/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12022487/ubuntu_4_15_pid2.txt) | 
| Slackware current | 4.14.290 |  [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12023125/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12023126/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12023127/slackware_4_14_pid2.txt) | 
| CentOS 7.9 | 3.10 | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12023134/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12023135/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12023136/centos_3_10_pid2.txt) | 
