### PR TITLE
Improve eBPF memory usage

### DIFF
--- a/includes/netdata_cache.h
+++ b/includes/netdata_cache.h
@@ -10,15 +10,17 @@ typedef struct netdata_cachestat {
     __u32 gid;
     char name[TASK_COMM_LEN];
 
-    __s64 total;
-    __s64 misses;
-    __u64 dirty;
+    __u32 add_to_page_cache_lru;
+    __u32 mark_page_accessed;
+    __u32 account_page_dirtied;
+    __u32 mark_buffer_dirty;
 } netdata_cachestat_t;
 
 enum cachestat_counters {
-    NETDATA_KEY_TOTAL,
-    NETDATA_KEY_MISSES,
-    NETDATA_KEY_DIRTY,
+    NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU,
+    NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED,
+    NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED,
+    NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY,
 
     // Keep this as last and don't skip numbers as it is used as element counter
     NETDATA_CACHESTAT_END

--- a/includes/netdata_dc.h
+++ b/includes/netdata_dc.h
@@ -10,9 +10,9 @@ typedef struct netdata_dc_stat {
     __u32 gid;
     char name[TASK_COMM_LEN];
 
-    __u64 references;
-    __u64 slow;
-    __u64 missed;
+    __u32 references;
+    __u32 slow;
+    __u32 missed;
 } netdata_dc_stat_t;
 
 enum directory_cache_counters {

--- a/includes/netdata_process.h
+++ b/includes/netdata_process.h
@@ -44,8 +44,6 @@ struct netdata_pid_stat_t {
     __u32 create_thread;                //Start syscall (fork, clone, forkv)
 
     __u32 task_err;
-
-    __u8 removeme;
 };
 
 enum process_counters {

--- a/includes/netdata_swap.h
+++ b/includes/netdata_swap.h
@@ -10,8 +10,8 @@ typedef struct netdata_swap_access {
     __u32 gid;
     char name[TASK_COMM_LEN];
 
-    __u64 read;
-    __u64 write;
+    __u32 read;
+    __u32 write;
 } netdata_swap_access_t;
 
 enum swap_counters {

--- a/kernel/cachestat_kern.c
+++ b/kernel/cachestat_kern.c
@@ -74,7 +74,7 @@ SEC("kprobe/add_to_page_cache_lru")
 int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU, 1);
 
     __u32 key = 0;
     __u32 tgid = 0;
@@ -83,7 +83,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_s64(&fill->misses, 1);
+        libnetdata_update_u32(&fill->add_to_page_cache_lru, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -94,7 +94,7 @@ int netdata_add_to_page_cache_lru(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.misses = 1;
+        data.add_to_page_cache_lru = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -107,7 +107,7 @@ SEC("kprobe/mark_page_accessed")
 int netdata_mark_page_accessed(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_TOTAL, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED, 1);
 
     __u32 key = 0;
     __u32 tgid = 0;
@@ -116,18 +116,19 @@ int netdata_mark_page_accessed(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_s64(&fill->total, 1);
+        libnetdata_update_u32(&fill->mark_page_accessed, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
         data.tgid = tgid;
+
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 #else
         data.name[0] = '\0';
 #endif
 
-        data.total = 1;
+        data.mark_page_accessed = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -159,7 +160,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
 #endif
 
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
 
     __u32 key = 0;
     __u32 tgid = 0;
@@ -168,7 +169,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_s64(&fill->misses, -1);
+        libnetdata_update_u32(&fill->account_page_dirtied, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -179,7 +180,7 @@ int netdata_set_page_dirty(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.misses = -1;
+        data.account_page_dirtied = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -196,7 +197,7 @@ SEC("kprobe/account_page_dirtied")
 int netdata_account_page_dirtied(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
 
     __u32 key = 0;
     __u32 tgid = 0;
@@ -205,7 +206,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_s64(&fill->misses, -1);
+        libnetdata_update_u32(&fill->account_page_dirtied, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -216,7 +217,7 @@ int netdata_account_page_dirtied(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.misses = -1;
+        data.account_page_dirtied = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -230,8 +231,7 @@ SEC("kprobe/mark_buffer_dirty")
 int netdata_mark_buffer_dirty(struct pt_regs* ctx)
 {
     netdata_cachestat_t *fill, data = {};
-    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_TOTAL, -1);
-    libnetdata_update_global(&cstat_global, NETDATA_KEY_DIRTY, 1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY, 1);
 
     __u32 key = 0;
     __u32 tgid = 0;
@@ -240,8 +240,7 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->total, -1);
-        libnetdata_update_u64(&fill->dirty, 1);
+        libnetdata_update_u32(&fill->mark_buffer_dirty, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -252,8 +251,7 @@ int netdata_mark_buffer_dirty(struct pt_regs* ctx)
         data.name[0] = '\0';
 #endif
 
-        data.dirty = 1;
-        data.total = -1;
+        data.mark_buffer_dirty = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);

--- a/kernel/dc_kern.c
+++ b/kernel/dc_kern.c
@@ -85,7 +85,7 @@ int netdata_lookup_fast(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->references, 1);
+        libnetdata_update_u32(&fill->references, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -120,7 +120,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
 
     fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->slow, 1);
+        libnetdata_update_u32(&fill->slow, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -142,7 +142,7 @@ int netdata_d_lookup(struct pt_regs* ctx)
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
         fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
-            libnetdata_update_u64(&fill->missed, 1);
+            libnetdata_update_u32(&fill->missed, 1);
         }
     }
 

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -89,7 +89,7 @@ int netdata_swap_readpage(struct pt_regs* ctx)
 
     netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &tgid, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
-        libnetdata_update_u64(&fill->read, 1);
+        libnetdata_update_u32(&fill->read, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -123,7 +123,7 @@ int netdata_swap_writepage(struct pt_regs* ctx)
 
     netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &tgid, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
-        libnetdata_update_u64(&fill->write, 1);
+        libnetdata_update_u32(&fill->write, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);


### PR DESCRIPTION
##### Summary
Adjust kernel-collector code improving memory usage in kernel ring.

##### Test Plan
1. Get binaries according to your C library from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |           |              |
