### PR TITLE
fix issue with CO-RE codes

### DIFF
--- a/includes/netdata_socket.h
+++ b/includes/netdata_socket.h
@@ -3,7 +3,8 @@
 #ifndef _NETDATA_NETWORK_H_
 #define _NETDATA_NETWORK_H_ 1
 
-#include <linux/in6.h>
+// Conflict with CO-RE code
+// #include <linux/in6.h>
 
 /**
  *      SOCKET
@@ -149,9 +150,16 @@ typedef enum __attribute__((packed)) {
     NETDATA_SOCKET_DIRECTION_LOCAL_OUTBOUND = (1 << 4), // the socket connecting 2 localhost applications
 } NETDATA_SOCKET_DIRECTION;
 
+// simplified version from https://elixir.bootlin.com/linux/v3.19.8/source/include/uapi/linux/in6.h
+struct netdata_in6_addr {
+	union {
+            __u8		u6_addr8[16];
+        } in6_u;
+};
+
 union ipv46 {
     uint32_t ipv4;
-    struct in6_addr ipv6;
+    struct netdata_in6_addr ipv6;
 };
 
 typedef struct netdata_nv_idx {


### PR DESCRIPTION
##### Summary
The usage of `linux/in6.h` created some issues to compile on more recent kernels, we are removing it and using a simplified version of the necessary structure

##### Test Plan
1. Get binaries according to your C library from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |           |              |
