### PR TITLE
Missing variable set

### DIFF
--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -254,6 +254,7 @@ static __always_inline void update_pid_connection(struct pt_regs* ctx)
     if (family == AF_UNSPEC)
         return;
 
+    stored = (netdata_socket_t *) bpf_map_lookup_elem(&tbl_nd_socket, &idx);
     if (stored) {
         stored->ct = bpf_ktime_get_ns();
 


### PR DESCRIPTION
##### Summary
Quick fix to update sockets already stored.
##### Test Plan
1. Get binaries according your LIBC from [this](ADD ACTIONS LINK HERE) link and extract them inside a `directory`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 2`; do ./kernel/legacy_test --netdata-path ../directory --content --iteration --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All |
|--------------------|----------------|---------------|-------------|--------|------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |      |
