### PR TITLE
Expand socket monitoring

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -36,6 +36,7 @@ typedef struct netdata_socket {
         __u32 retransmit;   //It is never used with UDP
         __u32 ipv4_connect; // Use to count new connections
         __u32 ipv6_connect; // Use to count new connections
+        __u32 state;        //Current socket state
     } tcp;
     // Number of calls
     struct {

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -109,6 +109,8 @@ enum socket_counters {
     NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
     NETDATA_KEY_ERROR_TCP_CONNECT_IPV6,
 
+    NETDATA_KEY_CALLS_TCP_SET_STATE,
+
     // Keep this as last and don't skip numbers as it is used as element counter
     NETDATA_SOCKET_COUNTER
 };

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -195,7 +195,6 @@ static __always_inline void update_socket_stats(netdata_socket_t *ptr,
 
 static __always_inline void update_socket_common(netdata_socket_t *data, __u16 protocol, __u16 family)
 {
-    data->ct = bpf_ktime_get_ns();
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
     bpf_get_current_comm(&data->name, TASK_COMM_LEN);
 #else
@@ -203,7 +202,6 @@ static __always_inline void update_socket_common(netdata_socket_t *data, __u16 p
 #endif
 
     data->first = bpf_ktime_get_ns();
-    data->ct = data->first;
     data->protocol = protocol;
     data->family = family;
 }

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -234,8 +234,10 @@ static __always_inline  void update_socket_table(struct pt_regs* ctx,
     val = (netdata_socket_t *) bpf_map_lookup_elem(&tbl_nd_socket, &idx);
     if (val) {
         update_socket_stats(val, sent, received, retransmitted, protocol);
+        val->tcp.state = state;
     } else {
         update_socket_common(&data, protocol, family);
+        data.tcp.state = state;
         update_socket_stats(&data, sent, received, retransmitted, protocol);
 
         libnetdata_update_global(&socket_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);

--- a/kernel/socket_kern.c
+++ b/kernel/socket_kern.c
@@ -422,7 +422,7 @@ SEC("kprobe/tcp_set_state")
 int netdata_tcp_set_state(struct pt_regs* ctx)
 {
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_TCP_SET_STATE, 1);
-    int state = PT_REGS_PARM1(ctx);
+    int state = PT_REGS_PARM2(ctx);
 
     update_socket_table(ctx, 0, 0, 1, IPPROTO_TCP, state);
 


### PR DESCRIPTION
##### Summary
Add socket state.
##### Test Plan
1. Get binaries according your LIBC from [this](https://github.com/netdata/kernel-collector/actions/runs/7628979041) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for glibc [here](https://github.com/netdata/kernel-collector/files/14027613/artifacts.zip).


2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --socket --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware currrent  | Bare metal  | 6.6.13      |  [slackware_current_pid0.txt](https://github.com/netdata/kernel-collector/files/14027642/slackware_current_pid0.txt) | [slackware_current_pid1.txt](https://github.com/netdata/kernel-collector/files/14027643/slackware_current_pid1.txt) | [slackware_current_pid2.txt](https://github.com/netdata/kernel-collector/files/14027644/slackware_current_pid2.txt) | [slackware_current_pid3.txt](https://github.com/netdata/kernel-collector/files/14027645/slackware_current_pid3.txt)  | 
|Arch | Vagrant VM | 6.7.0-arch3-1 | [arch_6_7_pid0.txt](https://github.com/netdata/kernel-collector/files/14027815/arch_6_7_pid0.txt) | [arch_6_7_pid1.txt](https://github.com/netdata/kernel-collector/files/14027816/arch_6_7_pid1.txt) | [arch_6_7_pid2.txt](https://github.com/netdata/kernel-collector/files/14027817/arch_6_7_pid2.txt) | [arch_6_7_pid3.txt](https://github.com/netdata/kernel-collector/files/14027818/arch_6_7_pid3.txt) | 
|Ubuntu 23.04 | Vagrant VM | 6.2.0-39-generic | [ubuntu_6_2_pid0.txt](https://github.com/netdata/kernel-collector/files/14028598/ubuntu_6_2_pid0.txt) | [ubuntu_6_2_pid1.txt](https://github.com/netdata/kernel-collector/files/14028599/ubuntu_6_2_pid1.txt) | [ubuntu_6_2_pid2.txt](https://github.com/netdata/kernel-collector/files/14028600/ubuntu_6_2_pid2.txt) | [ubuntu_6_2_pid3.txt](https://github.com/netdata/kernel-collector/files/14028601/ubuntu_6_2_pid3.txt) | 
|Ubuntu 22.04 | Vagrant VM | 5.15.0-76-generic | [ubuntu_5_15_pid0.txt](https://github.com/netdata/kernel-collector/files/14028887/ubuntu_5_15_pid0.txt) | [ubuntu_5_15_pid1.txt](https://github.com/netdata/kernel-collector/files/14028888/ubuntu_5_15_pid1.txt) | [ubuntu_5_15_pid2.txt](https://github.com/netdata/kernel-collector/files/14028890/ubuntu_5_15_pid2.txt) |  [ubuntu_5_15_pid3.txt](https://github.com/netdata/kernel-collector/files/14028892/ubuntu_5_15_pid3.txt) | 
|Alma 9 | Vagrant VM | 5.14.0-362.13.1.el9_3.x86_64 | [alma_5_14_pid0.txt](https://github.com/netdata/kernel-collector/files/14029867/alma_5_14_pid0.txt) | [alma_5_14_pid1.txt](https://github.com/netdata/kernel-collector/files/14029868/alma_5_14_pid1.txt) | [alma_5_14_pid2.txt](https://github.com/netdata/kernel-collector/files/14029869/alma_5_14_pid2.txt) | [alma_5_14_pid3.txt](https://github.com/netdata/kernel-collector/files/14029870/alma_5_14_pid3.txt) | 
| Debian 11 | Vagrant VM | 5.10.0-27-amd64 | [debian_5_10_pid0.txt](https://github.com/netdata/kernel-collector/files/14030315/debian_5_10_pid0.txt) | [debian_5_10_pid1.txt](https://github.com/netdata/kernel-collector/files/14030316/debian_5_10_pid1.txt) | [debian_5_10_pid2.txt](https://github.com/netdata/kernel-collector/files/14030317/debian_5_10_pid2.txt) | [debian_5_10_pid3.txt](https://github.com/netdata/kernel-collector/files/14030318/debian_5_10_pid3.txt) | 
|Ubuntu 18.04 | Vagrant VM | 4.15.0-208-generic | [ubuntu_4_15_pid0.txt](https://github.com/netdata/kernel-collector/files/14030894/ubuntu_4_15_pid0.txt) | [ubuntu_4_15_pid1.txt](https://github.com/netdata/kernel-collector/files/14030895/ubuntu_4_15_pid1.txt) | [ubuntu_4_15_pid2.txt](https://github.com/netdata/kernel-collector/files/14030896/ubuntu_4_15_pid2.txt) | [ubuntu_4_15_pid3.txt](https://github.com/netdata/kernel-collector/files/14030897/ubuntu_4_15_pid3.txt) |
|CentOS 7| Bare Metal |  3.10.0-1160.105.1.el7.x86_64 |[centos_3_10_pid1.txt](https://github.com/netdata/kernel-collector/files/14031331/centos_3_10_pid1.txt) | [centos_3_10_pid2.txt](https://github.com/netdata/kernel-collector/files/14031332/centos_3_10_pid2.txt) | [centos_3_10_pid3.txt](https://github.com/netdata/kernel-collector/files/14031333/centos_3_10_pid3.txt) | [centos_3_10_pid0.txt](https://github.com/netdata/kernel-collector/files/14031334/centos_3_10_pid0.txt) |
| Slackware Currrent | Qemu  | 4.14.290      |   [slackware_4_14_pid0.txt](https://github.com/netdata/kernel-collector/files/14031445/slackware_4_14_pid0.txt) | [slackware_4_14_pid1.txt](https://github.com/netdata/kernel-collector/files/14031446/slackware_4_14_pid1.txt) | [slackware_4_14_pid2.txt](https://github.com/netdata/kernel-collector/files/14031447/slackware_4_14_pid2.txt) | [slackware_4_14_pid3.txt](https://github.com/netdata/kernel-collector/files/14031448/slackware_4_14_pid3.txt) | 
