### PR TITLE
Explicit TGID

### DIFF
--- a/includes/netdata_process.h
+++ b/includes/netdata_process.h
@@ -32,8 +32,8 @@ struct netdata_pid_stat_t {
     __u64 ct;
     char name[TASK_COMM_LEN];
 
-    __u64 pid_tgid;                     //Unique identifier
-    __u32 pid;                          //process id
+    __u32 tgid;                         //Task id
+    __u32 pid;                          //Process id
 
     //Counter
     __u32 exit_call;                    //Exit syscalls (exit for exit_group)

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -79,6 +79,7 @@ static inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *d
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+    __u32 pid = (__u32) pid_tgid>>32;
 
     data->ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
@@ -87,8 +88,8 @@ static inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *d
     data->name[0] = '\0';
 #endif
 
-    data->pid_tgid = pid_tgid;
-    data->pid = tgid;
+    data->tgid = tgid;
+    data->pid = pid;
 }
 
 /************************************************************************************


### PR DESCRIPTION
##### Summary
While I was developing `ebpf_process` function it called my attention the number of  processes started by other processes. After to debug the event, I decided to also explicit TGID in this eBPF program, helping developers to understand better their own software.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/6292825746) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --process --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware Current  | Bare metal  | 6.1.54      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12709848/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12709849/slackware_6_1_pid1.txt)|[slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12709850/slackware_6_1_pid2.txt) |  [slackware_6_1_pid3.txt](https://github.com/netdata/kernel-collector/files/12709851/slackware_6_1_pid3.txt) |
|Slackwarre Currentt | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12709887/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12709888/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12709889/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12709890/slackware_4_14_pid3.txt) |
|CentOS 7.9 | Libvirt | 3.10.0-1160.95.1.el7.x86_64| [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12710034/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12710036/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12710037/centos_3_10_pid2.txt) | [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12710038/centos_3_10_pid3.txt) | 
