### PR TITLE
Modify Tracepoint

### DIFF
--- a/includes/netdata_process.h
+++ b/includes/netdata_process.h
@@ -20,6 +20,14 @@ typedef struct netdata_sched_process_fork {
     int child_pid;            // offset:44;      size:4; signed:1;
 } netdata_sched_process_fork_t;
 
+typedef struct netdata_sched_process_fork_v2 {
+    __u64 pad;                // This is not used with eBPF
+    char parent_comm[4];      // offset:8;       size:4;        signed:1;
+    int parent_pid;           // offset:12;      size:4; signed:1;
+    char child_comm[4];       // offset:16;      size:4;        signed:1;
+    int child_pid;            // offset:20;      size:4; signed:1;
+} netdata_sched_process_fork_v2_t;
+
 // /sys/kernel/tracing/events/sched/sched_process_exec/format
 typedef struct netdata_sched_process_exec {
     __u64 pad;      // This is not used with eBPF

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -67,8 +67,9 @@ NETDATA_ALL_APPS= btrfs \
 
 # Kernel newer than 6.16.0 ( 397312 = 6 * 65536 + 16 * 256)
 ifeq ($(shell test $(CURRENT_KERNEL) -ge 397312 ; echo $$?),0)
-NETDATA_APPS= swap \
-	      #
+NETDATA_APPS= 	swap \
+		process \
+		#
 
 # Kernel newer than 6.8.0 ( 395264 = 6 * 65536 + 8 * 256)
 else ifeq ($(shell test $(CURRENT_KERNEL) -ge 395264 ; echo $$?),0)

--- a/kernel/process_kern.c
+++ b/kernel/process_kern.c
@@ -169,7 +169,11 @@ int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr
 }
 
 SEC("tracepoint/sched/sched_process_fork")
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0))
+int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork_v2 *ptr)
+#else
 int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr)
+#endif
 {
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;

--- a/kernel/swap_kern.c
+++ b/kernel/swap_kern.c
@@ -109,7 +109,7 @@ int netdata_swap_readpage(struct pt_regs* ctx)
     return 0;
 }
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6,16,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0))
 SEC("kprobe/__swap_writepage")
 #else
 SEC("kprobe/swap_writepage")


### PR DESCRIPTION
##### Summary
Kernel 6.16 also modified tracepoint used to monitor process creation.

##### Test Plan
1. Get binaries according to your C library from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |           |              |
