### PR TITLE
Switch from xz to gz for temporary artifacts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: List Artifacts
         run: |
           ls -lah artifacts
-          test -f artifacts/netdata_ebpf-*.tar.xz
+          test -f artifacts/netdata_ebpf-*.tar.gz
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Checkout LFS objects
-        run: git lfs checkout    
+        run: git lfs checkout
       - name: Run build.sh
         run: |
           if [ ${{ matrix.kernel_version }} = "5.14.0" ]; then
@@ -59,7 +59,7 @@ jobs:
       - name: List Artifacts
         run: |
           ls -lah artifacts
-          test -f artifacts/netdata_ebpf-*.tar.xz
+          test -f artifacts/netdata_ebpf-*.tar.gz
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: success()
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Checkout LFS objects
-        run: git lfs checkout    
+        run: git lfs checkout
       - name: Download all Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -93,7 +93,7 @@ jobs:
         run: |
           mkdir -p final-artifacts
           for libc in static glibc musl; do
-            for pkg in artifacts/netdata_ebpf-*_*-${libc}.tar.xz; do
+            for pkg in artifacts/netdata_ebpf-*_*-${libc}.tar.gz; do
               mkdir -p "packages/netdata-kernel-collector-${libc}-${RELEASE_TAG}"
               tar -C "packages/netdata-kernel-collector-${libc}-${RELEASE_TAG}" -xvf "${pkg}"
             done

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ EXTRA_CFLAGS += -fno-stack-protector
 all: $(KERNEL_PROGRAM)
 	tar -cf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar [pr]netdata_ebpf_*.o
 	if [ "$${DEBUG:-0}" -eq 1 ]; then tar -uvf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar tools/check-kernel-config.sh; fi
-	gz artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar
+	gzip artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar
 	( cd artifacts; sha256sum netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar.gz > netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar.gz.sha256sum )
 
 dev:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ EXTRA_CFLAGS += -fno-stack-protector
 all: $(KERNEL_PROGRAM)
 	tar -cf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar [pr]netdata_ebpf_*.o
 	if [ "$${DEBUG:-0}" -eq 1 ]; then tar -uvf artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar tools/check-kernel-config.sh; fi
-	xz artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar
-	( cd artifacts; sha256sum netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar.xz > netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar.xz.sha256sum )
+	gz artifacts/netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar
+	( cd artifacts; sha256sum netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar.gz > netdata_ebpf-$(FIRST_KERNEL_VERSION)_$(VER_MAJOR).$(VER_MINOR)$(RHF)-$(_LIBC).tar.gz.sha256sum )
 
 dev:
 	cd $(KERNEL_DIR) && $(MAKE) dev;


### PR DESCRIPTION
##### Summary

The artifacts produced by the Makefile are only used for development and for internal transfer of the build artifacts within the CI jobs, so the choice of compression doesn’t really matter much here.

XZ seems to be having issues inside the GHA runners for CI, so we need to use something else. Gzip is the most logical choice here since it should be everywhere.

##### Test Plan

n/a

##### Additional information

n/a