### PR TITLE
Speed socket

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -29,12 +29,12 @@ typedef struct netdata_socket {
         __u64 tcp_bytes_received;
         __u32 close;        //It is never used with UDP
         __u32 retransmit;   //It is never used with UDP
-        __u32 ipv4_connect;
-        __u32 ipv6_connect;
+        __u32 ipv4_connect; // Use to count new connections
+        __u32 ipv6_connect; // Use to count new connections
     } tcp;
     // Number of calls
     struct {
-        __u32 call_udp_sent;
+        __u32 call_udp_sent; // Use to count new connections
         __u32 call_udp_received;
         __u64 udp_bytes_sent;
         __u64 udp_bytes_received;

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -59,7 +59,7 @@ typedef struct netdata_bandwidth {
 // Index used together previous structure
 typedef struct netdata_socket_idx {
     union netdata_ip saddr;
-    __u16 sport;
+    //__u16 sport;
     union netdata_ip daddr;
     __u16 dport;
     __u32 pid;

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -144,11 +144,12 @@ static __always_inline __u16 set_idx_value(netdata_socket_idx_t *nsi, struct ine
 
     //Read destination port
     bpf_probe_read(&nsi->dport, sizeof(u16), &is->inet_dport);
-    bpf_probe_read(&nsi->sport, sizeof(u16), &is->inet_num);
+ //   bpf_probe_read(&nsi->sport, sizeof(u16), &is->inet_num);
 
     // Socket for nowhere or system looking for port
     // This can be an attack vector that needs to be addressed in another opportunity
-    if (nsi->sport == 0 || nsi->dport == 0)
+    //if (nsi->sport == 0 || nsi->dport == 0)
+    if (nsi->dport == 0)
         return AF_UNSPEC;
 
 


### PR DESCRIPTION
##### Summary
After a talk with product team and to have a more clear picture about what we are going to deliver, we are creating this PR that will reduce I/O events in kernel ring.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/5965001864) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/12432198/artifacts.zip).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.1.46      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12431919/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12431920/slackware_6_1_pid1.txt) | [slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12431921/slackware_6_1_pid2.txt) | [slackware_6_1_pid3.txt](https://github.com/netdata/kernel-collector/files/12431922/slackware_6_1_pid3.txt) |
| Arch Linux | Libvirt | 6.4.11-arch2-1 | [arch_6_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12431937/arch_6_4_pid0.txt) | [arch_6_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12431938/arch_6_4_pid1.txt) | [arch_6_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12431939/arch_6_4_pid2.txt) | [arch_6_4_pid3.txt](https://github.com/netdata/kernel-collector/files/12431940/arch_6_4_pid3.txt) | 
| Slackware current  | Qemu  | 4.14.290      | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12431915/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12431916/slackware_4_14_pid1.txt)| [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12431917/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12431918/slackware_4_14_pid3.txt) |
|CentOS 7.9 | Libvirt |3.10 | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12432171/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12432172/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12432173/centos_3_10_pid2.txt) | [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12432174/centos_3_10_pid3.txt) | 
