### PR TITLE
Bump Libbpf and Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           ls -lah artifacts
           test -f artifacts/netdata_ebpf-*.tar.xz
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           ls -lah artifacts
           test -f artifacts/netdata_ebpf-*.tar.xz
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: artifacts

--- a/Dockerfile.glibc.generic
+++ b/Dockerfile.glibc.generic
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10 AS build
+FROM ubuntu:24.04 AS build
 
 ARG ARCH=x86
 ENV ARCH=$ARCH


### PR DESCRIPTION
##### Summary
Update `libbpf` and `Ubuntu` to generate new binaries.

##### Test Plan
1. Get binaries according to your C library from [this](https://github.com/netdata/kernel-collector/actions/runs/8923535477) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| Slackware current  | Bare metal  | 6.6.29      | [slackware_pid0.txt](https://github.com/netdata/kernel-collector/files/15189215/slackware_pid0.txt) | [slackware_pid1.txt](https://github.com/netdata/kernel-collector/files/15189216/slackware_pid1.txt) | [slackware_pid2.txt](https://github.com/netdata/kernel-collector/files/15189219/slackware_pid2.txt) | [slackware_pid3.txt](https://github.com/netdata/kernel-collector/files/15189220/slackware_pid3.txt) | 
