### PR TITLE
address_comments: Get different PIDs levels

### DIFF
--- a/kernel/network_viewer_kern.c
+++ b/kernel/network_viewer_kern.c
@@ -190,7 +190,8 @@ static __always_inline void set_common_tcp_nv_data(netdata_nv_data_t *data,
     data->name[0] = '\0';
 #endif
 
-    data->pid = bpf_get_current_pid_tgid() >> 32;
+    __u32 tgid = 0;
+    data->pid = netdata_get_pid(&nv_ctrl, &tgid);
     data->uid = bpf_get_current_uid_gid();
     // Only update this data when it is a new value
     if (!data->ts)
@@ -211,7 +212,8 @@ static __always_inline void set_common_udp_nv_data(netdata_nv_data_t *data,
                                                    struct sock *sk,
                                                    __u16 family,
                                                    NETDATA_SOCKET_DIRECTION direction) {
-    data->pid = bpf_get_current_pid_tgid() >> 32;
+    __u32 tgid = 0;
+    data->pid = netdata_get_pid(&nv_ctrl, &tgid);
     data->uid = bpf_get_current_uid_gid();
     // Only update this data when it is a new value
     if (!data->ts)


### PR DESCRIPTION
##### Summary
Address a comment in https://github.com/netdata/netdata/pull/17073.

##### Test Plan
1. Get binaries according to your C library from [this](https://github.com/netdata/kernel-collector/actions/runs/8486565906) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --networkviewer --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.6.22      |[slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/14809203/slackware_pid0.txt) | [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/14809204/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/14809205/slackware_pid2.txt) |[slackware_pid3.txt](https://github.com/netdata/kernel-collector/files/14809202/slackware_pid3.txt) |
