### PR TITLE
Network Viewer basis

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -15,11 +15,14 @@ union netdata_ip {
 
 typedef struct netdata_socket {
     // Timestamp
-    __u64 first;        //First timestamp
-    __u64 ct;           //Current timestamp
+    __u64 first;        // First timestamp
+    __u64 ct;           // Current timestamp
     // Socket additional info
     __u16 protocol;
     __u16 family;
+    __u32 external_origin;       // We are using only lower bits, so if it is
+                                 // necessary to store more info, this shoud be
+                                 // split in two __u16.
     // Stats
     // Number of bytes
     struct {

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -351,7 +351,7 @@ int netdata_inet_csk_accept(struct pt_regs* ctx)
 
     val = (netdata_socket_t *) bpf_map_lookup_elem(&tbl_nd_socket, &nv_idx);
     if (val) {
-        val->external_origin = 1;
+        libnetdata_update_u32(&val->external_origin, 1);
     } else {
         nv_data.first = bpf_ktime_get_ns();
         nv_data.ct = nv_data.first;

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -340,6 +340,28 @@ int netdata_inet_csk_accept(struct pt_regs* ctx)
         libnetdata_update_global(&socket_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
     }
 
+    struct inet_sock *is = inet_sk(sk);
+    netdata_socket_idx_t nv_idx = { };
+    __u16 family = set_idx_value(&nv_idx, is);
+    if (family == AF_UNSPEC)
+        return 0;
+
+    netdata_socket_t *val;
+    netdata_socket_t nv_data = { };
+
+    val = (netdata_socket_t *) bpf_map_lookup_elem(&tbl_nd_socket, &nv_idx);
+    if (val) {
+        val->external_origin = 1;
+    } else {
+        nv_data.first = bpf_ktime_get_ns();
+        nv_data.ct = nv_data.first;
+        nv_data.protocol = protocol;
+        nv_data.family = family;
+        nv_data.external_origin = 1;
+
+        bpf_map_update_elem(&tbl_nd_socket, &nv_idx, &nv_data, BPF_ANY);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
##### Summary
After our last demo, we discuss the basis to have our network viewer. This PR bringing necessary changes to have charts we discussed.

More details after tests..

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/6076592333) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/12515981/artifacts.zip)

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --socket --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackwre current  | Bare metal  | 6.1.51      | [slackwar_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12516700/slackwar_6_1_pid0.txt) | [slackwar_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12516701/slackwar_6_1_pid1.txt) | [slackwar_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12516702/slackwar_6_1_pid2.txt) |[slackwar_6_1_pid3.txt](https://github.com/netdata/kernel-collector/files/12516704/slackwar_6_1_pid3.txt)|
|Arch | Libvirt | 6.4.12-arch1-1 | [arch_6_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12517013/arch_6_4_pid0.txt) | [arch_6_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12517014/arch_6_4_pid1.txt) | [arch_6_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12517015/arch_6_4_pid2.txt) | [arch_6_4_pid3.txt](https://github.com/netdata/kernel-collector/files/12517016/arch_6_4_pid3.txt) | 
|Debian 11 | Libvirt | 5.10.191-1 |[debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12517128/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12517129/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12517130/debian_5_10_pid2.txt) | [debian_5_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12517131/debian_5_10_pid3.txt) | 
| Ubuntu 18.04 | Libvirt | 4.15.0-208-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12516945/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12516946/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12516947/ubuntu_4_15_pid2.txt) | [ubuntu_4_15_pid3.txt](https://github.com/netdata/kernel-collector/files/12516948/ubuntu_4_15_pid3.txt) |
|Slackware current | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12516894/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12516896/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12516897/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12516898/slackware_4_14_pid3.txt) | 