### PR TITLE
Update libbpf version (1.2.2)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,6 @@ You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SI
 
 This PR was tested on:
 
-| Linux Distribution | kernel version | real parent | parent |  all |
-|--------------------|----------------|-------------|--------|------|
-| LINUX DISTRIBUION  | uname -r       |             |        |      |
+| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All |
+|--------------------|----------------|---------------|-------------|--------|------|
+| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |      |

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -313,7 +313,7 @@ static __always_inline void update_pid_connection(__u8 version)
     }
 }
 
-static __always_inline void update_pid_cleanup(__u16 family)
+static __always_inline void update_pid_cleanup()
 {
     netdata_bandwidth_t *b;
     netdata_bandwidth_t data = { };
@@ -328,7 +328,6 @@ static __always_inline void update_pid_cleanup(__u16 family)
     } else {
         data.first = bpf_ktime_get_ns();
         data.ct = data.first;
-        data.family = family;
         data.close = 1;
 
         bpf_map_update_elem(&tbl_bandwidth, &key, &data, BPF_ANY);
@@ -471,7 +470,7 @@ int netdata_tcp_close(struct pt_regs* ctx)
     if (family == AF_UNSPEC)
         return 0;
 
-    update_pid_cleanup(family);
+    update_pid_cleanup();
 
     netdata_socket_t *val = (netdata_socket_t *) bpf_map_lookup_elem(&tbl_nd_socket, &idx);
     if (val) {

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -308,6 +308,8 @@ static __always_inline void update_pid_connection(__u8 version)
             data.ipv6_connect = 1;
 
         bpf_map_update_elem(&tbl_bandwidth, &key, &data, BPF_ANY);
+
+        libnetdata_update_global(&socket_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
     }
 }
 
@@ -376,6 +378,8 @@ int netdata_inet_csk_accept(struct pt_regs* ctx)
         data.pid = pid;
         data.counter = 1;
         bpf_map_update_elem(&tbl_lports, &idx, &data, BPF_ANY);
+
+        libnetdata_update_global(&socket_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
     }
 
     return 0;

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -328,6 +328,7 @@ static __always_inline void update_pid_cleanup(__u16 family)
     } else {
         data.first = bpf_ktime_get_ns();
         data.ct = data.first;
+        data.family = family;
         data.close = 1;
 
         bpf_map_update_elem(&tbl_bandwidth, &key, &data, BPF_ANY);


### PR DESCRIPTION
##### Summary
This PR is updating libbpf locally.
More details after tests...

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/5532840058) link and extract them inside a `directory`.
You can also get everything for glibc  using [this](https://github.com/netdata/kernel-collector/files/12029994/artifacts.zip) link.


2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../directory --content --iteration --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All |
|--------------------|----------------|---------------|-------------|--------|------|
| Slackware current  | Bare metal  | 6.1.38      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12031213/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12031214/slackware_6_1_pid1.txt) | [slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12031215/slackware_6_1_pid2.txt)  |
|Arch Linux | libvirt | 6.4.2-arch1-1 | [arch_6_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12041716/arch_6_4_pid0.txt) |  [arch_6_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12041718/arch_6_4_pid1.txt) |  [arch_6_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12041719/arch_6_4_pid2.txt)| 
| Ubuntu 22.04 | libvirt | 5.15.0-69-generic | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12045126/ubuntu_5_15_pid0.txt)  | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12045127/ubuntu_5_15_pid1.txt)  | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12045129/ubuntu_5_15_pid2.txt) |
| Alma 9 | libvirt | 5.14.0-284.11.1.el9_2.x86_64 |[alma9_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12045361/alma9_5_14_pid0.txt) |[alma9_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12045362/alma9_5_14_pid1.txt) | [alma9_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12045363/alma9_5_14_pid2.txt) |
|Oracle 9 | libvirt | 5.14.0-284.11.1.el9_2.x86_64 |[oracle_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12053799/oracle_5_14_pid0.txt)| [oracle_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12053800/oracle_5_14_pid1.txt) | [oracle_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12053801/oracle_5_14_pid2.txt) |
| Debian 11 | libvirt | 5.10.179-1 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12059501/debian_5_10_pid0.txt) |[debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12059502/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12059503/debian_5_10_pid2.txt) |
|Ubuntu 20.04 | libvirt | 5.4.0-146-generic |[ubuntu_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12061425/ubuntu_5_4_pid0.txt) |[ubuntu_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12061426/ubuntu_5_4_pid1.txt) |[ubuntu_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12061427/ubuntu_5_4_pid2.txt) |
|Debian 10 | libvirt | 4.19.269-1 | [debian_4_19_pid0.txt](https://github.com/netdata/kernel-collector/files/12062457/debian_4_19_pid0.txt) | [debian_4_19_pid1.txt](https://github.com/netdata/kernel-collector/files/12062458/debian_4_19_pid1.txt) | [debian_4_19_pid2.txt](https://github.com/netdata/kernel-collector/files/12062459/debian_4_19_pid2.txt) |
|Alma 8.6 | libvirtt | 4.18.0-477.13.1.el8_8.x86_64 | [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/12059549/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/12059551/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/12059552/alma_4_18_pid2.txt) | 
|Ubuntu 18.04 | libvirt | 4.15.0-208-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12062483/ubuntu_4_15_pid0.txt)| [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12062484/ubuntu_4_15_pid1.txt) |[ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12062485/ubuntu_4_15_pid2.txt) |
| Slackware current | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12062703/slackware_4_14_pid0.txt)|[slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12062704/slackware_4_14_pid1.txt) |[slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12062705/slackware_4_14_pid2.txt) | 
| CentOS | libbpf | 3.10 | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12062812/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12062813/centos_3_10_pid1.txt) |  [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12062814/centos_3_10_pid2.txt) | 