### PR TITLE
Remove Macro

### DIFF
--- a/includes/netdata_vfs.h
+++ b/includes/netdata_vfs.h
@@ -7,9 +7,7 @@
 
 struct netdata_vfs_stat_t {
     __u64 ct;
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
     char name[TASK_COMM_LEN];
-#endif
 
     //Counter
     __u32 write_call;                   

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -120,6 +120,8 @@ int netdata_sys_write(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -189,6 +191,8 @@ int netdata_sys_writev(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -258,6 +262,8 @@ int netdata_sys_read(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -328,6 +334,8 @@ int netdata_sys_readv(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -387,6 +395,8 @@ int netdata_sys_unlink(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -446,6 +456,8 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -505,6 +517,8 @@ int netdata_vfs_open(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2
@@ -564,6 +578,8 @@ int netdata_vfs_create(struct pt_regs* ctx)
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
+#else
+        data.name[0] = '\0';
 #endif
 
 #if NETDATASEL < 2


### PR DESCRIPTION
##### Summary
Change  macro avoiding necessity to modify codes in `ebpf-co-re` repo.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/6164634902) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --vfs --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.1.52      | [slackware_6_1_0.txt](https://github.com/netdata/kernel-collector/files/12591128/slackware_6_1_0.txt) | [slackware_6_1_1.txt](https://github.com/netdata/kernel-collector/files/12591129/slackware_6_1_1.txt) | [slackware_6_1_2.txt](https://github.com/netdata/kernel-collector/files/12591130/slackware_6_1_2.txt) | [slackware_6_1_3.txt](https://github.com/netdata/kernel-collector/files/12591131/slackware_6_1_3.txt) | 
| CentOS 7.9 | Libvirt | 3.10 | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12591186/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12591187/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12591188/centos_3_10_pid2.txt) | [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12591189/centos_3_10_pid3.txt) | 
