### PR TITLE
Update DC

### DIFF
--- a/includes/netdata_dc.h
+++ b/includes/netdata_dc.h
@@ -4,6 +4,10 @@
 #define _NETDATA_DIRECTORY_CACHE_H_ 1
 
 typedef struct netdata_dc_stat {
+    __u64 ct;
+    char name[TASK_COMM_LEN];
+
+
     __u64 references;
     __u64 slow;
     __u64 missed;


### PR DESCRIPTION
##### Summary
More details after tests...
##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/6345995038) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --dc --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.1.55      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12772527/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12772528/slackware_6_1_pid1.txt) |[slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12772529/slackware_6_1_pid2.txt) |[slackware_6_1_pid3.txt](https://github.com/netdata/kernel-collector/files/12772530/slackware_6_1_pid3.txt)|
|Arch Linux | Libvirt| 6.5.5-arch1-1 | [arch_6_5_5_pid0.txt](https://github.com/netdata/kernel-collector/files/12772534/arch_6_5_5_pid0.txt) | [arch_6_5_5_pid1.txt](https://github.com/netdata/kernel-collector/files/12772536/arch_6_5_5_pid1.txt) |  [arch_6_5_5_pid2.txt](https://github.com/netdata/kernel-collector/files/12772537/arch_6_5_5_pid2.txt) | [arch_6_5_5_pid3.txt](https://github.com/netdata/kernel-collector/files/12772538/arch_6_5_5_pid3.txt) | 
|Ubuntu 22.04 | Libvirt | 5.15.0-76-generic | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12772702/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12772703/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12772704/ubuntu_5_15_pid2.txt) | [ubuntu_5_15_pid3.txt](https://github.com/netdata/kernel-collector/files/12772705/ubuntu_5_15_pid3.txt) | 
|Alma 9 | Libvirt | 5.14.0-284.30.1.el9_2.x86_64 | [alma9_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12772860/alma9_5_14_pid0.txt) | [alma9_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12772861/alma9_5_14_pid1.txt) | [alma9_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12772862/alma9_5_14_pid2.txt) | [alma9_5_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12772863/alma9_5_14_pid3.txt) |
|Debian 11 | libvirt | 5.10.0-25-amd64 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12774500/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12774501/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12774502/debian_5_10_pid2.txt) | [debian_5_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12774503/debian_5_10_pid3.txt) | 
|Ubuntu 20.04 | libvirt | 5.4.0-146-generic | [ubuntu_5_4_pid0.txt](https://github.com/netdata/kernel-collector/files/12775398/ubuntu_5_4_pid0.txt) | [ubuntu_5_4_pid1.txt](https://github.com/netdata/kernel-collector/files/12775399/ubuntu_5_4_pid1.txt) | [ubuntu_5_4_pid2.txt](https://github.com/netdata/kernel-collector/files/12775400/ubuntu_5_4_pid2.txt) | [ubuntu_5_4_pid3.txt](https://github.com/netdata/kernel-collector/files/12775401/ubuntu_5_4_pid3.txt) | 
|Alma 8 | libvirt | 4.18.0-477.27.1.el8_8.x86_64 | [alma_4_18_pid0.txt](https://github.com/netdata/kernel-collector/files/12775814/alma_4_18_pid0.txt) | [alma_4_18_pid1.txt](https://github.com/netdata/kernel-collector/files/12775815/alma_4_18_pid1.txt) | [alma_4_18_pid2.txt](https://github.com/netdata/kernel-collector/files/12775816/alma_4_18_pid2.txt) | [alma_4_18_pid3.txt](https://github.com/netdata/kernel-collector/files/12775817/alma_4_18_pid3.txt) | 
|Ubuntu 18.04 | libvirt | 4.15.0-208-generic| [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12777631/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12777632/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12777633/ubuntu_4_15_pid2.txt) | [ubuntu_4_15_pid3.txt](https://github.com/netdata/kernel-collector/files/12777634/ubuntu_4_15_pid3.txt) | 
|Slackware Current | Qemu |4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12778071/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12778072/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12778073/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12778074/slackware_4_14_pid3.txt)  |
|CentOS 7.9 | libvirt | 3.10.0-1160.99.1.el7.x86_64 |[centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12778224/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12778225/centos_3_10_pid1.txt) |  [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12778226/centos_3_10_pid2.txt) | [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12778227/centos_3_10_pid3.txt) | 
