### PR TITLE
Discard completely necessity to parse /proc

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -140,6 +140,15 @@ enum socket_functions {
  *      NETWORK VIEWER
  */
 
+typedef enum __attribute__((packed)) {
+    NETDATA_SOCKET_DIRECTION_NONE = 0,
+    NETDATA_SOCKET_DIRECTION_LISTEN = (1 << 0),         // a listening socket
+    NETDATA_SOCKET_DIRECTION_INBOUND = (1 << 1),        // an inbound socket connecting a remote system to a local listening socket
+    NETDATA_SOCKET_DIRECTION_OUTBOUND = (1 << 2),       // a socket initiated by this system, connecting to another system
+    NETDATA_SOCKET_DIRECTION_LOCAL_INBOUND = (1 << 3),  // the socket connecting 2 localhost applications
+    NETDATA_SOCKET_DIRECTION_LOCAL_OUTBOUND = (1 << 4), // the socket connecting 2 localhost applications
+} NETDATA_SOCKET_DIRECTION;
+
 union ipv46 {
     uint32_t ipv4;
     struct in6_addr ipv6;
@@ -167,7 +176,7 @@ typedef struct netdata_nv_data {
 
     char name[TASK_COMM_LEN];
 
-    __u32 direction;
+    NETDATA_SOCKET_DIRECTION direction;
 
     __u16 family;
     __u16 protocol;

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -170,6 +170,7 @@ typedef struct netdata_nv_data {
 
     __u8  timer;
     __u8  retransmits;
+    __u16 closed;
     __u32 expires;
     __u32 rqueue;
     __u32 wqueue;

--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -3,6 +3,8 @@
 #ifndef _NETDATA_NETWORK_H_
 #define _NETDATA_NETWORK_H_ 1
 
+#include <linux/in6.h>
+
 /**
  *      SOCKET
  */
@@ -140,7 +142,7 @@ enum socket_functions {
 
 union ipv46 {
     uint32_t ipv4;
-    union netdata_ip ipv6;
+    struct in6_addr ipv6;
 };
 
 typedef struct netdata_nv_idx {

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -79,18 +79,12 @@ static __always_inline __u16 set_nv_idx_value(netdata_nv_idx_t *nvi, struct sock
     }
     // Check necessary according https://elixir.bootlin.com/linux/v5.6.14/source/include/net/sock.h#L199
     else if ( family == AF_INET6 ) {
-        char zero_ipv6[16] = { };
         // struct in6_addr *addr6 = &is->sk.sk_v6_rcv_saddr; // bind to local address
         struct in6_addr *addr6 = (struct in6_addr *)&is->sk.__sk_common.skc_v6_rcv_saddr.s6_addr;
         bpf_probe_read(&nvi->saddr.ipv6.in6_u.u6_addr8,  sizeof(__u8)*16, &addr6->s6_addr);
 
         addr6 = (struct in6_addr *)&is->sk.__sk_common.skc_v6_daddr.s6_addr;
         bpf_probe_read(&nvi->daddr.ipv6.in6_u.u6_addr8,  sizeof(__u8)*16, &addr6->s6_addr);
-
-        if (!__builtin_memcmp(&nvi->saddr.ipv6.in6_u.u6_addr8, zero_ipv6, sizeof(zero_ipv6)) ||
-            !__builtin_memcmp(&nvi->saddr.ipv6.in6_u.u6_addr8, zero_ipv6, sizeof(zero_ipv6)))
-            return AF_INET;
-
     }
     else {
         return AF_UNSPEC;

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -443,6 +443,25 @@ int netdata_tcp_v6_connect(struct pt_regs* ctx)
     return 0;
 }
 
+SEC("kprobe/tcp_close")
+int netdata_tcp_close(struct pt_regs* ctx)
+{
+    struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
+    if (!sk || sk == (void *)1)
+        return 0;
+
+    netdata_nv_idx_t idx = {};
+    __u16 family = set_nv_idx_value(&idx, sk);
+    NETDATA_SOCKET_DIRECTION direction = NETDATA_SOCKET_DIRECTION_OUTBOUND;
+    netdata_nv_data_t *val = (netdata_nv_data_t *) bpf_map_lookup_elem(&tbl_nv_socket, &idx);
+    if (!val)
+        return 0;
+
+    val->closed = 1;
+
+    return 0;
+}
+
 /************************************************************************************
  *
  *                                 UDP Section
@@ -463,6 +482,9 @@ int trace_udp_recvmsg(struct pt_regs* ctx)
     netdata_nv_data_t *val = (netdata_nv_data_t *) bpf_map_lookup_elem(&tbl_nv_socket, &idx);
     if (val) {
         set_common_udp_nv_data(val, sk, family, direction);
+        if (direction !=  NETDATA_SOCKET_DIRECTION_LISTEN)
+            val->closed = 1;
+
         return 0;
     }
 
@@ -471,6 +493,7 @@ int trace_udp_recvmsg(struct pt_regs* ctx)
 
     netdata_nv_data_t data = { };
     set_common_udp_nv_data(&data, sk, family, direction);
+
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -81,14 +81,10 @@ static __always_inline __u16 set_nv_idx_value(netdata_nv_idx_t *nvi, struct sock
     else if ( family == AF_INET6 ) {
         // struct in6_addr *addr6 = &is->sk.sk_v6_rcv_saddr; // bind to local address
         struct in6_addr *addr6 = (struct in6_addr *)&is->sk.__sk_common.skc_v6_rcv_saddr.s6_addr;
-        bpf_probe_read(&nvi->saddr.ipv6.addr8,  sizeof(__u8)*16, &addr6->s6_addr);
+        bpf_probe_read(&nvi->saddr.ipv6.in6_u.u6_addr8,  sizeof(__u8)*16, &addr6->s6_addr);
 
         addr6 = (struct in6_addr *)&is->sk.__sk_common.skc_v6_daddr.s6_addr;
-        bpf_probe_read(&nvi->daddr.ipv6.addr8,  sizeof(__u8)*16, &addr6->s6_addr);
-
-        if (((nvi->saddr.ipv6.addr64[0] == 0) && (nvi->saddr.ipv6.addr64[1] == 0)) ||
-            ((nvi->daddr.ipv6.addr64[0] == 0) && (nvi->daddr.ipv6.addr64[1] == 0))) // Zero addr
-            return AF_UNSPEC;
+        bpf_probe_read(&nvi->daddr.ipv6.in6_u.u6_addr8,  sizeof(__u8)*16, &addr6->s6_addr);
     }
     else {
         return AF_UNSPEC;

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -472,9 +472,10 @@ int trace_udp_recvmsg(struct pt_regs* ctx)
 
     netdata_nv_idx_t idx = {};
     __u16 family = set_nv_idx_value(&idx, sk);
-    NETDATA_SOCKET_DIRECTION direction = (idx.sport == idx.dport) ? NETDATA_SOCKET_DIRECTION_LISTEN : NETDATA_SOCKET_DIRECTION_OUTBOUND | NETDATA_SOCKET_DIRECTION_INBOUND;
+    NETDATA_SOCKET_DIRECTION direction;
     netdata_nv_data_t *val = (netdata_nv_data_t *) bpf_map_lookup_elem(&tbl_nv_socket, &idx);
     if (val) {
+        direction = NETDATA_SOCKET_DIRECTION_OUTBOUND;
         set_common_udp_nv_data(val, sk, family, direction);
         if (direction !=  NETDATA_SOCKET_DIRECTION_LISTEN)
             val->closed = 1;
@@ -486,6 +487,7 @@ int trace_udp_recvmsg(struct pt_regs* ctx)
         return 0;
 
     netdata_nv_data_t data = { };
+    direction = NETDATA_SOCKET_DIRECTION_OUTBOUND | NETDATA_SOCKET_DIRECTION_INBOUND;
     set_common_udp_nv_data(&data, sk, family, direction);
 
 
@@ -503,7 +505,7 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
 
     netdata_nv_idx_t idx = {};
     __u16 family = set_nv_idx_value(&idx, sk);
-    NETDATA_SOCKET_DIRECTION direction = (idx.sport == idx.dport) ? NETDATA_SOCKET_DIRECTION_LISTEN : NETDATA_SOCKET_DIRECTION_OUTBOUND;
+    NETDATA_SOCKET_DIRECTION direction = NETDATA_SOCKET_DIRECTION_OUTBOUND;
     netdata_nv_data_t *val = (netdata_nv_data_t *) bpf_map_lookup_elem(&tbl_nv_socket, &idx);
     if (val) {
         set_common_udp_nv_data(val, sk, family, direction);

--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -75,16 +75,22 @@ static __always_inline __u16 set_nv_idx_value(netdata_nv_idx_t *nvi, struct sock
         bpf_probe_read(&nvi->saddr.ipv4, sizeof(u32), &is->inet_saddr);
         bpf_probe_read(&nvi->daddr.ipv4, sizeof(u32), &is->inet_daddr);
         if (nvi->saddr.ipv4 == 0 || nvi->daddr.ipv4 == 0) // Zero
-            return AF_UNSPEC;
+            return AF_INET;
     }
     // Check necessary according https://elixir.bootlin.com/linux/v5.6.14/source/include/net/sock.h#L199
     else if ( family == AF_INET6 ) {
+        char zero_ipv6[16] = { };
         // struct in6_addr *addr6 = &is->sk.sk_v6_rcv_saddr; // bind to local address
         struct in6_addr *addr6 = (struct in6_addr *)&is->sk.__sk_common.skc_v6_rcv_saddr.s6_addr;
         bpf_probe_read(&nvi->saddr.ipv6.in6_u.u6_addr8,  sizeof(__u8)*16, &addr6->s6_addr);
 
         addr6 = (struct in6_addr *)&is->sk.__sk_common.skc_v6_daddr.s6_addr;
         bpf_probe_read(&nvi->daddr.ipv6.in6_u.u6_addr8,  sizeof(__u8)*16, &addr6->s6_addr);
+
+        if (!__builtin_memcmp(&nvi->saddr.ipv6.in6_u.u6_addr8, zero_ipv6, sizeof(zero_ipv6)) ||
+            !__builtin_memcmp(&nvi->saddr.ipv6.in6_u.u6_addr8, zero_ipv6, sizeof(zero_ipv6)))
+            return AF_INET;
+
     }
     else {
         return AF_UNSPEC;


### PR DESCRIPTION
##### Summary
After to do some tests, we are modifying the binary to avoid necessity to parse any `/proc` file.

##### Test Plan
1. Get binaries according to your C library from [this](https://github.com/netdata/kernel-collector/actions/runs/8134400052) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --networkviewer --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current | Bare Metal | 6.6.20 |  [slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/14475672/slackware_pid0.txt) | [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/14475673/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/14475674/slackware_pid2.txt) | [slackware_pid3.txt](https://github.com/netdata/kernel-collector/files/14475675/slackware_pid3.txt) | 