### PR TITLE
Restrict loopback addr

### DIFF
--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -171,10 +171,11 @@ static __always_inline __u32 netdata_get_pid(void *ctrl_tbl)
             return netdata_get_parent_pid();
         else if (*level == NETDATA_APPS_LEVEL_ALL)
             return netdata_get_current_pid();
+        else if (*level == NETDATA_APPS_LEVEL_IGNORE) // Ignore PID
+            return 0;
     }
 
-    // I do not care for PID, so group them
-    return 0;
+    return netdata_get_real_parent_pid();
 }
 
 static __always_inline void *netdata_get_pid_structure(__u32 *store_pid, void *ctrl_tbl, void *pid_tbl)


### PR DESCRIPTION
##### Summary
More details after final tests
##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/5834973565) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/12318150/artifacts.zip).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware Current  | Bare metal  | 6.1.43      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12318185/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12318186/slackware_6_1_pid1.txt) |[slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12318187/slackware_6_1_pid2.txt) |[slackware_6_1_pid3.txt](https://github.com/netdata/kernel-collector/files/12318188/slackware_6_1_pid3.txt)|
| Arch Linux | libvirt | 6.4.9 |[arch_6_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12322413/arch_6_4_pid0.txt) | [arch_6_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12322414/arch_6_4_pid1.txt) | [arch_6_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12322416/arch_6_4_pid2.txt) | [arch_6_4_pid3.txt](https://github.com/netdata/kernel-collector/files/12322417/arch_6_4_pid3.txt) | 
|Alma 9 | libvirt | 5.14.0-284.25.1.el9_2.x86_64 | [alma9_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12323165/alma9_5_14_pid0.txt) | [alma9_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12323166/alma9_5_14_pid1.txt) | [alma9_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12323167/alma9_5_14_pid2.txt) | [alma9_5_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12323168/alma9_5_14_pid3.txt) | 
| Debian 11 | libvirt | 5.10.179-3 |[debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12322681/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12322682/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12322683/debian_5_10_pid2.txt) | [debian_5_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12322684/debian_5_10_pid3.txt) | 
| Ubuntu  | Libvirt | 4.15 | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12318408/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12318409/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12318410/ubuntu_4_15_pid2.txt) |[ubuntu_4_15_pid3.txt](https://github.com/netdata/kernel-collector/files/12318411/ubuntu_4_15_pid3.txt) |
| Slackware Current | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12318251/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12318252/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12318253/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12318254/slackware_4_14_pid3.txt) | 