### PR TITLE
VFS functions

### DIFF
--- a/includes/netdata_vfs.h
+++ b/includes/netdata_vfs.h
@@ -3,8 +3,13 @@
 #ifndef _NETDATA_VFS_H_
 #define _NETDATA_VFS_H_ 1
 
+#include <linux/sched.h>
+
 struct netdata_vfs_stat_t {
     __u64 ct;
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    char name[TASK_COMM_LEN];
+#endif
 
     //Counter
     __u32 write_call;                   

--- a/includes/netdata_vfs.h
+++ b/includes/netdata_vfs.h
@@ -4,9 +4,7 @@
 #define _NETDATA_VFS_H_ 1
 
 struct netdata_vfs_stat_t {
-    __u64 pid_tgid;                     
-    __u32 pid;                          
-    __u32 pad;                          
+    __u64 ct;
 
     //Counter
     __u32 write_call;                   

--- a/kernel/tester_user.c
+++ b/kernel/tester_user.c
@@ -788,7 +788,7 @@ static void ebpf_fill_ctrl(struct bpf_object *obj, char *ctrl)
         const struct bpf_map_def *def = bpf_map__def(map);
         end = def->max_entries;
 #endif
-        uint32_t values[NETDATA_CONTROLLER_END] = { 1, map_level};
+        uint32_t values[NETDATA_CONTROLLER_END] = { 1, map_level, 0, 0, 0, 0};
         for (i = 0; i < end; i++) {
              int ret = bpf_map_update_elem(fd, &i, &values[i], 0);
              if (ret)
@@ -816,7 +816,7 @@ static void ebpf_fill_ctrl(struct bpf_object *obj, char *ctrl)
  *
  * @return It returns 'Success' or 'Fail' depending of final result.
  */
-static char *ebpf_tester(char *filename, ebpf_specify_name_t *names, int maps, char *ctrl)
+static char *ebpf_tester(char *filename, ebpf_specify_name_t *names, uint32_t maps, char *ctrl)
 {
     static char *result[] = { "Success", "Fail" };
 

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -68,21 +68,6 @@ struct bpf_map_def SEC("maps") vfs_ctrl = {
 #endif
 
 /************************************************************************************
- *
- *                                Local Function Section
- *
- ***********************************************************************************/
-
-static inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
-{
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-
-    data->pid_tgid = pid_tgid;
-    data->pid = tgid;
-}
-
-/************************************************************************************
  *     
  *                                   FILE Section
  *     
@@ -132,7 +117,7 @@ int netdata_sys_write(struct pt_regs* ctx)
         }
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -198,7 +183,7 @@ int netdata_sys_writev(struct pt_regs* ctx)
         }
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -264,7 +249,7 @@ int netdata_sys_read(struct pt_regs* ctx)
         }
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -331,7 +316,7 @@ int netdata_sys_readv(struct pt_regs* ctx)
         }
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -387,7 +372,7 @@ int netdata_sys_unlink(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -443,7 +428,7 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -499,7 +484,7 @@ int netdata_vfs_open(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -555,7 +540,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
         } 
 #endif
     } else {
-        netdata_fill_common_vfs_data(&data);
+        data.ct = bpf_ktime_get_ns();
 
 #if NETDATASEL < 2
         if (ret < 0) {

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -576,32 +576,5 @@ int netdata_vfs_create(struct pt_regs* ctx)
     return 0;
 }
 
-/**
- * Release task
- *
- * Removing a pid when it's no longer needed helps us reduce the default
- * size used with our tables.
- *
- * When a process stops so fast that apps.plugin or cgroup.plugin cannot detect it, we don't show
- * the information about the process, so it is safe to remove the information about the table.
- */
-SEC("kprobe/release_task")
-int netdata_release_task_vfs(struct pt_regs* ctx)
-{
-    struct netdata_vfs_stat_t *removeme;
-    __u32 key = 0;
-    if (!monitor_apps(&vfs_ctrl))
-        return 0;
-
-    removeme = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
-    if (removeme) {
-        bpf_map_delete_elem(&tbl_vfs_pid, &key);
-
-        libnetdata_update_global(&vfs_ctrl, NETDATA_CONTROLLER_PID_TABLE_DEL, 1);
-    }
-
-    return 0;
-}
-
 char _license[] SEC("license") = "GPL";
 

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -118,6 +118,9 @@ int netdata_sys_write(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -184,6 +187,9 @@ int netdata_sys_writev(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -250,6 +256,9 @@ int netdata_sys_read(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -317,6 +326,9 @@ int netdata_sys_readv(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -373,6 +385,9 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -429,6 +444,9 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -485,6 +503,9 @@ int netdata_vfs_open(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {
@@ -541,6 +562,9 @@ int netdata_vfs_create(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+        bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#endif
 
 #if NETDATASEL < 2
         if (ret < 0) {


### PR DESCRIPTION
##### Summary
We are staring with this PR a new cycle to bring a new eBPF function for netdata, this time the focus is VFS that is also a function that consumes a lot of resources from host.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/6150176835) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).


2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --vfs --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.1.52      | [slackware_6_1_0.txt](https://github.com/netdata/kernel-collector/files/12579425/slackware_6_1_0.txt) | [slackware_6_1_1.txt](https://github.com/netdata/kernel-collector/files/12579426/slackware_6_1_1.txt) | [slackware_6_1_3.txt](https://github.com/netdata/kernel-collector/files/12579427/slackware_6_1_3.txt) | [slackware_6_1_2.txt](https://github.com/netdata/kernel-collector/files/12579428/slackware_6_1_2.txt) | 
| Arch Linux | Libvirt| 6.5.2-arch1-1| [arch_6_5_pid0.txt](https://github.com/netdata/kernel-collector/files/12581562/arch_6_5_pid0.txt) | [arch_6_5_pid1.txt](https://github.com/netdata/kernel-collector/files/12581563/arch_6_5_pid1.txt) | [arch_6_5_pid2.txt](https://github.com/netdata/kernel-collector/files/12581564/arch_6_5_pid2.txt) | [arch_6_5_pid3.txt](https://github.com/netdata/kernel-collector/files/12581565/arch_6_5_pid3.txt) |
| Oracle 9 | Libvirt | 5.14.0-284.25.1.0.1.el9_2.x86_64| [oracle_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12581068/oracle_5_14_pid0.txt) | [oracle_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12581069/oracle_5_14_pid1.txt) | [oracle_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12581070/oracle_5_14_pid2.txt) | [oracle_5_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12581071/oracle_5_14_pid3.txt) | 
| Debian 11 | libvirt | 5.10.191-1 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12580892/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12580893/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12580894/debian_5_10_pid2.txt) | [debian_5_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12580895/debian_5_10_pid3.txt) | 
| Ubuntu 20.04  | Libvirt | 5.4.0-146-generic | [ubuntu_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12580741/ubuntu_5_4_pid0.txt)  | [ubuntu_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12580742/ubuntu_5_4_pid1.txt) | [ubuntu_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12580743/ubuntu_5_4_pid2.txt) | [ubuntu_5_4_pid3.txt](https://github.com/netdata/kernel-collector/files/12580744/ubuntu_5_4_pid3.txt) |
| Alma 8 | Libvirt | 4.18.0-477.21.1.el8_8.x86_64 | [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/12580627/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/12580628/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/12580629/alma_4_18_pid2.txt) | [alma_4_18_pid3.txt](https://github.com/netdata/kernel-collector/files/12580630/alma_4_18_pid3.txt) | 
| Ubuntu 18.04 | Libvirt |4.15.0-208-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12580208/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12580209/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12580211/ubuntu_4_15_pid2.txt) | [ubuntu_4_15_pid3.txt](https://github.com/netdata/kernel-collector/files/12580212/ubuntu_4_15_pid3.txt) | 
| Slackware current | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12579583/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12579584/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12579585/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12579586/slackware_4_14_pid3.txt) | 
| CentOS 7.9 | Libvirt | 3.10.0-1160.92.1.el7.x86_64 | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12579668/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12579669/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12579670/centos_3_10_pid2.txt) | [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12579671/centos_3_10_pid3.txt) | 