### PR TITLE
Swap 6.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         kernel_version:
+          - '6.8.2'
           - '5.16.18'
           - '5.15.63'
           - '5.14.0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         kernel_version:
+          - '6.8.2'
           - '5.16.18'
           - '5.15.63'
           - '5.14.0'

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -65,8 +65,12 @@ NETDATA_ALL_APPS= btrfs \
     		  zfs \
     		  #
 
+# Kernel newer than 6.8.0 ( 395264 = 6 * 65536 + 8 * 256)
+ifeq ($(shell test $(CURRENT_KERNEL) -ge 395264 ; echo $$?),0)
+NETDATA_APPS= swap \
+	      #
 # Kernel newer than 5.15.256 ( 331776 = 5 * 65536 + 16 * 256)
-ifeq ($(shell test $(CURRENT_KERNEL) -ge 331776 ; echo $$?),0)
+else ifeq ($(shell test $(CURRENT_KERNEL) -ge 331776 ; echo $$?),0)
 NETDATA_APPS= cachestat \
 	      #
 # Kernel newer than 5.14.256 ( 331520 = 5 * 65536 + 14 * 256)

--- a/kernel/rename_binaries.sh
+++ b/kernel/rename_binaries.sh
@@ -16,6 +16,7 @@ parse_kernel_version() {
 select_kernel_version() {
     KVER=$(parse_kernel_version "${1}" "${2}")
 
+    VER6_8_0="006008"
     VER5_16_0="005016"
     VER5_15_0="005015"
     VER5_14_0="005014"
@@ -32,6 +33,8 @@ select_kernel_version() {
         KSELECTED="3.10";
     elif [ "${KVER}" -eq "${VER4_18_0}" ]; then
         KSELECTED="4.18";
+    elif [ "${KVER}" -ge "${VER6_8_0}" ]; then
+        KSELECTED="6.8";
     elif [ "${KVER}" -ge "${VER5_16_0}" ]; then
         KSELECTED="5.16";
     elif [ "${KVER}" -ge "${VER5_15_0}" ]; then
@@ -64,3 +67,4 @@ KNAME=$(select_kernel_version "${1}" "${2}")
 
 cp "r${NAME}_kern.o" "../rnetdata_ebpf_${NAME}.${KNAME}.o"
 cp "p${NAME}_kern.o" "../pnetdata_ebpf_${NAME}.${KNAME}.o"
+

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -71,7 +71,11 @@ struct bpf_map_def SEC("maps") swap_ctrl = {
  *
  ***********************************************************************************/
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6,7,255))
+SEC("kprobe/swap_read_folio")
+#else
 SEC("kprobe/swap_readpage")
+#endif
 int netdata_swap_readpage(struct pt_regs* ctx)
 {
     netdata_swap_access_t data = {};

--- a/kernel/tester_user.c
+++ b/kernel/tester_user.c
@@ -73,7 +73,7 @@ ebpf_module_t ebpf_modules[] = {
       .flags = NETDATA_FLAG_SYNC, .name = "sync_file_range", .update_names = NULL, .ctrl_table = NULL },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SWAP, .name = "swap", .update_names = NULL, .ctrl_table = "swap_ctrl" },
-    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
+    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V6_8,
       .flags = NETDATA_FLAG_VFS, .name = "vfs", .update_names = NULL, .ctrl_table = "vfs_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_XFS, .name = "xfs", .update_names = NULL, .ctrl_table = "xfs_ctrl" },

--- a/kernel/tester_user.c
+++ b/kernel/tester_user.c
@@ -71,9 +71,9 @@ ebpf_module_t ebpf_modules[] = {
       .flags = NETDATA_FLAG_SYNC, .name = "syncfs", .update_names = NULL, .ctrl_table = NULL },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SYNC, .name = "sync_file_range", .update_names = NULL, .ctrl_table = NULL },
-    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
-      .flags = NETDATA_FLAG_SWAP, .name = "swap", .update_names = NULL, .ctrl_table = "swap_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V6_8,
+      .flags = NETDATA_FLAG_SWAP, .name = "swap", .update_names = NULL, .ctrl_table = "swap_ctrl" },
+    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_VFS, .name = "vfs", .update_names = NULL, .ctrl_table = "vfs_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_XFS, .name = "xfs", .update_names = NULL, .ctrl_table = "xfs_ctrl" },
@@ -212,7 +212,7 @@ int ebpf_get_redhat_release()
  */
 static char *ebpf_select_kernel_name(uint32_t selector)
 {
-    static char *kernel_names[] = { "3.10", "4.14", "4.16", "4.18", "5.4", "5.10", "5.11", "5.14", "5.15", "5.16" };
+    static char *kernel_names[] = { "3.10", "4.14", "4.16", "4.18", "5.4", "5.10", "5.11", "5.14", "5.15", "5.16", "6.8" };
 
     return kernel_names[selector];
 }
@@ -237,7 +237,9 @@ static int ebpf_select_max_index(int rhf_version, uint32_t kver)
         else if (kver >= NETDATA_EBPF_KERNEL_4_11)
             return 3;
     } else { // Kernels from kernel.org
-        if (kver >= NETDATA_EBPF_KERNEL_5_16)
+        if (kver >= NETDATA_EBPF_KERNEL_6_8)
+            return 10;
+	else if (kver >= NETDATA_EBPF_KERNEL_5_16)
             return 9;
         else if (kver >= NETDATA_EBPF_KERNEL_5_15)
             return 8;

--- a/kernel/tester_user.h
+++ b/kernel/tester_user.h
@@ -50,7 +50,8 @@ enum netdata_ebpf_kernel_versions {
     NETDATA_EBPF_KERNEL_5_11 = 330496,  //  330240 = 5 * 65536 + 11 * 256
     NETDATA_EBPF_KERNEL_5_14 = 331264,  //  331264 = 5 * 65536 + 14 * 256
     NETDATA_EBPF_KERNEL_5_15 = 331520,  //  331520 = 5 * 65536 + 15 * 256
-    NETDATA_EBPF_KERNEL_5_16 = 331776   //  331776 = 5 * 65536 + 16 * 256
+    NETDATA_EBPF_KERNEL_5_16 = 331776,  //  331776 = 5 * 65536 + 16 * 256
+    NETDATA_EBPF_KERNEL_6_8  = 395264   //  395264 = 5 * 65536 +  8 * 256
 };
 
 /**
@@ -60,16 +61,17 @@ enum netdata_ebpf_kernel_versions {
 
 
 enum netdata_kernel_flag {
-    NETDATA_V3_10 = 1 << 0,
-    NETDATA_V4_14 = 1 << 1,
-    NETDATA_V4_16 = 1 << 2,
-    NETDATA_V4_18 = 1 << 3,
-    NETDATA_V5_4  = 1 << 4,
-    NETDATA_V5_10 = 1 << 5,
-    NETDATA_V5_11 = 1 << 6,
-    NETDATA_V5_14 = 1 << 7,
-    NETDATA_V5_15 = 1 << 8,
-    NETDATA_V5_16 = 1 << 9
+    NETDATA_V3_10 = 1 <<  0,
+    NETDATA_V4_14 = 1 <<  1,
+    NETDATA_V4_16 = 1 <<  2,
+    NETDATA_V4_18 = 1 <<  3,
+    NETDATA_V5_4  = 1 <<  4,
+    NETDATA_V5_10 = 1 <<  5,
+    NETDATA_V5_11 = 1 <<  6,
+    NETDATA_V5_14 = 1 <<  7,
+    NETDATA_V5_15 = 1 <<  8,
+    NETDATA_V5_16 = 1 <<  9,
+    NETDATA_V6_8  = 1 << 10
 };
 
 enum netdata_kernel_counter {
@@ -83,6 +85,7 @@ enum netdata_kernel_counter {
     NETDATA_5_14,
     NETDATA_5_15,
     NETDATA_5_16,
+    NETDATA_6_8,
 
     NETDATA_VERSION_END
 };


### PR DESCRIPTION
##### Summary
This PR is modifying SWAP source code, after changes in [kernel source](https://elixir.bootlin.com/linux/latest/source/mm/page_io.c).

##### Test Plan
1. Get binaries according to your C library from [this](https://github.com/netdata/kernel-collector/actions/runs/8472577566) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test  --swap --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.6.22      |[slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/14794201/slackware_pid0.txt) | [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/14794202/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/14794203/slackware_pid2.txt) | [slackware_pid3.txt](https://github.com/netdata/kernel-collector/files/14794204/slackware_pid3.txt) | 
|Arch Linux | Libvirt | 6.8.1 | [arch_pid0.txt](https://github.com/netdata/kernel-collector/files/14796393/arch_pid0.txt) | [arch_pid1.txt](https://github.com/netdata/kernel-collector/files/14796394/arch_pid1.txt) | [arch_pid2.txt](https://github.com/netdata/kernel-collector/files/14796395/arch_pid2.txt) | [arch_pid3.txt](https://github.com/netdata/kernel-collector/files/14796396/arch_pid3.txt) | 
