### PR TITLE
Address incosinstency

### DIFF
--- a/kernel/btrfs_kern.c
+++ b/kernel/btrfs_kern.c
@@ -38,11 +38,10 @@ NETDATA_BPF_ARRAY_DEF(btrfs_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
 
 static __always_inline int netdata_btrfs_entry()
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
     __u64 ts = bpf_ktime_get_ns();
 
-    bpf_map_update_elem(&tmp_btrfs, &pid, &ts, BPF_ANY);
+    bpf_map_update_elem(&tmp_btrfs, &tid, &ts, BPF_ANY);
 
     libnetdata_update_global(&btrfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
 
@@ -129,15 +128,14 @@ int netdata_ret_generic_file_read_iter(struct pt_regs *ctx)
 #endif
 {
     __u64 *fill, data;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+    __u32 bin, tid = (__u32)bpf_get_current_pid_tgid();
 
-    fill = bpf_map_lookup_elem(&tmp_btrfs, &pid);
+    fill = bpf_map_lookup_elem(&tmp_btrfs, &tid);
     if (!fill)
         return 0;
 
     data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_btrfs, &pid);
+    bpf_map_delete_elem(&tmp_btrfs, &tid);
 
     libnetdata_update_global(&btrfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_DEL, 1);
 
@@ -157,15 +155,14 @@ SEC("kretprobe/btrfs_file_write_iter")
 int netdata_ret_btrfs_file_write_iter(struct pt_regs *ctx)
 {
     __u64 *fill, data;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+    __u32 bin, tid = (__u32)bpf_get_current_pid_tgid();
 
-    fill = bpf_map_lookup_elem(&tmp_btrfs, &pid);
+    fill = bpf_map_lookup_elem(&tmp_btrfs, &tid);
     if (!fill)
         return 0;
 
     data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_btrfs, &pid);
+    bpf_map_delete_elem(&tmp_btrfs, &tid);
 
     libnetdata_update_global(&btrfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_DEL, 1);
 
@@ -185,15 +182,14 @@ SEC("kretprobe/btrfs_file_open")
 int netdata_ret_btrfs_file_open(struct pt_regs *ctx)
 {
     __u64 *fill, data;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+    __u32 bin, tid = (__u32)bpf_get_current_pid_tgid();
 
-    fill = bpf_map_lookup_elem(&tmp_btrfs, &pid);
+    fill = bpf_map_lookup_elem(&tmp_btrfs, &tid);
     if (!fill)
         return 0;
 
     data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_btrfs, &pid);
+    bpf_map_delete_elem(&tmp_btrfs, &tid);
 
     libnetdata_update_global(&btrfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_DEL, 1);
 
@@ -213,15 +209,14 @@ SEC("kretprobe/btrfs_sync_file")
 int netdata_ret_btrfs_sync_file(struct pt_regs *ctx) 
 {
     __u64 *fill, data;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 bin, pid = (__u32)(pid_tgid >> 32);
+    __u32 bin, tid = (__u32)bpf_get_current_pid_tgid();
 
-    fill = bpf_map_lookup_elem(&tmp_btrfs, &pid);
+    fill = bpf_map_lookup_elem(&tmp_btrfs, &tid);
     if (!fill)
         return 0;
 
     data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_btrfs, &pid);
+    bpf_map_delete_elem(&tmp_btrfs, &tid);
 
     libnetdata_update_global(&btrfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_DEL, 1);
 
@@ -238,4 +233,3 @@ int netdata_ret_btrfs_sync_file(struct pt_regs *ctx)
 }
 
 char _license[] SEC("license") = "GPL";
-

--- a/kernel/ext4_kern.c
+++ b/kernel/ext4_kern.c
@@ -47,15 +47,14 @@ static __always_inline void netdata_ext4_store_bin(__u32 bin, __u32 selection)
 
 static __always_inline int netdata_ext4_ret(struct pt_regs *ctx, __u32 selector)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
 
-    __u64 *fill = bpf_map_lookup_elem(&tmp_ext4, &pid);
+    __u64 *fill = bpf_map_lookup_elem(&tmp_ext4, &tid);
     if (!fill)
         return 0;
 
     __u64 data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_ext4, &pid);
+    bpf_map_delete_elem(&tmp_ext4, &tid);
 
     if ((s64)data < 0)
         return 0;
@@ -76,8 +75,8 @@ static __always_inline int netdata_ext4_ret(struct pt_regs *ctx, __u32 selector)
 SEC("kprobe/ext4_file_read_iter")
 int netdata_ext4_file_read_iter(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_ext4, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_ext4, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&ext4_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -85,8 +84,8 @@ int netdata_ext4_file_read_iter(struct pt_regs *ctx)
 SEC("kprobe/ext4_file_write_iter")
 int netdata_ext4_file_write_iter(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_ext4, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_ext4, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&ext4_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -94,8 +93,8 @@ int netdata_ext4_file_write_iter(struct pt_regs *ctx)
 SEC("kprobe/ext4_file_open")
 int netdata_ext4_file_open(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_ext4, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_ext4, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&ext4_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -103,8 +102,8 @@ int netdata_ext4_file_open(struct pt_regs *ctx)
 SEC("kprobe/ext4_sync_file")
 int netdata_ext4_sync_file(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_ext4, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_ext4, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&ext4_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }

--- a/kernel/nfs_kern.c
+++ b/kernel/nfs_kern.c
@@ -47,15 +47,14 @@ static __always_inline void netdata_nfs_store_bin(__u32 bin, __u32 selection)
 
 static __always_inline int netdata_nfs_ret(struct pt_regs *ctx, __u32 selector)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
 
-    __u64 *fill = bpf_map_lookup_elem(&tmp_nfs, &pid);
+    __u64 *fill = bpf_map_lookup_elem(&tmp_nfs, &tid);
     if (!fill)
         return 0;
 
     __u64 data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_nfs, &pid);
+    bpf_map_delete_elem(&tmp_nfs, &tid);
 
     if ((s64)data < 0)
         return 0;
@@ -76,8 +75,8 @@ static __always_inline int netdata_nfs_ret(struct pt_regs *ctx, __u32 selector)
 SEC("kprobe/nfs_file_read")
 int netdata_nfs_file_read(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_nfs, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_nfs, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&nfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -85,8 +84,8 @@ int netdata_nfs_file_read(struct pt_regs *ctx)
 SEC("kprobe/nfs_file_write")
 int netdata_nfs_file_write(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_nfs, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_nfs, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&nfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -94,8 +93,8 @@ int netdata_nfs_file_write(struct pt_regs *ctx)
 SEC("kprobe/nfs_file_open")
 int netdata_nfs_file_open(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_nfs, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_nfs, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&nfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -103,8 +102,8 @@ int netdata_nfs_file_open(struct pt_regs *ctx)
 SEC("kprobe/nfs4_file_open")
 int netdata_nfs4_file_open(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_nfs, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_nfs, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&nfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }
@@ -112,8 +111,8 @@ int netdata_nfs4_file_open(struct pt_regs *ctx)
 SEC("kprobe/nfs_getattr")
 int netdata_nfs_getattr(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_nfs, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_nfs, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&nfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
     return 0;
 }

--- a/kernel/xfs_kern.c
+++ b/kernel/xfs_kern.c
@@ -20,8 +20,8 @@ NETDATA_BPF_ARRAY_DEF(xfs_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
 
 static __always_inline void netdata_xfs_entry(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_xfs, &pid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_xfs, &tid, &(unsigned long long){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&xfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
 }
 
@@ -43,15 +43,14 @@ static __always_inline void netdata_xfs_store_bin(__u32 bin, __u32 selection)
 
 static __always_inline int netdata_xfs_ret(struct pt_regs *ctx, __u32 selector)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
 
-    __u64 *fill = bpf_map_lookup_elem(&tmp_xfs, &pid);
+    __u64 *fill = bpf_map_lookup_elem(&tmp_xfs, &tid);
     if (!fill)
         return 0;
 
     __u64 data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_xfs, &pid);
+    bpf_map_delete_elem(&tmp_xfs, &tid);
 
     if ((s64)data < 0)
         return 0;

--- a/kernel/zfs_kern.c
+++ b/kernel/zfs_kern.c
@@ -47,15 +47,14 @@ static __always_inline void netdata_zfs_store_bin(__u32 bin, __u32 selection)
 
 static __always_inline int netdata_zfs_ret(struct pt_regs *ctx, __u32 selector)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
 
-    __u64 *fill = bpf_map_lookup_elem(&tmp_zfs, &pid);
+    __u64 *fill = bpf_map_lookup_elem(&tmp_zfs, &tid);
     if (!fill)
         return 0;
 
     __u64 data = bpf_ktime_get_ns() - *fill;
-    bpf_map_delete_elem(&tmp_zfs, &pid);
+    bpf_map_delete_elem(&tmp_zfs, &tid);
 
     if ((s64)data < 0)
         return 0;
@@ -75,8 +74,8 @@ static __always_inline int netdata_zfs_ret(struct pt_regs *ctx, __u32 selector)
 
 static __always_inline void netdata_zfs_start(struct pt_regs *ctx)
 {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    bpf_map_update_elem(&tmp_zfs, &pid, &(__u64){bpf_ktime_get_ns()}, BPF_ANY);
+    __u32 tid = (__u32)bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&tmp_zfs, &tid, &(__u64){bpf_ktime_get_ns()}, BPF_ANY);
     libnetdata_update_global(&zfs_ctrl, NETDATA_CONTROLLER_TEMP_TABLE_ADD, 1);
 }
 


### PR DESCRIPTION
##### Summary
This PR fixes inconsistency between filesystem variable value and name.

##### Test Plan
1. Get binaries according to your C library from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.xz`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following tests:

    ```sh
    # make clean; make tester
    # for i in `seq 0 3`; do ./kernel/legacy_test --netdata-path ../artifacts --content --iteration 1 --pid $i --log-path file_pid$i.txt; done
    ```

4. Every test should ends with `Success`, unless you do not have a specific target (function) available.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | Real Parent | Parent |  All PIDs | Without PIDs |
|--------------------|----------------|---------------|-------------|--------|-----------|--------------|
| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |        |           |              |
