### PR TITLE
Add timestamp to network viewer

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -155,6 +155,7 @@ typedef struct netdata_nv_data {
 
     __u32 pid;
     __u32 uid;
+    __u64 ts;
 
     __u8  timer;
     __u8  retransmits;

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -195,6 +195,7 @@ static __always_inline void set_common_tcp_nv_data(netdata_nv_data_t *data,
 
     data->pid = bpf_get_current_pid_tgid() >> 32;
     data->uid = bpf_get_current_uid_gid();
+    data->ts = bpf_ktime_get_ns();
     data->timer = 0;
     bpf_probe_read(&data->retransmits, sizeof(data->retransmits), &icsk->icsk_retransmits);
     data->expires = 0;
@@ -207,6 +208,9 @@ static __always_inline void set_common_tcp_nv_data(netdata_nv_data_t *data,
 static __always_inline void set_common_udp_nv_data(netdata_nv_data_t *data,
                                                    struct sock *sk,
                                                    __u16 family) {
+    data->pid = bpf_get_current_pid_tgid() >> 32;
+    data->uid = bpf_get_current_uid_gid();
+    data->ts = bpf_ktime_get_ns();
     data->protocol = IPPROTO_UDP;
     data->family = family;
     unsigned char state;
@@ -331,6 +335,7 @@ int netdata_tcp_set_state(struct pt_regs* ctx)
 
     netdata_nv_data_t data = { };
     set_common_tcp_nv_data(&data, sk, family, state);
+    data.state = state;
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 


### PR DESCRIPTION
##### Summary

We are using `inodes` in our network viewer, but this value is accessed inside kernel with a [lock](https://elixir.bootlin.com/linux/latest/source/net/core/sock.c#L2618), so we are adding a new variable to keep the pattern with the current kernel.

##### Test Plan
1. Get binaries according to your C library from [this](https://github.com/netdata/kernel-collector/actions/runs/8073057107) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch and run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --networkviewer --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware Current  | Bare metal/VM  | 6.6.18      | [slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/14427236/slackware_pid0.txt) | [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/14427238/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/14427240/slackware_pid2.txt) | [slackware_pid3.txt](https://github.com/netdata/kernel-collector/files/14427241/slackware_pid3.txt) | 

