### PR TITLE
Address Clang Warning

### DIFF
--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -21,7 +21,7 @@ static __always_inline void libnetdata_update_u64(__u64 *res, __u64 value)
     }
 }
 
-static __always_inline void libnetdata_update_s64(__u64 *res, __s64 value)
+static __always_inline void libnetdata_update_s64(__s64 *res, __s64 value)
 {
     __sync_fetch_and_add(res, value);
 }


### PR DESCRIPTION
##### Summary
While compiling with clang 17.0.2 it was observed warnings, this PR fixes them.

##### Test Plan
1. Get binaries according your LIBC from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |           |              |
