### PR TITLE
Append Libc to workflow name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: artifacts-${{ matrix.kernel_version }}
+          name: artifacts-${{ matrix.kernel_version }}-${{ matrix.libc }}
           path: artifacts
 
   create-release:


### PR DESCRIPTION
##### Summary
Address a conflict of name issue.

##### Test Plan
1. Get binaries according to your C library from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |           |              |
