### PR TITLE
Update algorithms

### DIFF
--- a/includes/netdata_cache.h
+++ b/includes/netdata_cache.h
@@ -7,17 +7,15 @@ typedef struct netdata_cachestat {
     __u64 ct;
     char name[TASK_COMM_LEN];
 
-    __u64 add_to_page_cache_lru;
-    __u64 mark_page_accessed;
-    __u64 account_page_dirtied;
-    __u64 mark_buffer_dirty;
+    __s64 total;
+    __s64 misses;
+    __u64 dirty;
 } netdata_cachestat_t;
 
 enum cachestat_counters {
-    NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU,
-    NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED,
-    NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED,
-    NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY,
+    NETDATA_KEY_TOTAL,
+    NETDATA_KEY_MISSES,
+    NETDATA_KEY_DIRTY,
 
     // Keep this as last and don't skip numbers as it is used as element counter
     NETDATA_CACHESTAT_END

--- a/includes/netdata_cache.h
+++ b/includes/netdata_cache.h
@@ -6,6 +6,8 @@
 typedef struct netdata_cachestat {
     __u64 ct;
     __u32 tgid;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     __s64 total;

--- a/includes/netdata_cache.h
+++ b/includes/netdata_cache.h
@@ -5,6 +5,7 @@
 
 typedef struct netdata_cachestat {
     __u64 ct;
+    __u32 tgid;
     char name[TASK_COMM_LEN];
 
     __s64 total;

--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -169,7 +169,7 @@ static __always_inline __u32 netdata_get_current_pid()
 {
     __u32 pid;
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid = (__u32)(pid_tgid >> 32);
+    pid = (__u32)pid_tgid;
 
     return pid;
 }

--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -26,12 +26,22 @@ static __always_inline void libnetdata_update_s64(__u64 *res, __s64 value)
     __sync_fetch_and_add(res, value);
 }
 
-static __always_inline void libnetdata_update_global(void *tbl,__u32 key, __u64 value)
+static __always_inline void libnetdata_update_global(void *tbl, __u32 key, __u64 value)
 {
     __u64 *res;
     res = bpf_map_lookup_elem(tbl, &key);
     if (res)
         libnetdata_update_u64(res, value) ;
+    else
+        bpf_map_update_elem(tbl, &key, &value, BPF_EXIST);
+}
+
+static __always_inline void libnetdata_update_sglobal(void *tbl, __u32 key, __s64 value)
+{
+    __s64 *res;
+    res = bpf_map_lookup_elem(tbl, &key);
+    if (res)
+        libnetdata_update_s64(res, value) ;
     else
         bpf_map_update_elem(tbl, &key, &value, BPF_EXIST);
 }

--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -21,6 +21,11 @@ static __always_inline void libnetdata_update_u64(__u64 *res, __u64 value)
     }
 }
 
+static __always_inline void libnetdata_update_s64(__u64 *res, __s64 value)
+{
+    __sync_fetch_and_add(res, value);
+}
+
 static __always_inline void libnetdata_update_global(void *tbl,__u32 key, __u64 value)
 {
     __u64 *res;

--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -46,6 +46,13 @@ static __always_inline void libnetdata_update_sglobal(void *tbl, __u32 key, __s6
         bpf_map_update_elem(tbl, &key, &value, BPF_EXIST);
 }
 
+static __always_inline void libnetdata_update_uid_gid(__u32 *uid, __u32 *gid)
+{
+    __u64 uid_gid = bpf_get_current_uid_gid();
+    *uid = (__u32)uid_gid;
+    *gid = (__u32)(uid_gid>>32);
+}
+
 /**
  * The motive we are using log2 to plot instead the raw value is well explained
  * inside this paper https://www.fsl.cs.stonybrook.edu/docs/osprof-osdi2006/osprof.pdf

--- a/includes/netdata_dc.h
+++ b/includes/netdata_dc.h
@@ -6,6 +6,8 @@
 typedef struct netdata_dc_stat {
     __u64 ct;
     __u32 tgid;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     __u64 references;

--- a/includes/netdata_dc.h
+++ b/includes/netdata_dc.h
@@ -5,8 +5,8 @@
 
 typedef struct netdata_dc_stat {
     __u64 ct;
+    __u32 tgid;
     char name[TASK_COMM_LEN];
-
 
     __u64 references;
     __u64 slow;

--- a/includes/netdata_fd.h
+++ b/includes/netdata_fd.h
@@ -5,6 +5,7 @@
 
 struct netdata_fd_stat_t {
     __u64 ct;
+    __u32 tgid;
     char name[TASK_COMM_LEN];
 
     //Counter

--- a/includes/netdata_fd.h
+++ b/includes/netdata_fd.h
@@ -6,6 +6,8 @@
 struct netdata_fd_stat_t {
     __u64 ct;
     __u32 tgid;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     //Counter

--- a/includes/netdata_process.h
+++ b/includes/netdata_process.h
@@ -30,6 +30,8 @@ typedef struct netdata_sched_process_exec {
 
 struct netdata_pid_stat_t {
     __u64 ct;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     __u32 tgid;                         //Task id

--- a/includes/netdata_shm.h
+++ b/includes/netdata_shm.h
@@ -5,6 +5,7 @@
 
 typedef struct netdata_shm {
     __u64 ct;
+    __u32 tgid;
     char name[TASK_COMM_LEN];
 
     __u32 get;

--- a/includes/netdata_shm.h
+++ b/includes/netdata_shm.h
@@ -6,6 +6,8 @@
 typedef struct netdata_shm {
     __u64 ct;
     __u32 tgid;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     __u32 get;

--- a/includes/netdata_swap.h
+++ b/includes/netdata_swap.h
@@ -6,6 +6,8 @@
 typedef struct netdata_swap_access {
     __u64 ct;
     __u32 tgid;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     __u64 read;

--- a/includes/netdata_swap.h
+++ b/includes/netdata_swap.h
@@ -5,6 +5,7 @@
 
 typedef struct netdata_swap_access {
     __u64 ct;
+    __u32 tgid;
     char name[TASK_COMM_LEN];
 
     __u64 read;

--- a/includes/netdata_vfs.h
+++ b/includes/netdata_vfs.h
@@ -6,6 +6,8 @@
 struct netdata_vfs_stat_t {
     __u64 ct;
     __u32 tgid;
+    __u32 uid;
+    __u32 gid;
     char name[TASK_COMM_LEN];
 
     //Counter

--- a/includes/netdata_vfs.h
+++ b/includes/netdata_vfs.h
@@ -5,6 +5,7 @@
 
 struct netdata_vfs_stat_t {
     __u64 ct;
+    __u32 tgid;
     char name[TASK_COMM_LEN];
 
     //Counter

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -86,6 +86,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->misses, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -118,6 +119,7 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->total, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -169,6 +171,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -205,6 +208,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -240,6 +244,7 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->dirty, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -74,7 +74,7 @@ SEC("kprobe/add_to_page_cache_lru")
 int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -82,7 +82,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->add_to_page_cache_lru, 1);
+        libnetdata_update_s64(&fill->misses, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
@@ -91,7 +91,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.add_to_page_cache_lru = 1;
+        data.misses = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -104,7 +104,7 @@ SEC("kprobe/mark_page_accessed")
 int netdata_mark_page_accessed(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_TOTAL, 1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -112,7 +112,7 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->mark_page_accessed, 1);
+        libnetdata_update_s64(&fill->total, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
@@ -121,7 +121,7 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.mark_page_accessed = 1;
+        data.total = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -153,7 +153,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
 #endif
 
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -161,7 +161,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->account_page_dirtied, 1);
+        libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
@@ -170,7 +170,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.account_page_dirtied = 1;
+        data.misses = -1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -187,7 +187,7 @@ SEC("kprobe/account_page_dirtied")
 int netdata_account_page_dirtied(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -195,7 +195,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->account_page_dirtied, 1);
+        libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
@@ -204,7 +204,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.account_page_dirtied = 1;
+        data.misses = -1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -218,7 +218,8 @@ SEC("kprobe/mark_buffer_dirty")
 int netdata_mark_buffer_dirty(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_TOTAL, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_DIRTY, 1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -226,7 +227,8 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->mark_buffer_dirty, 1);
+        libnetdata_update_u64(&fill->total, -1);
+        libnetdata_update_u64(&fill->dirty, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
@@ -235,7 +237,8 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.mark_buffer_dirty = 1;
+        data.dirty = 1;
+        data.total = -1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -77,10 +77,11 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
     libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&cstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_s64(&fill->misses, 1);
     } else {
@@ -107,10 +108,11 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
     libnetdata_update_global(&cstat_global, NETDATA_KEY_TOTAL, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&cstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_s64(&fill->total, 1);
     } else {
@@ -156,10 +158,11 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
     libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&cstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_s64(&fill->misses, -1);
     } else {
@@ -190,10 +193,11 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
     libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&cstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_s64(&fill->misses, -1);
     } else {
@@ -222,10 +226,11 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
     libnetdata_update_global(&cstat_global, NETDATA_KEY_DIRTY, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&cstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->total, -1);
         libnetdata_update_u64(&fill->dirty, 1);

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -153,7 +153,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
 #endif
 
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
+    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -187,7 +187,7 @@ SEC("kprobe/account_page_dirtied")
 int netdata_account_page_dirtied(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
+    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
 
     __u32 key = 0;
     if (!monitor_apps(&cstat_ctrl))
@@ -218,7 +218,7 @@ SEC("kprobe/mark_buffer_dirty")
 int netdata_mark_buffer_dirty(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_TOTAL, 1);
+    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_TOTAL, -1);
     libnetdata_update_global(&cstat_global, NETDATA_KEY_DIRTY, 1);
 
     __u32 key = 0;

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -86,6 +86,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->misses, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -117,6 +118,7 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->total, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -167,6 +169,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -202,6 +205,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
         libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -236,6 +240,7 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->dirty, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -88,6 +88,7 @@ int netdata_lookup_fast(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->references, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -121,6 +122,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->slow, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -79,10 +79,11 @@ int netdata_lookup_fast(struct pt_regs* ctx)
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&dcstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->references, 1);
     } else {
@@ -111,10 +112,11 @@ int netdata_d_lookup(struct pt_regs* ctx)
     int ret = PT_REGS_RC(ctx);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&dcstat_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->slow, 1);
     } else {
@@ -134,7 +136,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
     // file not found
     if (ret == 0) {
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
-        fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+        fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
             libnetdata_update_u64(&fill->missed, 1);
         } else {

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -88,6 +88,7 @@ int netdata_lookup_fast(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->references, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -122,6 +123,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->slow, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -141,18 +143,6 @@ int netdata_d_lookup(struct pt_regs* ctx)
         fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
             libnetdata_update_u64(&fill->missed, 1);
-        } else {
-            data.ct = bpf_ktime_get_ns();
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
-            bpf_get_current_comm(&data.name, TASK_COMM_LEN);
-#else
-            data.name[0] = '\0';
-#endif
-
-            data.missed = 1;
-            bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
-
-            libnetdata_update_global(&dcstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
         }
     }
 

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -120,6 +120,7 @@ int netdata_sys_open(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -198,6 +199,7 @@ int netdata_close(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -105,10 +105,11 @@ int netdata_sys_open(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&fd_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &fd_ctrl, &tbl_fd_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &fd_ctrl, &tbl_fd_pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
@@ -181,10 +182,11 @@ int netdata_close(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&fd_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &fd_ctrl, &tbl_fd_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &fd_ctrl, &tbl_fd_pid);
     if (fill) {
         libnetdata_update_u32(&fill->close_call, 1) ;
 

--- a/kernel/fd_kern.c
+++ b/kernel/fd_kern.c
@@ -120,6 +120,7 @@ int netdata_sys_open(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -197,6 +198,7 @@ int netdata_close(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -78,8 +78,8 @@ struct bpf_map_def SEC("maps") process_ctrl = {
 static inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *data)
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    __u32 pid = (__u32) pid_tgid>>32;
+    __u32 tgid = (__u32)pid_tgid >>32;
+    __u32 pid = (__u32)pid_tgid;
 
     data->ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -105,10 +105,11 @@ int netdata_tracepoint_sched_process_exit(struct netdata_sched_process_exit *ptr
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_EXIT, 1);
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&process_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         libnetdata_update_u32(&fill->exit_call, 1) ;
     }
@@ -123,10 +124,11 @@ int netdata_release_task(struct pt_regs* ctx)
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_RELEASE_TASK, 1);
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&process_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         libnetdata_update_u32(&fill->release_call, 1) ;
 
@@ -145,10 +147,11 @@ int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&process_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
         libnetdata_update_u32(&fill->create_process, 1) ;
@@ -180,10 +183,11 @@ int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr
     }
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&process_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
         libnetdata_update_u32(&fill->create_process, 1);
@@ -234,10 +238,11 @@ int netdata_fork(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&process_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
 
@@ -284,10 +289,11 @@ int netdata_sys_clone(struct pt_regs *ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&process_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
 

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -82,6 +82,7 @@ static inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *d
     __u32 pid = (__u32)pid_tgid;
 
     data->ct = bpf_ktime_get_ns();
+    libnetdata_update_uid_gid(&data->uid, &data->gid);
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
     bpf_get_current_comm(&data->name, TASK_COMM_LEN);
 #else

--- a/kernel/shm_kern.c
+++ b/kernel/shm_kern.c
@@ -81,6 +81,7 @@ int netdata_syscall_shmget(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->get, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -119,6 +120,7 @@ int netdata_syscall_shmat(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->at, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -157,6 +159,7 @@ int netdata_syscall_shmdt(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->dt, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -195,6 +198,7 @@ int netdata_syscall_shmctl(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->ctl, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);

--- a/kernel/shm_kern.c
+++ b/kernel/shm_kern.c
@@ -72,10 +72,11 @@ int netdata_syscall_shmget(struct pt_regs *ctx)
 
     // check if apps is enabled; if not, don't record apps data.
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&shm_ctrl))
         return 0;
 
-    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &tgid, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u32(&fill->get, 1);
     } else {
@@ -108,10 +109,11 @@ int netdata_syscall_shmat(struct pt_regs *ctx)
 
     // check if apps is enabled; if not, don't record apps data.
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&shm_ctrl))
         return 0;
 
-    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &tgid, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u32(&fill->at, 1);
     } else {
@@ -144,10 +146,11 @@ int netdata_syscall_shmdt(struct pt_regs *ctx)
 
     // check if apps is enabled; if not, don't record apps data.
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&shm_ctrl))
         return 0;
 
-    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &tgid, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u32(&fill->dt, 1);
     } else {
@@ -180,10 +183,11 @@ int netdata_syscall_shmctl(struct pt_regs *ctx)
 
     // check if apps is enabled; if not, don't record apps data.
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&shm_ctrl))
         return 0;
 
-    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &tgid, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         libnetdata_update_u32(&fill->ctl, 1);
     } else {

--- a/kernel/shm_kern.c
+++ b/kernel/shm_kern.c
@@ -81,6 +81,7 @@ int netdata_syscall_shmget(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->get, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -118,6 +119,7 @@ int netdata_syscall_shmat(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->at, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -155,6 +157,7 @@ int netdata_syscall_shmdt(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->dt, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -192,6 +195,7 @@ int netdata_syscall_shmctl(struct pt_regs *ctx)
         libnetdata_update_u32(&fill->ctl, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -155,7 +155,8 @@ static __always_inline __u16 set_idx_value(netdata_socket_idx_t *nsi, struct ine
         return AF_UNSPEC;
 
 
-    nsi->pid = netdata_get_pid(&socket_ctrl);
+    __u32 tgid = 0;
+    nsi->pid = netdata_get_pid(&socket_ctrl, &tgid);
 
     return family;
 }

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -331,8 +331,8 @@ int netdata_inet_csk_accept(struct pt_regs* ctx)
     bpf_probe_read(&idx.port, sizeof(u16), &sk->__sk_common.skc_num);
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid);
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u32 tgid = (__u32)pid_tgid >>32;
+    __u32 pid = (__u32)pid_tgid;
 
     netdata_passive_connection_t *value = (netdata_passive_connection_t *)bpf_map_lookup_elem(&tbl_lports, &idx);
     if (value) {

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -88,6 +88,7 @@ int netdata_swap_readpage(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->read, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -120,6 +121,7 @@ int netdata_swap_writepage(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->write, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -88,6 +88,7 @@ int netdata_swap_readpage(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->read, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -121,6 +122,7 @@ int netdata_swap_writepage(struct pt_regs* ctx)
         libnetdata_update_u64(&fill->write, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -79,10 +79,11 @@ int netdata_swap_readpage(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_READPAGE_CALL, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&swap_ctrl))
         return 0;
 
-    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &tgid, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->read, 1);
     } else {
@@ -110,10 +111,11 @@ int netdata_swap_writepage(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_WRITEPAGE_CALL, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&swap_ctrl))
         return 0;
 
-    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &tgid, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->write, 1);
     } else {

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -119,6 +119,7 @@ int netdata_sys_write(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -191,6 +192,7 @@ int netdata_sys_writev(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -263,6 +265,7 @@ int netdata_sys_read(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -336,6 +339,7 @@ int netdata_sys_readv(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -398,6 +402,7 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -460,6 +465,7 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -522,6 +528,7 @@ int netdata_vfs_open(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
@@ -584,6 +591,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -89,6 +89,7 @@ int netdata_sys_write(struct pt_regs* ctx)
     __u64 tot;
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
@@ -103,7 +104,7 @@ int netdata_sys_write(struct pt_regs* ctx)
     tot = libnetdata_log2l(ret);
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
@@ -171,10 +172,11 @@ int netdata_sys_writev(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->writev_call, 1) ;
 
@@ -242,10 +244,11 @@ int netdata_sys_read(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->read_call, 1) ;
 
@@ -313,10 +316,11 @@ int netdata_sys_readv(struct pt_regs* ctx)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->readv_call, 1) ;
 
@@ -379,10 +383,11 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
@@ -440,10 +445,11 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->fsync_call, 1) ;
 
@@ -501,10 +507,11 @@ int netdata_vfs_open(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
@@ -562,10 +569,11 @@ int netdata_vfs_create(struct pt_regs* ctx)
 #endif
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (!monitor_apps(&vfs_ctrl))
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->create_call, 1) ;
 

--- a/kernel/vfs_kern.c
+++ b/kernel/vfs_kern.c
@@ -119,6 +119,7 @@ int netdata_sys_write(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -192,6 +193,7 @@ int netdata_sys_writev(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -265,6 +267,7 @@ int netdata_sys_read(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -339,6 +342,7 @@ int netdata_sys_readv(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -402,6 +406,7 @@ int netdata_sys_unlink(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -465,6 +470,7 @@ int netdata_vfs_fsync(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -528,6 +534,7 @@ int netdata_vfs_open(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
@@ -591,6 +598,7 @@ int netdata_vfs_create(struct pt_regs* ctx)
 #endif
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);


### PR DESCRIPTION
##### Summary
This PR is updating some internal algorithms to simplify user ring codes.

##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/6418621912) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --cachestat --dc --filedescriptor --process --shm --socket --swap --vfs --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware Current  | Bare metal  | 6.1.55      | [slackware_6_1_pid0.txt](https://github.com/netdata/kernel-collector/files/12824683/slackware_6_1_pid0.txt) | [slackware_6_1_pid1.txt](https://github.com/netdata/kernel-collector/files/12824691/slackware_6_1_pid1.txt) | [slackware_6_1_pid2.txt](https://github.com/netdata/kernel-collector/files/12824694/slackware_6_1_pid2.txt) | [slackware_6_1_pid3.txt](https://github.com/netdata/kernel-collector/files/12824697/slackware_6_1_pid3.txt) |
|Arch Linux | libvirt | 6.5.5-arch1-1 |  [arch_6_5_5_pid0.txt](https://github.com/netdata/kernel-collector/files/12825493/arch_6_5_5_pid0.txt) | [arch_6_5_5_pid1.txt](https://github.com/netdata/kernel-collector/files/12825494/arch_6_5_5_pid1.txt) | [arch_6_5_5_pid2.txt](https://github.com/netdata/kernel-collector/files/12825496/arch_6_5_5_pid2.txt) | [arch_6_5_5_pid3.txt](https://github.com/netdata/kernel-collector/files/12825497/arch_6_5_5_pid3.txt) | 
|Ubuntu 22.04 | libvirt | 5.15.0-76-generic| [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/12826331/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/12826332/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/12826333/ubuntu_5_15_pid2.txt) | [ubuntu_5_15_pid3.txt](https://github.com/netdata/kernel-collector/files/12826334/ubuntu_5_15_pid3.txt) | 
|Debian 11 | libvirt | 5.10.0-25-amd64 |[debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12826594/debian_5_10_pid0.txt)  | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12826595/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12826596/debian_5_10_pid2.txt) | [debian_5_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12826597/debian_5_10_pid3.txt) | 
|Ubuntu 20.04 | libvirt | 5.4.0-146-generic|  [file_pid0.txt](https://github.com/netdata/kernel-collector/files/12826833/file_pid0.txt) | [file_pid1.txt](https://github.com/netdata/kernel-collector/files/12826834/file_pid1.txt) | [file_pid2.txt](https://github.com/netdata/kernel-collector/files/12826835/file_pid2.txt) | [file_pid3.txt](https://github.com/netdata/kernel-collector/files/12826836/file_pid3.txt) |
|Ubuntu 18.04 | libvrt | 4.15.0-208-generic| [file_pid0.txt](https://github.com/netdata/kernel-collector/files/12825978/file_pid0.txt) | [file_pid1.txt](https://github.com/netdata/kernel-collector/files/12825980/file_pid1.txt) | [file_pid2.txt](https://github.com/netdata/kernel-collector/files/12825981/file_pid2.txt) | [file_pid3.txt](https://github.com/netdata/kernel-collector/files/12825982/file_pid3.txt) | 
|Slackware Current | Qemu | 4.14.290 | [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/12824809/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/12824810/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/12824811/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/12824812/slackware_4_14_pid3.txt) |
|CentOS 7.9 | Libviirt | 3.10.0-1160.99.1.el7.x86_64| [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/12825677/centos_3_10_pid0.txt) | [centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/12825678/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/12825679/centos_3_10_pid2.txt) |  [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/12825680/centos_3_10_pid3.txt) |