### PR TITLE
Network Viewer Stats

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -27,7 +27,7 @@
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
 struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, netdata_nv_idx_t);
     __type(value, netdata_nv_data_t);
     __uint(max_entries, PID_MAX_DEFAULT);
@@ -262,6 +262,8 @@ int netdata_inet_csk_accept(struct pt_regs* ctx)
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
+
     return 0;
 }
 
@@ -295,6 +297,8 @@ int netdata_tcp_sendmsg(struct pt_regs* ctx)
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
+
     return 0;
 }
 
@@ -321,6 +325,8 @@ int netdata_tcp_retransmit_skb(struct pt_regs* ctx)
     set_common_tcp_nv_data(&data, sk, family, 0, direction);
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
+
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
 
     return 0;
 }
@@ -352,6 +358,8 @@ int netdata_tcp_set_state(struct pt_regs* ctx)
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
+
     return 0;
 }
 
@@ -380,6 +388,8 @@ int netdata_tcp_cleanup_rbuf(struct pt_regs* ctx)
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
+
     return 0;
 }
 
@@ -407,6 +417,8 @@ int netdata_tcp_v4_connect(struct pt_regs* ctx)
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
+
     return 0;
 }
 
@@ -433,6 +445,8 @@ int netdata_tcp_v6_connect(struct pt_regs* ctx)
     set_common_tcp_nv_data(&data, sk, family, 0, direction);
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
+
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
 
     return 0;
 }
@@ -493,6 +507,8 @@ int trace_udp_recvmsg(struct pt_regs* ctx)
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
 
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
+
     return 0;
 }
 
@@ -519,6 +535,8 @@ int trace_udp_sendmsg(struct pt_regs* ctx)
     set_common_udp_nv_data(&data, sk, family, direction);
 
     bpf_map_update_elem(&tbl_nv_socket, &idx, &data, BPF_ANY);
+
+    libnetdata_update_global(&nv_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
 
     return 0;
 }


### PR DESCRIPTION
##### Summary
Add stats to hash table, to clean up them when users are not accessing the cloud dashboard.

##### Test Plan
1. Get binaries according to your C library from [this](https://github.com/netdata/kernel-collector/actions/runs/8173561389) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --networkviewer --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware Current  | Bare meta  | 6.6.20      |[slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/14511888/slackware_pid0.txt) | [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/14511889/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/14511890/slackware_pid2.txt) | [slackware_pid3.txt](https://github.com/netdata/kernel-collector/files/14511891/slackware_pid3.txt) | 
