### PR TITLE
Update Socket

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -29,6 +29,8 @@ typedef struct netdata_socket {
         __u64 tcp_bytes_received;
         __u32 close;        //It is never used with UDP
         __u32 retransmit;   //It is never used with UDP
+        __u32 ipv4_connect;
+        __u32 ipv6_connect;
     } tcp;
     // Number of calls
     struct {
@@ -37,8 +39,6 @@ typedef struct netdata_socket {
         __u64 udp_bytes_sent;
         __u64 udp_bytes_received;
     } udp;
-    __u32 ipv4_connect;
-    __u32 ipv6_connect;
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -14,17 +14,31 @@ union netdata_ip {
 };
 
 typedef struct netdata_socket {
-    __u64 recv_packets;
-    __u64 sent_packets;
-    __u64 recv_bytes;
-    __u64 sent_bytes;
+    // Timestamp
     __u64 first;        //First timestamp
     __u64 ct;           //Current timestamp
-    __u32 close;        //It is never used with UDP
-    __u32 retransmit;   //It is never used with UDP
+    // Socket additional info
     __u16 protocol;
     __u16 family;
-    __u32 reserved;
+    // Stats
+    // Number of bytes
+    struct {
+        __u32 call_tcp_sent;
+        __u32 call_tcp_received;
+        __u64 tcp_bytes_sent;
+        __u64 tcp_bytes_received;
+        __u32 close;        //It is never used with UDP
+        __u32 retransmit;   //It is never used with UDP
+    } tcp;
+    // Number of calls
+    struct {
+        __u32 call_udp_sent;
+        __u32 call_udp_received;
+        __u64 udp_bytes_sent;
+        __u64 udp_bytes_received;
+    } udp;
+    __u32 ipv4_connect;
+    __u32 ipv6_connect;
 } netdata_socket_t;
 
 typedef struct netdata_bandwidth {

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -48,6 +48,7 @@ typedef struct netdata_socket_idx {
     __u16 sport;
     union netdata_ip daddr;
     __u16 dport;
+    __u32 pid;
 } netdata_socket_idx_t;
 
 typedef struct netdata_passive_connection {

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -156,6 +156,8 @@ static __always_inline __u16 set_idx_value(netdata_socket_idx_t *nsi, struct ine
     bpf_probe_read(&nsi->sport, sizeof(u16), &is->inet_num);
     nsi->sport = ntohs(nsi->sport);
 
+    nsi->pid =  netdata_get_current_pid();
+
     return family;
 }
 

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -27,13 +27,6 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-    __type(key, __u32);
-    __type(value, netdata_bandwidth_t);
-    __uint(max_entries, PID_MAX_DEFAULT);
-} tbl_bandwidth SEC(".maps");
-
-struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __type(key, __u32);
     __type(value, __u64);
@@ -51,7 +44,7 @@ struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
     __type(key, __u64);
     __type(value, void *);
-    __uint(max_entries, 8192);
+    __uint(max_entries, 4096);
 } tbl_nv_udp SEC(".maps");
 
 struct {
@@ -69,14 +62,6 @@ struct {
 } socket_ctrl SEC(".maps");
 
 #else
-
-struct bpf_map_def SEC("maps") tbl_bandwidth = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(netdata_bandwidth_t),
-    .max_entries = PID_MAX_DEFAULT
-};
-
 struct bpf_map_def SEC("maps") tbl_global_sock = {
     .type = BPF_MAP_TYPE_PERCPU_ARRAY,
     .key_size = sizeof(__u32),
@@ -95,7 +80,7 @@ struct bpf_map_def SEC("maps") tbl_nv_udp = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(__u64),
     .value_size = sizeof(void *),
-    .max_entries = 8192
+    .max_entries = 4096
 };
 
 struct bpf_map_def SEC("maps") tbl_lports = {

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -563,6 +563,8 @@ int trace_udp_ret_recvmsg(struct pt_regs* ctx)
 
     update_pid_bandwidth(0, received, IPPROTO_UDP);
 
+    update_socket_table(ctx, 0, received, 0, IPPROTO_UDP);
+
     return 0;
 }
 
@@ -591,6 +593,8 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_BYTES_UDP_SENDMSG, (__u64) sent);
 
     update_pid_bandwidth((__u64) sent, 0, IPPROTO_UDP);
+
+    update_socket_table(ctx, sent, 0, 0, IPPROTO_UDP);
 
     return 0;
 }


### PR DESCRIPTION
##### Summary
While I was updating socket in `netdata/netdata`, I observed that we could simplify even more the socket program, so this PR is addressing this.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/5627027207) link and extract them inside a `directory`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/12134990/artifacts.zip).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../directory --content --iteration --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All |
|--------------------|----------------|---------------|-------------|--------|------|
| Slackware Current  | Bare metal  | 6.1.38      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12135052/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12135053/slackware_6_1_pid1.txt) |[slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12135054/slackware_6_1_pid2.txt)|
| Arch Linux | Libvirt VM | 6.4.3-arch1-1 | [arch_6_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12135212/arch_6_4_pid0.txt) | [arch_6_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12135213/arch_6_4_pid1.txt) | [arch_6_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12135214/arch_6_4_pid2.txt) | 
| Ubuntu 22.04 | Libvirt | 5.15.0-76-generic | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12135303/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12135304/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12135305/ubuntu_5_15_pid2.txt) |
| Alma 9 | Libvirt | 5.14.0-284.18.1.el9_2.x86_64  |[alma9_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12136118/alma9_5_14_pid0.txt) | [alma9_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12136119/alma9_5_14_pid1.txt) | [alma9_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12136120/alma9_5_14_pid2.txt) | 
| Oracle 9 | Libvir | 5.14.0-284.11.1.el9_2.x86_64 | [oracle_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12136572/oracle_5_14_pid0.txt) |  [oracle_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12136573/oracle_5_14_pid1.txt) | [oracle_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12136574/oracle_5_14_pid2.txt)  
| Debian 11 | Libvirt VM | 5.10.0-23-amd64| [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12135333/debian_5_10_pid0.txt) |  [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12135334/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12135335/debian_5_10_pid2.txt) | 
| Ubuntu 20.04 | Libvirt VM | 5.4.0-146-generic|  [ubuntu_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12135369/ubuntu_5_4_pid0.txt) | [ubuntu_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12135370/ubuntu_5_4_pid1.txt) | [ubuntu_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12135371/ubuntu_5_4_pid2.txt) |
|Alma 8.6 | Libvirt VM | 4.18.0-477.13.1.el8_8.x86_64 |  [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/12135422/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/12135423/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/12135424/alma_4_18_pid2.txt) | 
| Ubuntu 18.04 | Libvirt | 4.15.0-208-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12135079/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12135080/ubuntu_4_15_pid1.txt) |[ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12135081/ubuntu_4_15_pid2.txt) |
| Slackware current | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12135149/slackware_4_14_pid0.txt) |[slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12135150/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12135151/slackware_4_14_pid2.txt) | 
| CentOS 7.9 | Libvirt | 3.10.0-1160.92.1.el7.x86_64 | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12135153/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12135154/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12135155/centos_3_10_pid2.txt) | 