### PR TITLE
Buffer Ring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 *.a
 
 kernel/legacy_test
-tests/legacy_test
+tests/legacy_tests
 tests/go_tester
 gotests/go_tester
 gotests/gotests

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 kernel/legacy_test
 tests/legacy_tests
+tests/legacy_test
 tests/go_tester
 gotests/go_tester
 gotests/gotests

--- a/gotests/cgo_helpers.go
+++ b/gotests/cgo_helpers.go
@@ -20,6 +20,11 @@ package main
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
+struct netdata_ringbuf_stats {
+	uint64_t samples;
+	uint64_t bytes;
+};
+
 #ifdef LIBBPF_MAJOR_VERSION
 static int netdata_libbpf_probe_bpf_map_type(unsigned int map_type)
 {
@@ -113,6 +118,99 @@ static int netdata_close_fd(int fd)
 {
 	return close(fd);
 }
+
+static int netdata_ring_buffer_sample_cb(void *ctx, void *data, size_t size)
+{
+	struct netdata_ringbuf_stats *stats = ctx;
+
+	(void)data;
+	if (stats) {
+		stats->samples++;
+		stats->bytes += size;
+	}
+
+	return 0;
+}
+
+static struct netdata_ringbuf_stats *netdata_ringbuf_stats_new(void)
+{
+	return calloc(1, sizeof(struct netdata_ringbuf_stats));
+}
+
+static void netdata_ringbuf_stats_free(struct netdata_ringbuf_stats *stats)
+{
+	free(stats);
+}
+
+static uint64_t netdata_ringbuf_stats_samples(const struct netdata_ringbuf_stats *stats)
+{
+	return stats ? stats->samples : 0;
+}
+
+static uint64_t netdata_ringbuf_stats_bytes(const struct netdata_ringbuf_stats *stats)
+{
+	return stats ? stats->bytes : 0;
+}
+
+static struct ring_buffer *netdata_ring_buffer_new(int map_fd, struct netdata_ringbuf_stats *stats)
+{
+	return ring_buffer__new(map_fd, netdata_ring_buffer_sample_cb, stats, NULL);
+}
+
+static int netdata_ring_buffer_poll(struct ring_buffer *rb, int timeout_ms)
+{
+	return ring_buffer__poll(rb, timeout_ms);
+}
+
+static uint64_t netdata_ring_buffer_avail_data(const struct ring_buffer *rb)
+{
+	struct ring *ring = ring_buffer__ring((struct ring_buffer *)rb, 0);
+
+	if (!ring)
+		return 0;
+
+	return (uint64_t)ring__avail_data_size(ring);
+}
+
+static uint64_t netdata_ring_buffer_size(const struct ring_buffer *rb)
+{
+	struct ring *ring = ring_buffer__ring((struct ring_buffer *)rb, 0);
+
+	if (!ring)
+		return 0;
+
+	return (uint64_t)ring__size(ring);
+}
+
+static void netdata_ring_buffer_free(struct ring_buffer *rb)
+{
+	ring_buffer__free(rb);
+}
+
+static struct user_ring_buffer *netdata_user_ring_buffer_new(int map_fd)
+{
+	return user_ring_buffer__new(map_fd, NULL);
+}
+
+static int netdata_user_ring_buffer_submit_u64(struct user_ring_buffer *rb, uint64_t value)
+{
+	void *sample;
+
+	errno = 0;
+	sample = user_ring_buffer__reserve(rb, sizeof(value));
+	if (!sample)
+		return errno ? -errno : -1;
+
+	memcpy(sample, &value, sizeof(value));
+	user_ring_buffer__submit(rb, sample);
+
+	return 0;
+}
+
+static void netdata_user_ring_buffer_free(struct user_ring_buffer *rb)
+{
+	user_ring_buffer__free(rb);
+}
 */
 import "C"
 
@@ -129,6 +227,8 @@ const (
 	bpfMapTypeArray       = uint32(C.BPF_MAP_TYPE_ARRAY)
 	bpfMapTypePerCPUHash  = uint32(C.BPF_MAP_TYPE_PERCPU_HASH)
 	bpfMapTypePerCPUArray = uint32(C.BPF_MAP_TYPE_PERCPU_ARRAY)
+	bpfMapTypeRingBuf     = uint32(C.BPF_MAP_TYPE_RINGBUF)
+	bpfMapTypeUserRingBuf = uint32(C.BPF_MAP_TYPE_USER_RINGBUF)
 )
 
 type bpfObject struct {
@@ -145,6 +245,15 @@ type bpfMap struct {
 
 type bpfLink struct {
 	ptr *C.struct_bpf_link
+}
+
+type ringBuffer struct {
+	ptr   *C.struct_ring_buffer
+	stats *C.struct_netdata_ringbuf_stats
+}
+
+type userRingBuffer struct {
+	ptr *C.struct_user_ring_buffer
 }
 
 type mapMeta struct {
@@ -364,4 +473,71 @@ func closeFD(fd int) error {
 	}
 
 	return nil
+}
+
+func newRingBuffer(mapFD int) (*ringBuffer, int) {
+	stats := C.netdata_ringbuf_stats_new()
+	if stats == nil {
+		return nil, -int(C.ENOMEM)
+	}
+
+	rb := C.netdata_ring_buffer_new(C.int(mapFD), stats)
+	if err := int(C.netdata_libbpf_get_error(unsafe.Pointer(rb))); err != 0 {
+		C.netdata_ringbuf_stats_free(stats)
+		return nil, err
+	}
+
+	return &ringBuffer{ptr: rb, stats: stats}, 0
+}
+
+func (rb *ringBuffer) free() {
+	if rb == nil {
+		return
+	}
+
+	if rb.ptr != nil {
+		C.netdata_ring_buffer_free(rb.ptr)
+	}
+	if rb.stats != nil {
+		C.netdata_ringbuf_stats_free(rb.stats)
+	}
+}
+
+func (rb *ringBuffer) poll(timeoutMS int) int {
+	return int(C.netdata_ring_buffer_poll(rb.ptr, C.int(timeoutMS)))
+}
+
+func (rb *ringBuffer) samples() uint64 {
+	return uint64(C.netdata_ringbuf_stats_samples(rb.stats))
+}
+
+func (rb *ringBuffer) bytes() uint64 {
+	return uint64(C.netdata_ringbuf_stats_bytes(rb.stats))
+}
+
+func (rb *ringBuffer) availData() uint64 {
+	return uint64(C.netdata_ring_buffer_avail_data(rb.ptr))
+}
+
+func (rb *ringBuffer) size() uint64 {
+	return uint64(C.netdata_ring_buffer_size(rb.ptr))
+}
+
+func newUserRingBuffer(mapFD int) (*userRingBuffer, int) {
+	rb := C.netdata_user_ring_buffer_new(C.int(mapFD))
+	if err := int(C.netdata_libbpf_get_error(unsafe.Pointer(rb))); err != 0 {
+		return nil, err
+	}
+
+	return &userRingBuffer{ptr: rb}, 0
+}
+
+func (rb *userRingBuffer) free() {
+	if rb != nil && rb.ptr != nil {
+		C.netdata_user_ring_buffer_free(rb.ptr)
+	}
+}
+
+func (rb *userRingBuffer) submitUint64(value uint64) int {
+	return int(C.netdata_user_ring_buffer_submit_u64(rb.ptr, C.uint64_t(value)))
 }

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -663,9 +663,18 @@ func detectSupportedMapTypes(rhfVersion int, kernelVersion int) map[uint32]bool 
 		bpfMapTypeArray:       kernelVersion >= netdataMinimumEBPFKernel || rhfVersion > 0,
 		bpfMapTypePerCPUHash:  fallbackPerCPUMapSupport(rhfVersion, kernelVersion),
 		bpfMapTypePerCPUArray: fallbackPerCPUMapSupport(rhfVersion, kernelVersion),
+		bpfMapTypeRingBuf:     false,
+		bpfMapTypeUserRingBuf: false,
 	}
 
-	for _, mapType := range []uint32{bpfMapTypeHash, bpfMapTypeArray, bpfMapTypePerCPUHash, bpfMapTypePerCPUArray} {
+	for _, mapType := range []uint32{
+		bpfMapTypeHash,
+		bpfMapTypeArray,
+		bpfMapTypePerCPUHash,
+		bpfMapTypePerCPUArray,
+		bpfMapTypeRingBuf,
+		bpfMapTypeUserRingBuf,
+	} {
 		if probe := probeMapTypeSupport(mapType); probe >= 0 {
 			supported[mapType] = probe > 0
 		}
@@ -684,14 +693,25 @@ func mapTypeName(mapType uint32) string {
 		return "percpu_hash"
 	case bpfMapTypePerCPUArray:
 		return "percpu_array"
+	case bpfMapTypeRingBuf:
+		return "ringbuf"
+	case bpfMapTypeUserRingBuf:
+		return "user_ringbuf"
 	default:
 		return fmt.Sprintf("type_%d", mapType)
 	}
 }
 
 func writeSupportedMapTypes(w io.Writer, supported map[uint32]bool) {
-	names := make([]string, 0, 4)
-	for _, mapType := range []uint32{bpfMapTypeHash, bpfMapTypeArray, bpfMapTypePerCPUHash, bpfMapTypePerCPUArray} {
+	names := make([]string, 0, 6)
+	for _, mapType := range []uint32{
+		bpfMapTypeHash,
+		bpfMapTypeArray,
+		bpfMapTypePerCPUHash,
+		bpfMapTypePerCPUArray,
+		bpfMapTypeRingBuf,
+		bpfMapTypeUserRingBuf,
+	} {
 		if supported[mapType] {
 			names = append(names, fmt.Sprintf("\"%s\"", mapTypeName(mapType)))
 		}
@@ -1121,6 +1141,18 @@ func isPerCPUMapType(mapType uint32) bool {
 	return mapType == bpfMapTypePerCPUArray || mapType == bpfMapTypePerCPUHash
 }
 
+func isRingBufferMapType(mapType uint32) bool {
+	return mapType == bpfMapTypeRingBuf || mapType == bpfMapTypeUserRingBuf
+}
+
+func isUserRingBufferMapType(mapType uint32) bool {
+	return mapType == bpfMapTypeUserRingBuf
+}
+
+func supportsMapKeyValueIO(mapType uint32) bool {
+	return !isRingBufferMapType(mapType)
+}
+
 func roundUpSize(value int, align int) int {
 	return ((value + align - 1) / align) * align
 }
@@ -1232,10 +1264,93 @@ func controllerJSON(w io.Writer, fd int, meta mapMeta, nprocesses int) {
 		filled+zero, filled, zero)
 }
 
+func testRingBufferMap(w io.Writer, meta mapMeta, iterations int) {
+	mode := "ringbuf_consumer"
+	var (
+		rb       *ringBuffer
+		urb      *userRingBuffer
+		setupErr int
+	)
+
+	if isUserRingBufferMapType(meta.Type) {
+		mode = "user_ringbuf_producer"
+		urb, setupErr = newUserRingBuffer(meta.FD)
+	} else {
+		rb, setupErr = newRingBuffer(meta.FD)
+	}
+
+	fmt.Fprintf(w,
+		"        \"%s\" : {\n            \"Info\" : { \"Length\" : { \"Key\" : %d, \"Value\" : %d},\n"+
+			"                       \"Type\" : %d,\n"+
+			"                       \"FD\" : %d,\n"+
+			"                       \"Data\" : [\n",
+		meta.Name, meta.KeySize, meta.ValueSize, meta.Type, meta.FD)
+
+	var prevSamples uint64
+	var prevBytes uint64
+	for i := 0; i < iterations; i++ {
+		time.Sleep(5 * time.Second)
+
+		opErr := setupErr
+		opResult := 0
+		var iterSamples uint64
+		var iterBytes uint64
+		var availData uint64
+		var ringSize uint64
+
+		if rb != nil {
+			opResult = rb.poll(0)
+			if opResult < 0 {
+				opErr = opResult
+			}
+
+			samples := rb.samples()
+			bytes := rb.bytes()
+			iterSamples = samples - prevSamples
+			iterBytes = bytes - prevBytes
+			prevSamples = samples
+			prevBytes = bytes
+			availData = rb.availData()
+			ringSize = rb.size()
+		} else if urb != nil {
+			opResult = urb.submitUint64(uint64(i + 1))
+			if opResult < 0 {
+				opErr = opResult
+			}
+		}
+
+		if i > 0 {
+			fmt.Fprint(w, ",\n")
+		}
+		fmt.Fprintf(w,
+			"                                    { \"Iteration\" : %d, \"Mode\" : \"%s\", \"Setup\" : %d, "+
+				"\"Operation Result\" : %d, \"Samples\" : %d, \"Bytes\" : %d, "+
+				"\"Available\" : %d, \"Ring Size\" : %d, \"Error Code\" : %d, "+
+				"\"Error Message\" : \"%s\" }",
+			i, mode, boolToInt(setupErr == 0), opResult, iterSamples, iterBytes,
+			availData, ringSize, opErr, describeError(opErr))
+	}
+	fmt.Fprint(w, "\n")
+
+	if rb != nil {
+		rb.free()
+	}
+	if urb != nil {
+		urb.free()
+	}
+}
+
 func testMaps(w io.Writer, obj *bpfObject, ctrl string, iterations int, nprocesses int) {
 	tables := 0
 	for m := obj.firstMap(); m != nil; m = obj.nextMap(m) {
 		meta := m.meta()
+		if !supportsMapKeyValueIO(meta.Type) {
+			testRingBufferMap(w, meta, iterations)
+			fmt.Fprint(w, "                                ]\n                      }\n        },\n")
+			tables++
+			continue
+		}
+
 		values := allocateTableData(meta, nprocesses)
 		fmt.Fprintf(w,
 			"        \"%s\" : {\n            \"Info\" : { \"Length\" : { \"Key\" : %d, \"Value\" : %d},\n"+
@@ -1266,6 +1381,9 @@ func fillCtrl(obj *bpfObject, ctrl string, mapLevel int, nprocesses int) {
 	}
 
 	meta := m.meta()
+	if !supportsMapKeyValueIO(meta.Type) {
+		return
+	}
 	values := []uint64{1, uint64(mapLevel), 0, 0, 0, 0}
 	key := make([]byte, meta.KeySize)
 	value := make([]byte, mapValueLength(meta, nprocesses))

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -37,6 +37,7 @@ const (
 	netdataEBPFKernel515        = 331520
 	netdataEBPFKernel516        = 331776
 	netdataEBPFKernel68         = 395264
+	netdataEBPFKernel612        = 396288
 
 	netdataV310 = 1 << 0
 	netdataV414 = 1 << 1
@@ -49,6 +50,7 @@ const (
 	netdataV515 = 1 << 8
 	netdataV516 = 1 << 9
 	netdataV68  = 1 << 10
+	netdataV612 = 1 << 11
 
 	flagBtrfs         uint64 = 1 << 0
 	flagCachestat     uint64 = 1 << 1
@@ -75,8 +77,14 @@ const (
 	flagContent       uint64 = 1 << 22
 	flagDNS           uint64 = 1 << 23
 
-	flagFS  uint64 = flagBtrfs | flagExt4 | flagVFS | flagNFS | flagXFS | flagZFS
-	flagAll uint64 = ^uint64(0)
+	flagFS         uint64 = flagBtrfs | flagExt4 | flagVFS | flagNFS | flagXFS | flagZFS
+	flagCollectors uint64 = flagBtrfs | flagCachestat | flagDC | flagDisk |
+		flagExt4 | flagFD | flagSync | flagHardIRQ |
+		flagMDFlush | flagMount | flagNetworkViewer |
+		flagOOMKill | flagProcess | flagSHM | flagSocket |
+		flagSoftIRQ | flagSwap | flagVFS | flagNFS |
+		flagXFS | flagZFS | flagDNS
+	flagAll uint64 = flagCollectors
 )
 
 type specifyName struct {
@@ -89,11 +97,12 @@ type specifyName struct {
 }
 
 type module struct {
-	kernels     uint32
-	flags       uint64
-	name        string
-	updateNames *[]specifyName
-	ctrlTable   string
+	kernels       uint32
+	bufferKernels uint32
+	flags         uint64
+	name          string
+	updateNames   *[]specifyName
+	ctrlTable     string
 }
 
 type options struct {
@@ -208,11 +217,11 @@ var (
 
 	ebpfModules = []module{
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV510 | netdataV514, flags: flagBtrfs, name: "btrfs", ctrlTable: "btrfs_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV515 | netdataV514 | netdataV516, flags: flagCachestat, name: "cachestat", ctrlTable: "cstat_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagDC, name: "dc", updateNames: &dcOptionalNames, ctrlTable: "dcstat_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV515 | netdataV514 | netdataV516, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagCachestat, name: "cachestat", ctrlTable: "cstat_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagDC, name: "dc", updateNames: &dcOptionalNames, ctrlTable: "dcstat_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagDisk, name: "disk", ctrlTable: "disk_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagExt4, name: "ext4", ctrlTable: "ext4_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV511 | netdataV514, flags: flagFD, name: "fd", ctrlTable: "fd_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV511 | netdataV514, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagFD, name: "fd", ctrlTable: "fd_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSync, name: "fdatasync"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSync, name: "fsync"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagHardIRQ, name: "hardirq"},
@@ -220,18 +229,18 @@ var (
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagMount, name: "mount"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSync, name: "msync"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSocket, name: "socket", ctrlTable: "socket_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagDNS, name: "dns"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagDNS, name: "dns"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagNFS, name: "nfs", ctrlTable: "nfs_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagNetworkViewer, name: "network_viewer", ctrlTable: "nv_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagOOMKill, name: "oomkill"},
-		{kernels: netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514 | netdataV510, flags: flagProcess, name: "process", ctrlTable: "process_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSHM, name: "shm", ctrlTable: "shm_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagOOMKill, name: "oomkill"},
+		{kernels: netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514 | netdataV510 | netdataV612, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagProcess, name: "process", ctrlTable: "process_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagSHM, name: "shm", ctrlTable: "shm_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSoftIRQ, name: "softirq"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSync, name: "sync"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSync, name: "syncfs"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagSync, name: "sync_file_range"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514 | netdataV68, flags: flagSwap, name: "swap", updateNames: &swapOptionalNames, ctrlTable: "swap_ctrl"},
-		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagVFS, name: "vfs", ctrlTable: "vfs_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514 | netdataV68 | netdataV612, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagSwap, name: "swap", updateNames: &swapOptionalNames, ctrlTable: "swap_ctrl"},
+		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, bufferKernels: netdataV510 | netdataV511 | netdataV514 | netdataV515 | netdataV516 | netdataV68 | netdataV612, flags: flagVFS, name: "vfs", ctrlTable: "vfs_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagXFS, name: "xfs", ctrlTable: "xfs_ctrl"},
 		{kernels: netdataV310 | netdataV414 | netdataV416 | netdataV418 | netdataV54 | netdataV514, flags: flagZFS, name: "zfs", updateNames: &zfsOptionalNames, ctrlTable: "zfs_ctrl"},
 	}
@@ -439,7 +448,7 @@ func helpText(exe string) string {
 }
 
 func setCommonFlag() uint64 {
-	return flagAll & ^(flagFS | flagLoadBinary | flagMDFlush | flagContent)
+	return flagCollectors & ^(flagFS | flagLoadBinary | flagMDFlush | flagContent)
 }
 
 func parseArguments(args []string, kernelVersion int, logger *logState) (options, int) {
@@ -500,7 +509,7 @@ func parseArguments(args []string, kernelVersion int, logger *logState) (options
 		case "unit-test":
 			opts.unitTest = true
 		case "all":
-			opts.flags |= flagAll
+			opts.flags |= flagCollectors
 		case "common":
 			opts.flags |= setCommonFlag()
 		case "load-binary":
@@ -547,7 +556,7 @@ func parseArguments(args []string, kernelVersion int, logger *logState) (options
 		}
 	}
 
-	if !opts.unitTest && opts.flags&(flagAll&^flagContent) == 0 {
+	if !opts.unitTest && opts.flags&flagCollectors == 0 {
 		opts.flags |= setCommonFlag()
 	}
 
@@ -654,7 +663,24 @@ func candidateMatches(filename string, moduleName string, isReturn bool, version
 	return !hasRHF
 }
 
-func discoverCandidates(moduleName string, isReturn bool, version string, rhfVersion int, netdataPath string, bufferMode bool) []string {
+func candidateVersionIndex(filename string, moduleName string, isReturn bool, rhfVersion int, kernels uint32, maxIndex uint32, bufferMode bool) int {
+	if rhfVersion == -1 {
+		kernels &^= netdataV514
+	}
+
+	for idx := int(maxIndex); idx >= 0; idx-- {
+		if kernels&(1<<uint32(idx)) == 0 {
+			continue
+		}
+		if candidateMatches(filename, moduleName, isReturn, selectKernelName(uint32(idx)), rhfVersion, bufferMode) {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+func discoverCandidates(moduleName string, isReturn bool, rhfVersion int, kernels uint32, maxIndex uint32, netdataPath string, bufferMode bool) []string {
 	path := resolveBinaryDir(netdataPath)
 	entries, err := os.ReadDir(path)
 	if err != nil {
@@ -662,11 +688,20 @@ func discoverCandidates(moduleName string, isReturn bool, version string, rhfVer
 	}
 
 	candidates := make([]string, 0, len(entries))
+	bestIndex := -1
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-		if !candidateMatches(entry.Name(), moduleName, isReturn, version, rhfVersion, bufferMode) {
+
+		candidateIndex := candidateVersionIndex(entry.Name(), moduleName, isReturn, rhfVersion, kernels, maxIndex, bufferMode)
+		if candidateIndex < 0 {
+			continue
+		}
+		if candidateIndex > bestIndex {
+			candidates = candidates[:0]
+			bestIndex = candidateIndex
+		} else if candidateIndex < bestIndex {
 			continue
 		}
 
@@ -917,9 +952,13 @@ func runNetdataTests(w io.Writer, rhfVersion int, kernelVersion int, isReturn bo
 			continue
 		}
 
-		idx := selectIndex(mod.kernels, rhfVersion, kernelVersion)
-		version := selectKernelName(idx)
-		candidates := discoverCandidates(mod.name, isReturn, version, rhfVersion, opts.netdataPath, opts.bufferMode)
+		kernels := mod.kernels
+		if opts.bufferMode && mod.bufferKernels != 0 {
+			kernels = mod.bufferKernels
+		}
+		maxIndex := selectMaxIndex(rhfVersion, kernelVersion)
+		idx := selectIndex(kernels, rhfVersion, kernelVersion)
+		candidates := discoverCandidates(mod.name, isReturn, rhfVersion, kernels, maxIndex, opts.netdataPath, opts.bufferMode)
 		compatible, incompatible, unsupportedType := filterCompatibleCandidates(candidates, supportedMapTypes)
 
 		if len(compatible) == 0 {
@@ -942,7 +981,7 @@ func runNetdataTests(w io.Writer, rhfVersion int, kernelVersion int, isReturn bo
 }
 
 func selectKernelName(selector uint32) string {
-	kernelNames := []string{"3.10", "4.14", "4.16", "4.18", "5.4", "5.10", "5.11", "5.14", "5.15", "5.16", "6.8"}
+	kernelNames := []string{"3.10", "4.14", "4.16", "4.18", "5.4", "5.10", "5.11", "5.14", "5.15", "5.16", "6.8", "6.12"}
 	return kernelNames[selector]
 }
 
@@ -958,6 +997,8 @@ func selectMaxIndex(rhfVersion int, kernelVersion int) uint32 {
 		}
 	} else {
 		switch {
+		case kernelVersion >= netdataEBPFKernel612:
+			return 11
 		case kernelVersion >= netdataEBPFKernel68:
 			return 10
 		case kernelVersion >= netdataEBPFKernel516:

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -414,7 +414,7 @@ func helpText(exe string) string {
 		"                   software will use stderr.\n\n"+
 		"--content          Test content stored inside hash tables.\n"+
 		"--iteration        Number of iterations when content is read, default value is 1.\n"+
-		"--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, and 2 - All PID \n"+
+		"--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, 2 - All PID, and 3 - Ignore PID (ring buffer mode).\n"+
 		"--buffer           Test ring buffer versions of collectors (cachestat, dc, fd, oomkill, process, shm, swap, vfs, dns).\n\n"+
 		"You can also specify an unique eBPF program developed by Netdata with the following\n"+
 		"options:\n"+
@@ -509,7 +509,7 @@ func parseArguments(args []string, kernelVersion int, logger *logState) (options
 		case "unit-test":
 			opts.unitTest = true
 		case "all":
-			opts.flags |= flagCollectors
+			opts.flags |= flagCollectors | flagContent
 		case "common":
 			opts.flags |= setCommonFlag()
 		case "load-binary":

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -136,6 +136,8 @@ type tableData struct {
 }
 
 var (
+	testsStarted = 0
+
 	dcOptionalNames = []specifyName{
 		{
 			programName:      "netdata_lookup_fast",
@@ -242,6 +244,7 @@ func main() {
 func run() int {
 	kernelVersion := getKernelVersion()
 	rhfVersion := getRedHatRelease()
+	testsStarted = 0
 	nprocesses := libbpfNumPossibleCPUs()
 	if nprocesses < 1 {
 		nprocesses = runtime.NumCPU()
@@ -280,6 +283,12 @@ func run() int {
 		startExternalJSON(writer, opts.specificEBPF)
 		result := ebpfTester(writer, opts.specificEBPF, nil, opts.flags&flagContent != 0, "", opts, nprocesses)
 		fmt.Fprintf(writer, "    },\n    \"Status\" :  \"%s\"\n},\n", result)
+	}
+
+	if testsStarted == 0 {
+		fmt.Fprint(writer, "\"Error\" : \"No eBPF tests were started. Check selected options, binary name, and --netdata-path.\",\n")
+		fmt.Fprint(writer, "\"End\" : \"Good bye!!!\" }\n")
+		return 1
 	}
 
 	fmt.Fprint(writer, "\"End\" : \"Good bye!!!\" }\n")
@@ -1022,10 +1031,12 @@ func mountName(kernelIndex uint32, name string, isReturn bool, rhfVersion int, n
 }
 
 func startExternalJSON(w io.Writer, filename string) {
+	testsStarted++
 	fmt.Fprintf(w, "\n\"%s\" : {\n    \"Tables\" : {\n", filename)
 }
 
 func startNetdataJSON(w io.Writer, filename string, isReturn bool) {
+	testsStarted++
 	testType := "entry"
 	if isReturn {
 		testType = "return"

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -30,6 +30,7 @@ const (
 	netdataEBPFKernel415        = 265984
 	netdataEBPFKernel417        = 266496
 	netdataEBPFKernel54         = 328704
+	netdataEBPFKernel58         = 329728
 	netdataEBPFKernel510        = 330240
 	netdataEBPFKernel511        = 330496
 	netdataEBPFKernel514        = 331264
@@ -105,6 +106,7 @@ type options struct {
 	dnsPorts     []uint16
 	unitTest     bool
 	showHelp     bool
+	bufferMode   bool
 }
 
 type logState struct {
@@ -394,7 +396,8 @@ func helpText(exe string) string {
 		"                   software will use stderr.\n\n"+
 		"--content          Test content stored inside hash tables.\n"+
 		"--iteration        Number of iterations when content is read, default value is 1.\n"+
-		"--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, and 2 - All PID \n\n"+
+		"--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, and 2 - All PID \n"+
+		"--buffer           Test ring buffer versions of collectors (cachestat, dc, fd, oomkill, process, shm, swap, vfs, dns).\n\n"+
 		"You can also specify an unique eBPF program developed by Netdata with the following\n"+
 		"options:\n"+
 		"--btrfs            Latency for btrfs.\n"+
@@ -530,6 +533,8 @@ func parseArguments(args []string, kernelVersion int, logger *logState) (options
 				pidLevel = 0
 			}
 			opts.mapLevel = pidLevel
+		case "buffer":
+			opts.bufferMode = true
 		}
 	}
 
@@ -539,6 +544,11 @@ func parseArguments(args []string, kernelVersion int, logger *logState) (options
 
 	if !opts.unitTest && kernelVersion < netdataEBPFKernel414 {
 		opts.flags &^= flagOOMKill
+	}
+
+	if opts.bufferMode && kernelVersion < netdataEBPFKernel58 {
+		fmt.Fprintf(logger.writer, "\"Error\" : \"Ring buffer support requires kernel >= 5.8, current version is not supported.\",\n")
+		return opts, 1
 	}
 
 	return opts, 0
@@ -608,8 +618,13 @@ func resolveBinaryDir(netdataPath string) string {
 	return netdataPath
 }
 
-func candidateMatches(filename string, moduleName string, isReturn bool, version string, rhfVersion int) bool {
-	prefix := fmt.Sprintf("%cnetdata_ebpf_%s.", map[bool]rune{true: 'r', false: 'p'}[isReturn], moduleName)
+func candidateMatches(filename string, moduleName string, isReturn bool, version string, rhfVersion int, bufferMode bool) bool {
+	var prefix string
+	if bufferMode {
+		prefix = fmt.Sprintf("%cnetdata_ebpf_%s_buffer.", map[bool]rune{true: 'r', false: 'p'}[isReturn], moduleName)
+	} else {
+		prefix = fmt.Sprintf("%cnetdata_ebpf_%s.", map[bool]rune{true: 'r', false: 'p'}[isReturn], moduleName)
+	}
 	if !strings.HasPrefix(filename, prefix) || !strings.HasSuffix(filename, ".o") {
 		return false
 	}
@@ -630,7 +645,7 @@ func candidateMatches(filename string, moduleName string, isReturn bool, version
 	return !hasRHF
 }
 
-func discoverCandidates(moduleName string, isReturn bool, version string, rhfVersion int, netdataPath string) []string {
+func discoverCandidates(moduleName string, isReturn bool, version string, rhfVersion int, netdataPath string, bufferMode bool) []string {
 	path := resolveBinaryDir(netdataPath)
 	entries, err := os.ReadDir(path)
 	if err != nil {
@@ -642,7 +657,7 @@ func discoverCandidates(moduleName string, isReturn bool, version string, rhfVer
 		if entry.IsDir() {
 			continue
 		}
-		if !candidateMatches(entry.Name(), moduleName, isReturn, version, rhfVersion) {
+		if !candidateMatches(entry.Name(), moduleName, isReturn, version, rhfVersion, bufferMode) {
 			continue
 		}
 
@@ -866,6 +881,21 @@ func updateNames(names []specifyName) {
 	}
 }
 
+func moduleHasBuffer(name string) bool {
+	bufferModules := map[string]bool{
+		"cachestat": true,
+		"dc":        true,
+		"fd":        true,
+		"oomkill":   true,
+		"process":   true,
+		"shm":       true,
+		"swap":      true,
+		"vfs":       true,
+		"dns":       true,
+	}
+	return bufferModules[name]
+}
+
 func runNetdataTests(w io.Writer, rhfVersion int, kernelVersion int, isReturn bool, opts options, nprocesses int) {
 	supportedMapTypes := detectSupportedMapTypes(rhfVersion, kernelVersion)
 
@@ -874,9 +904,13 @@ func runNetdataTests(w io.Writer, rhfVersion int, kernelVersion int, isReturn bo
 			continue
 		}
 
+		if opts.bufferMode && !moduleHasBuffer(mod.name) {
+			continue
+		}
+
 		idx := selectIndex(mod.kernels, rhfVersion, kernelVersion)
 		version := selectKernelName(idx)
-		candidates := discoverCandidates(mod.name, isReturn, version, rhfVersion, opts.netdataPath)
+		candidates := discoverCandidates(mod.name, isReturn, version, rhfVersion, opts.netdataPath, opts.bufferMode)
 		compatible, incompatible, unsupportedType := filterCompatibleCandidates(candidates, supportedMapTypes)
 
 		if len(compatible) == 0 {
@@ -887,7 +921,7 @@ func runNetdataTests(w io.Writer, rhfVersion int, kernelVersion int, isReturn bo
 				continue
 			}
 
-			compatible = []string{mountName(idx, mod.name, isReturn, rhfVersion, opts.netdataPath)}
+			compatible = []string{mountName(idx, mod.name, isReturn, rhfVersion, opts.netdataPath, opts.bufferMode)}
 		}
 
 		for _, filename := range compatible {
@@ -952,7 +986,7 @@ func selectIndex(kernels uint32, rhfVersion int, kernelVersion int) uint32 {
 	return 0
 }
 
-func mountName(kernelIndex uint32, name string, isReturn bool, rhfVersion int, netdataPath string) string {
+func mountName(kernelIndex uint32, name string, isReturn bool, rhfVersion int, netdataPath string, bufferMode bool) string {
 	version := selectKernelName(kernelIndex)
 	path := netdataPath
 	if path == "" {
@@ -979,7 +1013,12 @@ func mountName(kernelIndex uint32, name string, isReturn bool, rhfVersion int, n
 		suffix = ".rhf"
 	}
 
-	return fmt.Sprintf("%s/%cnetdata_ebpf_%s.%s%s.o", path, prefix, name, version, suffix)
+	var bufferStr string
+	if bufferMode {
+		bufferStr = "_buffer"
+	}
+
+	return fmt.Sprintf("%s/%cnetdata_ebpf_%s%s.%s%s.o", path, prefix, name, bufferStr, version, suffix)
 }
 
 func startExternalJSON(w io.Writer, filename string) {

--- a/gotests/main.go
+++ b/gotests/main.go
@@ -553,6 +553,7 @@ func parseArguments(args []string, kernelVersion int, logger *logState) (options
 			opts.mapLevel = pidLevel
 		case "buffer":
 			opts.bufferMode = true
+			opts.flags |= flagContent
 		}
 	}
 
@@ -1380,7 +1381,7 @@ func testRingBufferMap(w io.Writer, meta mapMeta, iterations int) {
 	var prevSamples uint64
 	var prevBytes uint64
 	for i := 0; i < iterations; i++ {
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		opErr := setupErr
 		opResult := 0

--- a/gotests/main_test.go
+++ b/gotests/main_test.go
@@ -210,14 +210,37 @@ func TestCandidateSelectionHelpers(t *testing.T) {
 			bpfMapTypeArray:       true,
 			bpfMapTypePerCPUHash:  true,
 			bpfMapTypePerCPUArray: false,
+			bpfMapTypeRingBuf:     false,
+			bpfMapTypeUserRingBuf: true,
 		}
 
-		mapType, ok := firstUnsupportedMapType([]uint32{bpfMapTypeHash, bpfMapTypePerCPUArray}, supported)
+		mapType, ok := firstUnsupportedMapType([]uint32{bpfMapTypeHash, bpfMapTypeRingBuf, bpfMapTypePerCPUArray}, supported)
 		if !ok {
 			t.Fatal("expected unsupported map type")
 		}
-		if mapType != bpfMapTypePerCPUArray {
-			t.Fatalf("unexpected unsupported map type: got %d want %d", mapType, bpfMapTypePerCPUArray)
+		if mapType != bpfMapTypeRingBuf {
+			t.Fatalf("unexpected unsupported map type: got %d want %d", mapType, bpfMapTypeRingBuf)
+		}
+	})
+
+	t.Run("names ring buffer map types", func(t *testing.T) {
+		if got := mapTypeName(bpfMapTypeRingBuf); got != "ringbuf" {
+			t.Fatalf("unexpected ringbuf name: %q", got)
+		}
+		if got := mapTypeName(bpfMapTypeUserRingBuf); got != "user_ringbuf" {
+			t.Fatalf("unexpected user ringbuf name: %q", got)
+		}
+	})
+
+	t.Run("disables key value io for ring buffers", func(t *testing.T) {
+		if supportsMapKeyValueIO(bpfMapTypeRingBuf) {
+			t.Fatal("ringbuf should not use generic key/value io")
+		}
+		if supportsMapKeyValueIO(bpfMapTypeUserRingBuf) {
+			t.Fatal("user ringbuf should not use generic key/value io")
+		}
+		if !supportsMapKeyValueIO(bpfMapTypeHash) {
+			t.Fatal("hash maps should keep generic key/value io")
 		}
 	})
 

--- a/gotests/main_test.go
+++ b/gotests/main_test.go
@@ -166,7 +166,7 @@ func TestCandidateSelectionHelpers(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				if got := candidateMatches(tc.filename, tc.module, tc.isReturn, tc.version, tc.rhf); got != tc.wantMatch {
+				if got := candidateMatches(tc.filename, tc.module, tc.isReturn, tc.version, tc.rhf, false); got != tc.wantMatch {
 					t.Fatalf("unexpected match result for %q: got %v want %v", tc.filename, got, tc.wantMatch)
 				}
 			})
@@ -188,7 +188,7 @@ func TestCandidateSelectionHelpers(t *testing.T) {
 			}
 		}
 
-		got := discoverCandidates("swap", false, "3.10", 1, dir)
+		got := discoverCandidates("swap", false, "3.10", 1, dir, false)
 		want := []string{
 			filepath.Join(dir, "pnetdata_ebpf_swap.3.10.rhf.o"),
 			filepath.Join(dir, "pnetdata_ebpf_swap.3.10.variant.rhf.o"),

--- a/gotests/main_test.go
+++ b/gotests/main_test.go
@@ -329,6 +329,36 @@ func TestParseArgumentsUnitTest(t *testing.T) {
 	}
 }
 
+func TestParseArgumentsAll(t *testing.T) {
+	t.Run("--all enables content flag for PID collection", func(t *testing.T) {
+		var log bytes.Buffer
+		opts, code := parseArguments([]string{"--all"}, netdataEBPFKernel68, &logState{writer: &log})
+		if code != 0 {
+			t.Fatalf("unexpected parse code: %d", code)
+		}
+		if opts.flags&flagContent == 0 {
+			t.Fatal("--all must enable flagContent so PID collection runs via fillCtrl/testMaps")
+		}
+		if opts.flags&flagCollectors == 0 {
+			t.Fatal("--all must enable flagCollectors")
+		}
+	})
+
+	t.Run("--pid 3 is accepted", func(t *testing.T) {
+		var log bytes.Buffer
+		opts, code := parseArguments([]string{"--all", "--pid", "3"}, netdataEBPFKernel68, &logState{writer: &log})
+		if code != 0 {
+			t.Fatalf("unexpected parse code: %d", code)
+		}
+		if opts.mapLevel != 3 {
+			t.Fatalf("expected mapLevel 3 (ring buffer mode), got %d", opts.mapLevel)
+		}
+		if log.Len() != 0 {
+			t.Fatalf("expected no parse error for pid=3, got %q", log.String())
+		}
+	})
+}
+
 func TestResolveUnitTestDir(t *testing.T) {
 	t.Run("finds gotests module from repo root cwd", func(t *testing.T) {
 		root := t.TempDir()

--- a/gotests/main_test.go
+++ b/gotests/main_test.go
@@ -188,7 +188,7 @@ func TestCandidateSelectionHelpers(t *testing.T) {
 			}
 		}
 
-		got := discoverCandidates("swap", false, "3.10", 1, dir, false)
+		got := discoverCandidates("swap", false, 1, netdataV310, 0, dir, false)
 		want := []string{
 			filepath.Join(dir, "pnetdata_ebpf_swap.3.10.rhf.o"),
 			filepath.Join(dir, "pnetdata_ebpf_swap.3.10.variant.rhf.o"),
@@ -201,6 +201,28 @@ func TestCandidateSelectionHelpers(t *testing.T) {
 			if got[i] != want[i] {
 				t.Fatalf("unexpected candidate ordering: got %v want %v", got, want)
 			}
+		}
+	})
+
+	t.Run("discovers best compatible version in netdata path", func(t *testing.T) {
+		dir := t.TempDir()
+		files := []string{
+			"pnetdata_ebpf_swap.5.4.o",
+			"pnetdata_ebpf_swap.6.8.o",
+			"pnetdata_ebpf_swap.6.12.o",
+			"rnetdata_ebpf_swap.6.12.o",
+			"pnetdata_ebpf_swap.5.14.rhf.o",
+		}
+		for _, name := range files {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+				t.Fatalf("cannot create %s: %v", name, err)
+			}
+		}
+
+		got := discoverCandidates("swap", false, -1, netdataV54|netdataV68|netdataV612, 11, dir, false)
+		want := []string{filepath.Join(dir, "pnetdata_ebpf_swap.6.12.o")}
+		if len(got) != len(want) || got[0] != want[0] {
+			t.Fatalf("unexpected candidates: got %v want %v", got, want)
 		}
 	})
 

--- a/gotests/main_test.go
+++ b/gotests/main_test.go
@@ -359,6 +359,22 @@ func TestParseArgumentsAll(t *testing.T) {
 	})
 }
 
+func TestParseArgumentsBuffer(t *testing.T) {
+	t.Run("--buffer enables content flag for ring buffer data", func(t *testing.T) {
+		var log bytes.Buffer
+		opts, code := parseArguments([]string{"--buffer"}, netdataEBPFKernel612, &logState{writer: &log})
+		if code != 0 {
+			t.Fatalf("unexpected parse code: %d", code)
+		}
+		if !opts.bufferMode {
+			t.Fatal("--buffer must set bufferMode")
+		}
+		if opts.flags&flagContent == 0 {
+			t.Fatal("--buffer must enable flagContent so ring buffer data is collected and ring size is shown")
+		}
+	})
+}
+
 func TestResolveUnitTestDir(t *testing.T) {
 	t.Run("finds gotests module from repo root cwd", func(t *testing.T) {
 		root := t.TempDir()

--- a/includes/netdata_cache_buffer.h
+++ b/includes/netdata_cache_buffer.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_CACHE_BUFFER_H_
+#define _NETDATA_CACHE_BUFFER_H_ 1
+
+#define NETDATA_CACHESTAT_RINGBUF_SIZE (1 << 20)
+
+enum netdata_cachestat_event_action {
+    NETDATA_CACHESTAT_EVENT_PAGE_CACHE_LRU = 0,
+    NETDATA_CACHESTAT_EVENT_PAGE_ACCESSED  = 1,
+    NETDATA_CACHESTAT_EVENT_PAGE_DIRTIED   = 2,
+    NETDATA_CACHESTAT_EVENT_BUFFER_DIRTY   = 3,
+};
+
+struct netdata_cachestat_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  pad[3];
+};
+
+#endif /* _NETDATA_CACHE_BUFFER_H_ */

--- a/includes/netdata_common.h
+++ b/includes/netdata_common.h
@@ -233,6 +233,12 @@ static __always_inline __u32 monitor_apps(void *ctrl_tbl)
         __uint(max_entries, MAX_ENTRIES); \
     } NAME SEC(".maps")
 
+#define NETDATA_BPF_RINGBUF_MAP_DEF(NAME, TYPE, MAX_ENTRIES) \
+    struct { \
+        __uint(type, TYPE); \
+        __uint(max_entries, MAX_ENTRIES); \
+    } NAME SEC(".maps")
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0))
 #define NETDATA_BPF_HASH_DEF(NAME, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
     NETDATA_BPF_MAP_DEF(NAME, BPF_MAP_TYPE_HASH, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES)
@@ -245,6 +251,12 @@ static __always_inline __u32 monitor_apps(void *ctrl_tbl)
 
 #define NETDATA_BPF_PERCPU_ARRAY_DEF(NAME, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
     NETDATA_BPF_MAP_DEF(NAME, BPF_MAP_TYPE_PERCPU_ARRAY, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES)
+
+#define NETDATA_BPF_RINGBUF_DEF(NAME, MAX_ENTRIES) \
+    NETDATA_BPF_RINGBUF_MAP_DEF(NAME, BPF_MAP_TYPE_RINGBUF, MAX_ENTRIES)
+
+#define NETDATA_BPF_USER_RINGBUF_DEF(NAME, MAX_ENTRIES) \
+    NETDATA_BPF_RINGBUF_MAP_DEF(NAME, BPF_MAP_TYPE_USER_RINGBUF, MAX_ENTRIES)
 #else
 #define NETDATA_BPF_HASH_DEF(NAME, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
     NETDATA_BPF_MAP_DEF(NAME, BPF_MAP_TYPE_HASH, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES)
@@ -257,6 +269,12 @@ static __always_inline __u32 monitor_apps(void *ctrl_tbl)
 
 #define NETDATA_BPF_PERCPU_ARRAY_DEF(NAME, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
     NETDATA_BPF_MAP_DEF(NAME, BPF_MAP_TYPE_ARRAY, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES)
+
+#define NETDATA_BPF_RINGBUF_DEF(NAME, MAX_ENTRIES) \
+    NETDATA_BPF_RINGBUF_MAP_DEF(NAME, BPF_MAP_TYPE_RINGBUF, MAX_ENTRIES)
+
+#define NETDATA_BPF_USER_RINGBUF_DEF(NAME, MAX_ENTRIES) \
+    NETDATA_BPF_RINGBUF_MAP_DEF(NAME, BPF_MAP_TYPE_USER_RINGBUF, MAX_ENTRIES)
 #endif
 
 #else
@@ -265,6 +283,14 @@ static __always_inline __u32 monitor_apps(void *ctrl_tbl)
         .type = TYPE, \
         .key_size = sizeof(KEY_TYPE), \
         .value_size = sizeof(VALUE_TYPE), \
+        .max_entries = MAX_ENTRIES \
+    }
+
+#define NETDATA_BPF_RINGBUF_MAP_DEF(NAME, TYPE, MAX_ENTRIES) \
+    struct bpf_map_def SEC("maps") NAME = { \
+        .type = TYPE, \
+        .key_size = 0, \
+        .value_size = 0, \
         .max_entries = MAX_ENTRIES \
     }
 
@@ -280,7 +306,12 @@ static __always_inline __u32 monitor_apps(void *ctrl_tbl)
 #define NETDATA_BPF_PERCPU_ARRAY_DEF(NAME, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
     NETDATA_BPF_MAP_DEF(NAME, BPF_MAP_TYPE_ARRAY, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES)
 
+#define NETDATA_BPF_RINGBUF_DEF(NAME, MAX_ENTRIES) \
+    NETDATA_BPF_RINGBUF_MAP_DEF(NAME, BPF_MAP_TYPE_RINGBUF, MAX_ENTRIES)
+
+#define NETDATA_BPF_USER_RINGBUF_DEF(NAME, MAX_ENTRIES) \
+    NETDATA_BPF_RINGBUF_MAP_DEF(NAME, BPF_MAP_TYPE_USER_RINGBUF, MAX_ENTRIES)
+
 #endif
 
 #endif /* _NETDATA_COMMON_ */
-

--- a/includes/netdata_dc_buffer.h
+++ b/includes/netdata_dc_buffer.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_DC_BUFFER_H_
+#define _NETDATA_DC_BUFFER_H_ 1
+
+#define NETDATA_DC_RINGBUF_SIZE (1 << 20)
+
+enum netdata_dc_event_action {
+    NETDATA_DC_EVENT_REFERENCE = 0,
+    NETDATA_DC_EVENT_SLOW      = 1,
+    NETDATA_DC_EVENT_SLOW_MISS = 2,
+};
+
+struct netdata_dc_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  pad[3];
+};
+
+#endif /* _NETDATA_DC_BUFFER_H_ */

--- a/includes/netdata_dns_buffer.h
+++ b/includes/netdata_dns_buffer.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_DNS_BUFFER_H_
+#define _NETDATA_DNS_BUFFER_H_ 1
+
+#define NETDATA_DNS_RINGBUF_SIZE (1 << 20)
+
+enum netdata_dns_event_direction {
+    NETDATA_DNS_QUERY    = 0,   /* packet destined for a DNS port */
+    NETDATA_DNS_RESPONSE = 1,   /* packet originating from a DNS port */
+};
+
+/*
+ * saddr/daddr layout matches union netdata_ip.addr32:
+ *   IPv4 — addr in [0], [1..3] = 0
+ *   IPv6 — full 128-bit address across all four slots
+ */
+struct netdata_dns_event_t {
+    __u64 ct;           /* bpf_ktime_get_ns() at capture time */
+    __u32 saddr[4];     /* source IP */
+    __u32 daddr[4];     /* destination IP */
+    __u32 pkt_len;      /* skb->len in bytes */
+    __u16 sport;        /* source port (host byte order) */
+    __u16 dport;        /* destination port (host byte order) */
+    __u8  protocol;     /* IPPROTO_UDP or IPPROTO_TCP */
+    __u8  ip_version;   /* 4 or 6 */
+    __u8  direction;    /* netdata_dns_event_direction */
+    __u8  pad;
+};
+
+#endif /* _NETDATA_DNS_BUFFER_H_ */

--- a/includes/netdata_fd_buffer.h
+++ b/includes/netdata_fd_buffer.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_FD_BUFFER_H_
+#define _NETDATA_FD_BUFFER_H_ 1
+
+#define NETDATA_FD_RINGBUF_SIZE (1 << 20)
+
+enum netdata_fd_event_action {
+    NETDATA_FD_EVENT_OPEN  = 0,
+    NETDATA_FD_EVENT_CLOSE = 1,
+};
+
+struct netdata_fd_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  error;
+    __u8  pad[2];
+};
+
+#endif /* _NETDATA_FD_BUFFER_H_ */

--- a/includes/netdata_oomkill_buffer.h
+++ b/includes/netdata_oomkill_buffer.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_OOMKILL_BUFFER_H_
+#define _NETDATA_OOMKILL_BUFFER_H_ 1
+
+#define NETDATA_OOMKILL_RINGBUF_SIZE (1 << 20)
+
+struct netdata_oomkill_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 pad;
+};
+
+#endif /* _NETDATA_OOMKILL_BUFFER_H_ */

--- a/includes/netdata_process_buffer.h
+++ b/includes/netdata_process_buffer.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_PROCESS_BUFFER_H_
+#define _NETDATA_PROCESS_BUFFER_H_ 1
+
+#define NETDATA_PROCESS_RINGBUF_SIZE (1 << 20)
+
+enum netdata_process_event_action {
+    NETDATA_PROCESS_EVENT_EXIT     = 0,
+    NETDATA_PROCESS_EVENT_RELEASE  = 1,
+    NETDATA_PROCESS_EVENT_EXEC     = 2,
+    NETDATA_PROCESS_EVENT_FORK     = 3,
+    NETDATA_PROCESS_EVENT_THREAD   = 4,
+    NETDATA_PROCESS_EVENT_FORK_ERR = 5,
+};
+
+struct netdata_process_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  pad[3];
+};
+
+#endif /* _NETDATA_PROCESS_BUFFER_H_ */

--- a/includes/netdata_shm_buffer.h
+++ b/includes/netdata_shm_buffer.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_SHM_BUFFER_H_
+#define _NETDATA_SHM_BUFFER_H_ 1
+
+#define NETDATA_SHM_RINGBUF_SIZE (1 << 20)
+
+enum netdata_shm_event_action {
+    NETDATA_SHM_EVENT_GET = 0,
+    NETDATA_SHM_EVENT_AT  = 1,
+    NETDATA_SHM_EVENT_DT  = 2,
+    NETDATA_SHM_EVENT_CTL = 3,
+};
+
+struct netdata_shm_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  pad[3];
+};
+
+#endif /* _NETDATA_SHM_BUFFER_H_ */

--- a/includes/netdata_swap_buffer.h
+++ b/includes/netdata_swap_buffer.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_SWAP_BUFFER_H_
+#define _NETDATA_SWAP_BUFFER_H_ 1
+
+#define NETDATA_SWAP_RINGBUF_SIZE (1 << 20)
+
+enum netdata_swap_event_action {
+    NETDATA_SWAP_EVENT_READ  = 0,
+    NETDATA_SWAP_EVENT_WRITE = 1,
+};
+
+struct netdata_swap_event_t {
+    __u64 ct;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  pad[3];
+};
+
+#endif /* _NETDATA_SWAP_BUFFER_H_ */

--- a/includes/netdata_vfs_buffer.h
+++ b/includes/netdata_vfs_buffer.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_VFS_BUFFER_H_
+#define _NETDATA_VFS_BUFFER_H_ 1
+
+#define NETDATA_VFS_RINGBUF_SIZE (1 << 20)
+
+enum netdata_vfs_event_action {
+    NETDATA_VFS_EVENT_WRITE  = 0,
+    NETDATA_VFS_EVENT_WRITEV = 1,
+    NETDATA_VFS_EVENT_READ   = 2,
+    NETDATA_VFS_EVENT_READV  = 3,
+    NETDATA_VFS_EVENT_UNLINK = 4,
+    NETDATA_VFS_EVENT_FSYNC  = 5,
+    NETDATA_VFS_EVENT_OPEN   = 6,
+    NETDATA_VFS_EVENT_CREATE = 7,
+};
+
+struct netdata_vfs_event_t {
+    __u64 ct;
+    __u64 bytes;
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    char  name[TASK_COMM_LEN];
+    __u8  action;
+    __u8  error;
+    __u8  pad[2];
+};
+
+#endif /* _NETDATA_VFS_BUFFER_H_ */

--- a/kernel/DEVELOPER.md
+++ b/kernel/DEVELOPER.md
@@ -62,12 +62,20 @@ unnecessary headers inside eBPF codes. Thanks this every time you see the prepro
 means that we are using codes that will be compiled with latest `libbpf` version.
 
 
-For all hash tables we are defining:
+For key/value tables we are defining:
 
 - Type: We are working with [HASH](https://docs.kernel.org/bpf/map_hash.html) and  [ARRAY](https://docs.kernel.org/bpf/map_array.html)
 - Key size: the size in bytes of the key.
 - Value size: the size in bytes of the value.
 - Max entries: Number of entries expected in the table.
+
+For ring-buffer maps we use dedicated helpers in [`includes/netdata_common.h`](../includes/netdata_common.h):
+
+- `NETDATA_BPF_RINGBUF_DEF`
+- `NETDATA_BPF_USER_RINGBUF_DEF`
+
+These maps are not generic key/value maps. Their key and value sizes are zero, and user-space tests must use
+ring-buffer-specific logic instead of `lookup`, `get_next_key`, or generic `update` paths.
 
 ### Tracers
 
@@ -104,6 +112,9 @@ for j in `seq 0 2`; do for i in `ls *.o`; do ./gotests/go_tester --content --pid
 
 The `legacy_test` and `go_tester` binaries are compiled with debug symbols to
 make local debugging easier.
+
+When a tested object contains `BPF_MAP_TYPE_RINGBUF` or `BPF_MAP_TYPE_USER_RINGBUF`, both testers switch to
+ring-buffer-specific handling. They no longer try to iterate those maps as generic key/value tables.
 
 You can take a look in all options available for tests running:
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -107,9 +107,24 @@ else
 CC_LIBBPF = gcc
 endif
 
-all: $(NETDATA_APPS)
+# BPF_MAP_TYPE_RINGBUF requires kernel >= 5.8 (329728 = 5 * 65536 + 8 * 256)
+ifeq ($(shell test $(CURRENT_KERNEL) -ge 329728 ; echo $$?),0)
+NETDATA_RINGBUF_APPS= cachestat_buffer \
+                      dc_buffer \
+                      fd_buffer \
+                      oomkill_buffer \
+                      process_buffer \
+                      shm_buffer \
+                      swap_buffer \
+                      vfs_buffer \
+                      #
+else
+NETDATA_RINGBUF_APPS=
+endif
 
-dev: ${NETDATA_ALL_APPS}
+all: $(NETDATA_APPS) $(NETDATA_RINGBUF_APPS)
+
+dev: ${NETDATA_ALL_APPS} ${NETDATA_RINGBUF_APPS}
 
 libbpf:
 	# -fPIE added to be compatible with olders clang/gcc
@@ -151,6 +166,8 @@ libbpf:
 $(NETDATA_APPS): %: %_kern.o
 
 ${NETDATA_ALL_APPS}: %: %_kern.o
+
+${NETDATA_RINGBUF_APPS}: %: %_kern.o
 
 tester: libbpf
 	cd ../tests && $(MAKE) tester

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -111,6 +111,7 @@ endif
 ifeq ($(shell test $(CURRENT_KERNEL) -ge 329728 ; echo $$?),0)
 NETDATA_RINGBUF_APPS= cachestat_buffer \
                       dc_buffer \
+                      dns_buffer \
                       fd_buffer \
                       oomkill_buffer \
                       process_buffer \

--- a/kernel/cachestat_buffer_kern.c
+++ b/kernel/cachestat_buffer_kern.c
@@ -1,0 +1,171 @@
+#define KBUILD_MODNAME "cachestat_buffer_kern"
+#include <linux/version.h>
+#include <linux/sched.h>
+#include <linux/mm_types.h>
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_cache.h"
+#include "netdata_cache_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(cachestat_events, NETDATA_CACHESTAT_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(cstat_global, __u32, __u64, NETDATA_CACHESTAT_END);
+NETDATA_BPF_ARRAY_DEF(cstat_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_cachestat_fill_event(struct netdata_cachestat_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = ev->pad[2] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/add_to_page_cache_lru")
+int netdata_add_to_page_cache_lru_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU, 1);
+
+    if (!monitor_apps(&cstat_ctrl))
+        return 0;
+
+    struct netdata_cachestat_event_t *ev = bpf_ringbuf_reserve(&cachestat_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_cachestat_fill_event(ev, &cstat_ctrl);
+    ev->action = NETDATA_CACHESTAT_EVENT_PAGE_CACHE_LRU;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+SEC("kprobe/mark_page_accessed")
+int netdata_mark_page_accessed_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED, 1);
+
+    if (!monitor_apps(&cstat_ctrl))
+        return 0;
+
+    struct netdata_cachestat_event_t *ev = bpf_ringbuf_reserve(&cachestat_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_cachestat_fill_event(ev, &cstat_ctrl);
+    ev->action = NETDATA_CACHESTAT_EVENT_PAGE_ACCESSED;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
+SEC("kprobe/__folio_mark_dirty")
+#else
+SEC("kprobe/__set_page_dirty")
+#endif
+int netdata_set_page_dirty_buffer(struct pt_regs *ctx)
+{
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,16,0))
+    /* On 5.15, skip anonymous pages that have no backing store. */
+    struct page *page = (struct page *)PT_REGS_PARM1(ctx);
+    struct address_space *mapping = _(page->mapping);
+    if (!mapping)
+        return 0;
+#endif
+
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
+
+    if (!monitor_apps(&cstat_ctrl))
+        return 0;
+
+    struct netdata_cachestat_event_t *ev = bpf_ringbuf_reserve(&cachestat_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_cachestat_fill_event(ev, &cstat_ctrl);
+    ev->action = NETDATA_CACHESTAT_EVENT_PAGE_DIRTIED;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#else  /* < 5.15.0 */
+
+#if defined(RHEL_MAJOR) && (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0))
+SEC("kprobe/__folio_mark_dirty")
+#else
+SEC("kprobe/account_page_dirtied")
+#endif
+int netdata_account_page_dirtied_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED, 1);
+
+    if (!monitor_apps(&cstat_ctrl))
+        return 0;
+
+    struct netdata_cachestat_event_t *ev = bpf_ringbuf_reserve(&cachestat_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_cachestat_fill_event(ev, &cstat_ctrl);
+    ev->action = NETDATA_CACHESTAT_EVENT_PAGE_DIRTIED;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#endif  /* LINUX_VERSION_CODE >= 5.15.0 */
+
+SEC("kprobe/mark_buffer_dirty")
+int netdata_mark_buffer_dirty_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY, 1);
+
+    if (!monitor_apps(&cstat_ctrl))
+        return 0;
+
+    struct netdata_cachestat_event_t *ev = bpf_ringbuf_reserve(&cachestat_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_cachestat_fill_event(ev, &cstat_ctrl);
+    ev->action = NETDATA_CACHESTAT_EVENT_BUFFER_DIRTY;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/dc_buffer_kern.c
+++ b/kernel/dc_buffer_kern.c
@@ -1,0 +1,99 @@
+#define KBUILD_MODNAME "dc_buffer_kern"
+#include <linux/version.h>
+#include <linux/sched.h>
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_dc.h"
+#include "netdata_dc_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(dc_events, NETDATA_DC_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(dcstat_global, __u32, __u64, NETDATA_DIRECTORY_CACHE_END);
+NETDATA_BPF_PERCPU_ARRAY_DEF(dcstat_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_dc_fill_event(struct netdata_dc_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = ev->pad[2] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+SEC("kprobe/lookup_fast")
+int netdata_lookup_fast_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
+
+    if (!monitor_apps(&dcstat_ctrl))
+        return 0;
+
+    struct netdata_dc_event_t *ev = bpf_ringbuf_reserve(&dc_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_dc_fill_event(ev, &dcstat_ctrl);
+    ev->action = NETDATA_DC_EVENT_REFERENCE;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+SEC("kretprobe/d_lookup")
+int netdata_d_lookup_buffer(struct pt_regs *ctx)
+{
+    int ret = PT_REGS_RC(ctx);
+
+    libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_SLOW, 1);
+    if (ret == 0)
+        libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
+
+    if (!monitor_apps(&dcstat_ctrl))
+        return 0;
+
+    struct netdata_dc_event_t *ev = bpf_ringbuf_reserve(&dc_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_dc_fill_event(ev, &dcstat_ctrl);
+    /*
+     * ret == 0 means d_lookup found nothing (cache miss).
+     * Encode both slow-path and miss in a single event to avoid a second reserve/submit.
+     */
+    ev->action = (ret == 0) ? NETDATA_DC_EVENT_SLOW_MISS : NETDATA_DC_EVENT_SLOW;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/dns_buffer_kern.c
+++ b/kernel/dns_buffer_kern.c
@@ -1,0 +1,207 @@
+#define KBUILD_MODNAME "dns_buffer_netdata"
+#include <linux/if_ether.h>
+#include <linux/if_vlan.h>
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+#include <linux/version.h>
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+
+#include "bpf_endian.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_dns_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(dns_events, NETDATA_DNS_RINGBUF_SIZE);
+
+/*
+ * Configurable set of DNS ports. User space populates this before attaching
+ * the filter — the same design as dns_kern.c.
+ */
+NETDATA_BPF_HASH_DEF(dns_ports, __u16, __u8, 32);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline int read_l2_protocol(struct __sk_buff *skb, __u64 *offset, __u16 *protocol)
+{
+    struct ethhdr eth = { };
+
+    if (bpf_skb_load_bytes(skb, 0, &eth, sizeof(eth)) < 0)
+        return 0;
+
+    *offset = sizeof(eth);
+    *protocol = bpf_ntohs(eth.h_proto);
+
+    if (*protocol == ETH_P_8021Q || *protocol == ETH_P_8021AD) {
+        struct vlan_hdr vlan = { };
+
+        if (bpf_skb_load_bytes(skb, *offset, &vlan, sizeof(vlan)) < 0)
+            return 0;
+
+        *offset += sizeof(vlan);
+        *protocol = bpf_ntohs(vlan.h_vlan_encapsulated_proto);
+    }
+
+    return 1;
+}
+
+/*
+ * Parse the L3 header, advance *offset past it, and fill saddr/daddr.
+ * Returns the IP version (4 or 6) on success, 0 on failure.
+ * saddr and daddr must each point to a 16-byte (4 x __u32) buffer.
+ */
+static __always_inline __u8 read_l3_info(struct __sk_buff *skb, __u64 *offset, __u16 l2_protocol,
+                                          __u8 *transport_protocol,
+                                          __u32 *saddr, __u32 *daddr)
+{
+    if (l2_protocol == ETH_P_IP) {
+        struct iphdr iph = { };
+        __u16 frag;
+
+        if (bpf_skb_load_bytes(skb, *offset, &iph, sizeof(iph)) < 0)
+            return 0;
+
+        if (iph.ihl < 5)
+            return 0;
+
+        frag = bpf_ntohs(iph.frag_off);
+        if (frag & 0x1FFF)  /* non-first fragments have no complete L4 header */
+            return 0;
+
+        *transport_protocol = iph.protocol;
+        saddr[0] = iph.saddr;
+        saddr[1] = saddr[2] = saddr[3] = 0;
+        daddr[0] = iph.daddr;
+        daddr[1] = daddr[2] = daddr[3] = 0;
+        *offset += (__u64)iph.ihl * 4;
+        return 4;
+
+    } else if (l2_protocol == ETH_P_IPV6) {
+        struct ipv6hdr ip6h = { };
+
+        if (bpf_skb_load_bytes(skb, *offset, &ip6h, sizeof(ip6h)) < 0)
+            return 0;
+
+        *transport_protocol = ip6h.nexthdr;
+
+        if (bpf_skb_load_bytes(skb, *offset + offsetof(struct ipv6hdr, saddr), saddr, 16) < 0)
+            return 0;
+        if (bpf_skb_load_bytes(skb, *offset + offsetof(struct ipv6hdr, daddr), daddr, 16) < 0)
+            return 0;
+
+        *offset += sizeof(ip6h);
+        return 6;
+    }
+
+    return 0;
+}
+
+static __always_inline int read_transport_ports(struct __sk_buff *skb, __u64 offset, __u8 protocol,
+                                                 __u16 *sport, __u16 *dport)
+{
+    if (protocol == IPPROTO_UDP) {
+        struct udphdr udp = { };
+
+        if (bpf_skb_load_bytes(skb, offset, &udp, sizeof(udp)) < 0)
+            return 0;
+
+        *sport = bpf_ntohs(udp.source);
+        *dport = bpf_ntohs(udp.dest);
+        return 1;
+    }
+
+    if (protocol == IPPROTO_TCP) {
+        struct tcphdr tcp = { };
+
+        if (bpf_skb_load_bytes(skb, offset, &tcp, sizeof(tcp)) < 0)
+            return 0;
+
+        *sport = bpf_ntohs(tcp.source);
+        *dport = bpf_ntohs(tcp.dest);
+        return 1;
+    }
+
+    return 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Filter Section
+ *
+ ***********************************************************************************/
+
+SEC("socket")
+int socket__dns_filter_buffer(struct __sk_buff *skb)
+{
+    __u64 offset = 0;
+    __u16 l2_protocol = 0;
+    __u8  transport_protocol = 0;
+    __u8  ip_version = 0;
+    __u16 sport = 0, dport = 0;
+    __u32 saddr[4], daddr[4];
+
+    if (!read_l2_protocol(skb, &offset, &l2_protocol))
+        return 0;
+
+    ip_version = read_l3_info(skb, &offset, l2_protocol, &transport_protocol, saddr, daddr);
+    if (!ip_version)
+        return 0;
+
+    if (!read_transport_ports(skb, offset, transport_protocol, &sport, &dport))
+        return 0;
+
+    /* Determine direction: query goes TO a DNS port, response comes FROM one. */
+    __u8 is_query    = bpf_map_lookup_elem(&dns_ports, &dport) ? 1 : 0;
+    __u8 is_response = (!is_query && bpf_map_lookup_elem(&dns_ports, &sport)) ? 1 : 0;
+
+    if (!is_query && !is_response)
+        return 0;
+
+    struct netdata_dns_event_t *ev = bpf_ringbuf_reserve(&dns_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    ev->ct         = bpf_ktime_get_ns();
+    ev->saddr[0]   = saddr[0];
+    ev->saddr[1]   = saddr[1];
+    ev->saddr[2]   = saddr[2];
+    ev->saddr[3]   = saddr[3];
+    ev->daddr[0]   = daddr[0];
+    ev->daddr[1]   = daddr[1];
+    ev->daddr[2]   = daddr[2];
+    ev->daddr[3]   = daddr[3];
+    ev->pkt_len    = skb->len;
+    ev->sport      = sport;
+    ev->dport      = dport;
+    ev->protocol   = transport_protocol;
+    ev->ip_version = ip_version;
+    ev->direction  = is_query ? NETDATA_DNS_QUERY : NETDATA_DNS_RESPONSE;
+    ev->pad        = 0;
+
+    bpf_ringbuf_submit(ev, 0);
+
+    /*
+     * Return 0 (drop) — user space reads structured events from the ring buffer
+     * and no longer needs raw packet delivery via the socket.
+     */
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/fd_buffer_kern.c
+++ b/kernel/fd_buffer_kern.c
@@ -1,0 +1,151 @@
+#define KBUILD_MODNAME "fd_buffer_kern"
+#include <linux/version.h>
+#include <linux/ptrace.h>
+#include <linux/sched.h>
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,10,17))
+# include <linux/sched/task.h>
+#endif
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_fd.h"
+#include "netdata_fd_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(fd_events, NETDATA_FD_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(tbl_fd_global, __u32, __u64, NETDATA_FD_COUNTER);
+NETDATA_BPF_ARRAY_DEF(fd_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_fd_fill_event(struct netdata_fd_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5,5,19))
+#if NETDATASEL < 2
+SEC("kretprobe/do_sys_open")
+#else
+SEC("kprobe/do_sys_open")
+#endif
+#else
+#if NETDATASEL < 2
+SEC("kretprobe/do_sys_openat2")
+#else
+SEC("kprobe/do_sys_openat2")
+#endif
+#endif
+int netdata_sys_open_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    int ret = (int)PT_REGS_RC(ctx);
+#endif
+
+    libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_CALLS_DO_SYS_OPEN, 1);
+#if NETDATASEL < 2
+    if (ret < 0)
+        libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_ERROR_DO_SYS_OPEN, 1);
+#endif
+
+    if (!monitor_apps(&fd_ctrl))
+        return 0;
+
+    struct netdata_fd_event_t *ev = bpf_ringbuf_reserve(&fd_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_fd_fill_event(ev, &fd_ctrl);
+    ev->action = NETDATA_FD_EVENT_OPEN;
+#if NETDATASEL < 2
+    ev->error  = (ret < 0) ? 1 : 0;
+#else
+    ev->error  = 0;
+#endif
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+#if NETDATASEL < 2
+SEC("kretprobe/close_fd")
+#else
+SEC("kprobe/close_fd")
+#endif
+#elif defined(RHEL_MAJOR) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)) && (LINUX_VERSION_CODE <= KERNEL_VERSION(4,19,0))
+#if NETDATASEL < 2
+SEC("kretprobe/close_fd")
+#else
+SEC("kprobe/close_fd")
+#endif
+#else
+#if NETDATASEL < 2
+SEC("kretprobe/__close_fd")
+#else
+SEC("kprobe/__close_fd")
+#endif
+#endif
+int netdata_close_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    int ret = (int)PT_REGS_RC(ctx);
+#endif
+
+    libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_CALLS_CLOSE_FD, 1);
+#if NETDATASEL < 2
+    if (ret < 0)
+        libnetdata_update_global(&tbl_fd_global, NETDATA_KEY_ERROR_CLOSE_FD, 1);
+#endif
+
+    if (!monitor_apps(&fd_ctrl))
+        return 0;
+
+    struct netdata_fd_event_t *ev = bpf_ringbuf_reserve(&fd_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_fd_fill_event(ev, &fd_ctrl);
+    ev->action = NETDATA_FD_EVENT_CLOSE;
+#if NETDATASEL < 2
+    ev->error  = (ret < 0) ? 1 : 0;
+#else
+    ev->error  = 0;
+#endif
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/oomkill_buffer_kern.c
+++ b/kernel/oomkill_buffer_kern.c
@@ -1,0 +1,45 @@
+#define KBUILD_MODNAME "oomkill_buffer_kern"
+#include <linux/ptrace.h>
+#include <linux/version.h>
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_oomkill.h"
+#include "netdata_oomkill_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(oomkill_events, NETDATA_OOMKILL_RINGBUF_SIZE);
+
+/************************************************************************************
+ *
+ *                                   Probe Section
+ *
+ ***********************************************************************************/
+
+SEC("tracepoint/oom/mark_victim")
+int netdata_oom_mark_victim_buffer(struct netdata_oom_mark_victim_entry *ptr)
+{
+    struct netdata_oomkill_event_t *ev = bpf_ringbuf_reserve(&oomkill_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    ev->ct  = bpf_ktime_get_ns();
+    ev->pad = 0;
+    bpf_probe_read(&ev->pid, sizeof(ev->pid), &ptr->pid);
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/process_buffer_kern.c
+++ b/kernel/process_buffer_kern.c
@@ -1,0 +1,217 @@
+#define KBUILD_MODNAME "process_buffer_kern"
+#include <linux/version.h>
+#include <linux/ptrace.h>
+#include <linux/sched.h>
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,10,17))
+# include <linux/sched/task.h>
+#endif
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_process.h"
+#include "netdata_process_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(process_events, NETDATA_PROCESS_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(tbl_total_stats, __u32, __u64, NETDATA_GLOBAL_COUNTER);
+NETDATA_BPF_ARRAY_DEF(process_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_process_fill_event(struct netdata_process_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = ev->pad[2] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+SEC("tracepoint/sched/sched_process_exit")
+int netdata_tracepoint_sched_process_exit_buffer(struct netdata_sched_process_exit *ptr)
+{
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_EXIT, 1);
+
+    if (!monitor_apps(&process_ctrl))
+        return 0;
+
+    struct netdata_process_event_t *ev = bpf_ringbuf_reserve(&process_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_process_fill_event(ev, &process_ctrl);
+    ev->action = NETDATA_PROCESS_EVENT_EXIT;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+SEC("kprobe/release_task")
+int netdata_release_task_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_RELEASE_TASK, 1);
+
+    if (!monitor_apps(&process_ctrl))
+        return 0;
+
+    struct netdata_process_event_t *ev = bpf_ringbuf_reserve(&process_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_process_fill_event(ev, &process_ctrl);
+    ev->action = NETDATA_PROCESS_EVENT_RELEASE;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exec")
+int netdata_tracepoint_sched_process_exec_buffer(struct netdata_sched_process_exec *ptr)
+{
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
+
+    if (!monitor_apps(&process_ctrl))
+        return 0;
+
+    struct netdata_process_event_t *ev = bpf_ringbuf_reserve(&process_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_process_fill_event(ev, &process_ctrl);
+    ev->action = NETDATA_PROCESS_EVENT_EXEC;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_fork")
+int netdata_tracepoint_sched_process_fork_buffer(void *ctx)
+{
+    libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
+
+    /*
+     * Read parent_pid and child_pid via byte offsets to avoid direct typed-context
+     * dereference, which can interfere with user-ring metadata consumers on newer kernels.
+     * Offsets come from /sys/kernel/tracing/events/sched/sched_process_fork/format.
+     */
+    int parent_pid = 0, child_pid = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0))
+    /* fork_v2: u64 pad(0) + char[4](8) + int parent_pid(12) + char[4](16) + int child_pid(20) */
+    bpf_probe_read(&parent_pid, sizeof(parent_pid), (char *)ctx + 12);
+    bpf_probe_read(&child_pid,  sizeof(child_pid),  (char *)ctx + 20);
+#else
+    /* fork_v1: u64 pad(0) + char[16](8) + int parent_pid(24) + char[16](28) + int child_pid(44) */
+    bpf_probe_read(&parent_pid, sizeof(parent_pid), (char *)ctx + 24);
+    bpf_probe_read(&child_pid,  sizeof(child_pid),  (char *)ctx + 44);
+#endif
+
+    __u8 is_thread = (parent_pid != child_pid && parent_pid != 1) ? 1 : 0;
+    if (is_thread)
+        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_THREAD, 1);
+
+    if (!monitor_apps(&process_ctrl))
+        return 0;
+
+    struct netdata_process_event_t *ev = bpf_ringbuf_reserve(&process_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_process_fill_event(ev, &process_ctrl);
+    ev->action = is_thread ? NETDATA_PROCESS_EVENT_THREAD : NETDATA_PROCESS_EVENT_FORK;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5,9,16))
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0))
+# if NETDATASEL < 2
+SEC("kretprobe/_do_fork")
+# else
+SEC("kprobe/_do_fork")
+# endif
+#else
+# if NETDATASEL < 2
+SEC("kretprobe/do_fork")
+# else
+SEC("kprobe/do_fork")
+# endif
+#endif
+int netdata_fork_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_PROCESS, 1);
+
+        if (monitor_apps(&process_ctrl)) {
+            struct netdata_process_event_t *ev = bpf_ringbuf_reserve(&process_events, sizeof(*ev), 0);
+            if (ev) {
+                netdata_process_fill_event(ev, &process_ctrl);
+                ev->action = NETDATA_PROCESS_EVENT_FORK_ERR;
+                bpf_ringbuf_submit(ev, 0);
+            }
+        }
+    }
+#endif
+    return 0;
+}
+
+#else
+
+#if NETDATASEL < 2
+SEC("kretprobe/kernel_clone")
+#else
+SEC("kprobe/kernel_clone")
+#endif
+int netdata_sys_clone_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret < 0) {
+        libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_ERROR_PROCESS, 1);
+
+        if (monitor_apps(&process_ctrl)) {
+            struct netdata_process_event_t *ev = bpf_ringbuf_reserve(&process_events, sizeof(*ev), 0);
+            if (ev) {
+                netdata_process_fill_event(ev, &process_ctrl);
+                ev->action = NETDATA_PROCESS_EVENT_FORK_ERR;
+                bpf_ringbuf_submit(ev, 0);
+            }
+        }
+    }
+#endif
+    return 0;
+}
+
+#endif
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/shm_buffer_kern.c
+++ b/kernel/shm_buffer_kern.c
@@ -1,0 +1,145 @@
+#define KBUILD_MODNAME "shm_buffer_kern"
+#include <linux/version.h>
+#include <linux/sched.h>
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_shm.h"
+#include "netdata_shm_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(shm_events, NETDATA_SHM_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(tbl_shm, __u32, __u64, NETDATA_SHM_END);
+NETDATA_BPF_ARRAY_DEF(shm_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_shm_fill_event(struct netdata_shm_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = ev->pad[2] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+#if defined(LIBBPF_MAJOR_VERSION) && (LIBBPF_MAJOR_VERSION >= 1)
+SEC("ksyscall/shmget")
+#else
+SEC("kprobe/" NETDATA_SYSCALL(shmget))
+#endif
+int netdata_syscall_shmget_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_shm, NETDATA_KEY_SHMGET_CALL, 1);
+
+    if (!monitor_apps(&shm_ctrl))
+        return 0;
+
+    struct netdata_shm_event_t *ev = bpf_ringbuf_reserve(&shm_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_shm_fill_event(ev, &shm_ctrl);
+    ev->action = NETDATA_SHM_EVENT_GET;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if defined(LIBBPF_MAJOR_VERSION) && (LIBBPF_MAJOR_VERSION >= 1)
+SEC("ksyscall/shmat")
+#else
+SEC("kprobe/" NETDATA_SYSCALL(shmat))
+#endif
+int netdata_syscall_shmat_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_shm, NETDATA_KEY_SHMAT_CALL, 1);
+
+    if (!monitor_apps(&shm_ctrl))
+        return 0;
+
+    struct netdata_shm_event_t *ev = bpf_ringbuf_reserve(&shm_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_shm_fill_event(ev, &shm_ctrl);
+    ev->action = NETDATA_SHM_EVENT_AT;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if defined(LIBBPF_MAJOR_VERSION) && (LIBBPF_MAJOR_VERSION >= 1)
+SEC("ksyscall/shmdt")
+#else
+SEC("kprobe/" NETDATA_SYSCALL(shmdt))
+#endif
+int netdata_syscall_shmdt_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_shm, NETDATA_KEY_SHMDT_CALL, 1);
+
+    if (!monitor_apps(&shm_ctrl))
+        return 0;
+
+    struct netdata_shm_event_t *ev = bpf_ringbuf_reserve(&shm_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_shm_fill_event(ev, &shm_ctrl);
+    ev->action = NETDATA_SHM_EVENT_DT;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if defined(LIBBPF_MAJOR_VERSION) && (LIBBPF_MAJOR_VERSION >= 1)
+SEC("ksyscall/shmctl")
+#else
+SEC("kprobe/" NETDATA_SYSCALL(shmctl))
+#endif
+int netdata_syscall_shmctl_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_shm, NETDATA_KEY_SHMCTL_CALL, 1);
+
+    if (!monitor_apps(&shm_ctrl))
+        return 0;
+
+    struct netdata_shm_event_t *ev = bpf_ringbuf_reserve(&shm_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_shm_fill_event(ev, &shm_ctrl);
+    ev->action = NETDATA_SHM_EVENT_CTL;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/swap_buffer_kern.c
+++ b/kernel/swap_buffer_kern.c
@@ -1,0 +1,99 @@
+#define KBUILD_MODNAME "swap_buffer_kern"
+#include <linux/version.h>
+#include <linux/sched.h>
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_swap.h"
+#include "netdata_swap_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(swap_events, NETDATA_SWAP_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(tbl_swap, __u32, __u64, NETDATA_SWAP_END);
+NETDATA_BPF_ARRAY_DEF(swap_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_swap_fill_event(struct netdata_swap_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = ev->pad[2] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6,7,255))
+SEC("kprobe/swap_read_folio")
+#else
+SEC("kprobe/swap_readpage")
+#endif
+int netdata_swap_readpage_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_READPAGE_CALL, 1);
+
+    if (!monitor_apps(&swap_ctrl))
+        return 0;
+
+    struct netdata_swap_event_t *ev = bpf_ringbuf_reserve(&swap_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_swap_fill_event(ev, &swap_ctrl);
+    ev->action = NETDATA_SWAP_EVENT_READ;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0))
+SEC("kprobe/__swap_writepage")
+#else
+SEC("kprobe/swap_writepage")
+#endif
+int netdata_swap_writepage_buffer(struct pt_regs *ctx)
+{
+    libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_WRITEPAGE_CALL, 1);
+
+    if (!monitor_apps(&swap_ctrl))
+        return 0;
+
+    struct netdata_swap_event_t *ev = bpf_ringbuf_reserve(&swap_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_swap_fill_event(ev, &swap_ctrl);
+    ev->action = NETDATA_SWAP_EVENT_WRITE;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/kernel/vfs_buffer_kern.c
+++ b/kernel/vfs_buffer_kern.c
@@ -1,0 +1,345 @@
+#define KBUILD_MODNAME "vfs_buffer_kern"
+#include <linux/version.h>
+#include <linux/ptrace.h>
+#include <linux/sched.h>
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,10,17))
+# include <linux/sched/task.h>
+#endif
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+#include <uapi/linux/bpf.h>
+#else
+#include <linux/bpf.h>
+#endif
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "netdata_common.h"
+#include "netdata_vfs.h"
+#include "netdata_vfs_buffer.h"
+
+/************************************************************************************
+ *
+ *                                 MAPS Section
+ *
+ ***********************************************************************************/
+
+NETDATA_BPF_RINGBUF_DEF(vfs_events, NETDATA_VFS_RINGBUF_SIZE);
+NETDATA_BPF_PERCPU_ARRAY_DEF(tbl_vfs_stats, __u32, __u64, NETDATA_VFS_COUNTER);
+NETDATA_BPF_ARRAY_DEF(vfs_ctrl, __u32, __u64, NETDATA_CONTROLLER_END);
+
+/************************************************************************************
+ *
+ *                                Local Functions
+ *
+ ***********************************************************************************/
+
+static __always_inline void netdata_vfs_fill_event(struct netdata_vfs_event_t *ev, void *ctrl)
+{
+    __u32 tgid = 0;
+    ev->ct   = bpf_ktime_get_ns();
+    ev->pid  = netdata_get_pid(ctrl, &tgid);
+    ev->tgid = tgid;
+    libnetdata_update_uid_gid(&ev->uid, &ev->gid);
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(ev->name, TASK_COMM_LEN);
+#else
+    ev->name[0] = '\0';
+#endif
+    ev->pad[0] = ev->pad[1] = 0;
+}
+
+/************************************************************************************
+ *
+ *                                   Probes Section
+ *
+ ***********************************************************************************/
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_write")
+#else
+SEC("kprobe/vfs_write")
+#endif
+int netdata_sys_write_buffer(struct pt_regs *ctx)
+{
+    ssize_t bytes = (ssize_t)PT_REGS_PARM3(ctx);
+#if NETDATASEL < 2
+    __u8 err = ((ssize_t)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITE, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITE, 1);
+#endif
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, libnetdata_log2l(bytes));
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = (__u64)bytes;
+    ev->action = NETDATA_VFS_EVENT_WRITE;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_writev")
+#else
+SEC("kprobe/vfs_writev")
+#endif
+int netdata_sys_writev_buffer(struct pt_regs *ctx)
+{
+    ssize_t bytes = (ssize_t)PT_REGS_PARM3(ctx);
+#if NETDATASEL < 2
+    __u8 err = ((ssize_t)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_WRITEV, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_WRITEV, 1);
+#endif
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, libnetdata_log2l(bytes));
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = (__u64)bytes;
+    ev->action = NETDATA_VFS_EVENT_WRITEV;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_read")
+#else
+SEC("kprobe/vfs_read")
+#endif
+int netdata_sys_read_buffer(struct pt_regs *ctx)
+{
+    ssize_t bytes = (ssize_t)PT_REGS_PARM3(ctx);
+#if NETDATASEL < 2
+    __u8 err = ((ssize_t)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_READ, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READ, 1);
+#endif
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, libnetdata_log2l(bytes));
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = (__u64)bytes;
+    ev->action = NETDATA_VFS_EVENT_READ;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_readv")
+#else
+SEC("kprobe/vfs_readv")
+#endif
+int netdata_sys_readv_buffer(struct pt_regs *ctx)
+{
+    ssize_t bytes = (ssize_t)PT_REGS_PARM3(ctx);
+#if NETDATASEL < 2
+    __u8 err = ((ssize_t)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_READV, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_READV, 1);
+#endif
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, libnetdata_log2l(bytes));
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = (__u64)bytes;
+    ev->action = NETDATA_VFS_EVENT_READV;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_unlink")
+#else
+SEC("kprobe/vfs_unlink")
+#endif
+int netdata_sys_unlink_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    __u8 err = ((int)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_UNLINK, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_UNLINK, 1);
+#endif
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = 0;
+    ev->action = NETDATA_VFS_EVENT_UNLINK;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_fsync")
+#else
+SEC("kprobe/vfs_fsync")
+#endif
+int netdata_vfs_fsync_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    __u8 err = ((int)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_FSYNC, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
+#endif
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = 0;
+    ev->action = NETDATA_VFS_EVENT_FSYNC;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_open")
+#else
+SEC("kprobe/vfs_open")
+#endif
+int netdata_vfs_open_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    __u8 err = ((int)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_OPEN, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
+#endif
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = 0;
+    ev->action = NETDATA_VFS_EVENT_OPEN;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+#if NETDATASEL < 2
+SEC("kretprobe/vfs_create")
+#else
+SEC("kprobe/vfs_create")
+#endif
+int netdata_vfs_create_buffer(struct pt_regs *ctx)
+{
+#if NETDATASEL < 2
+    __u8 err = ((int)PT_REGS_RC(ctx) < 0) ? 1 : 0;
+#else
+    __u8 err = 0;
+#endif
+
+    libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_CREATE, 1);
+#if NETDATASEL < 2
+    if (err)
+        libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
+#endif
+
+    if (!monitor_apps(&vfs_ctrl))
+        return 0;
+
+    struct netdata_vfs_event_t *ev = bpf_ringbuf_reserve(&vfs_events, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    netdata_vfs_fill_event(ev, &vfs_ctrl);
+    ev->bytes  = 0;
+    ev->action = NETDATA_VFS_EVENT_CREATE;
+    ev->error  = err;
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -128,7 +128,14 @@ typedef struct ebpf_map_support {
     int array;
     int percpu_array;
     int percpu_hash;
+    int ringbuf;
+    int user_ringbuf;
 } ebpf_map_support_t;
+
+typedef struct ebpf_ringbuf_stats {
+    size_t samples;
+    size_t bytes;
+} ebpf_ringbuf_stats_t;
 
 typedef struct ebpf_candidate_list {
     char **files;
@@ -157,6 +164,21 @@ static int ebpf_possible_cpu_count(void)
 static int ebpf_map_is_percpu(uint32_t type)
 {
     return type == BPF_MAP_TYPE_PERCPU_ARRAY || type == BPF_MAP_TYPE_PERCPU_HASH;
+}
+
+static int ebpf_map_is_ringbuf(uint32_t type)
+{
+    return type == BPF_MAP_TYPE_RINGBUF || type == BPF_MAP_TYPE_USER_RINGBUF;
+}
+
+static int ebpf_map_is_user_ringbuf(uint32_t type)
+{
+    return type == BPF_MAP_TYPE_USER_RINGBUF;
+}
+
+static int ebpf_map_supports_key_value_io(uint32_t type)
+{
+    return !ebpf_map_is_ringbuf(type);
 }
 
 static size_t ebpf_map_value_stride(uint32_t type, size_t value_size)
@@ -263,6 +285,34 @@ static const char *ebpf_describe_error(int err, char *buffer, size_t length)
 
     snprintf(buffer, length, "%s", strerror(code));
     return buffer;
+}
+
+static int ebpf_ringbuf_sample_cb(void *ctx, void *data, size_t size)
+{
+    ebpf_ringbuf_stats_t *stats = ctx;
+
+    (void)data;
+    if (stats) {
+        stats->samples++;
+        stats->bytes += size;
+    }
+
+    return 0;
+}
+
+static int ebpf_user_ringbuf_submit_sample(struct user_ring_buffer *rb, uint64_t value)
+{
+    void *sample;
+
+    errno = 0;
+    sample = user_ring_buffer__reserve(rb, sizeof(value));
+    if (!sample)
+        return -(errno ? errno : EIO);
+
+    memcpy(sample, &value, sizeof(value));
+    user_ring_buffer__submit(rb, sample);
+
+    return 0;
 }
 
 static void ebpf_write_program_inventory(struct bpf_object *obj)
@@ -482,6 +532,8 @@ static void ebpf_detect_map_support(ebpf_map_support_t *support, int rhf_version
     support->array = support->hash;
     support->percpu_array = ebpf_should_fallback_percpu_support(rhf_version, kver);
     support->percpu_hash = support->percpu_array;
+    support->ringbuf = 0;
+    support->user_ringbuf = 0;
 
     probe = ebpf_probe_map_type_support(BPF_MAP_TYPE_HASH);
     if (probe >= 0)
@@ -498,6 +550,14 @@ static void ebpf_detect_map_support(ebpf_map_support_t *support, int rhf_version
     probe = ebpf_probe_map_type_support(BPF_MAP_TYPE_PERCPU_HASH);
     if (probe >= 0)
         support->percpu_hash = probe > 0;
+
+    probe = ebpf_probe_map_type_support(BPF_MAP_TYPE_RINGBUF);
+    if (probe >= 0)
+        support->ringbuf = probe > 0;
+
+    probe = ebpf_probe_map_type_support(BPF_MAP_TYPE_USER_RINGBUF);
+    if (probe >= 0)
+        support->user_ringbuf = probe > 0;
 }
 
 static const char *ebpf_map_type_name(int map_type)
@@ -511,6 +571,10 @@ static const char *ebpf_map_type_name(int map_type)
             return "percpu_hash";
         case BPF_MAP_TYPE_PERCPU_ARRAY:
             return "percpu_array";
+        case BPF_MAP_TYPE_RINGBUF:
+            return "ringbuf";
+        case BPF_MAP_TYPE_USER_RINGBUF:
+            return "user_ringbuf";
         default:
             return "unknown";
     }
@@ -527,6 +591,10 @@ static int ebpf_is_supported_map_type(const ebpf_map_support_t *support, int map
             return support->percpu_hash;
         case BPF_MAP_TYPE_PERCPU_ARRAY:
             return support->percpu_array;
+        case BPF_MAP_TYPE_RINGBUF:
+            return support->ringbuf;
+        case BPF_MAP_TYPE_USER_RINGBUF:
+            return support->user_ringbuf;
         default:
             return 1;
     }
@@ -573,8 +641,16 @@ static void ebpf_write_supported_map_types_json(const ebpf_map_support_t *suppor
         fprintf(stdlog, "%s\"percpu_hash\"", first ? "" : ", ");
         first = 0;
     }
-    if (support->percpu_array)
+    if (support->percpu_array) {
         fprintf(stdlog, "%s\"percpu_array\"", first ? "" : ", ");
+        first = 0;
+    }
+    if (support->ringbuf) {
+        fprintf(stdlog, "%s\"ringbuf\"", first ? "" : ", ");
+        first = 0;
+    }
+    if (support->user_ringbuf)
+        fprintf(stdlog, "%s\"user_ringbuf\"", first ? "" : ", ");
 
     fprintf(stdlog, "]");
 }
@@ -582,7 +658,7 @@ static void ebpf_write_supported_map_types_json(const ebpf_map_support_t *suppor
 static void ebpf_write_object_map_types(struct bpf_object *obj)
 {
     struct bpf_map *map;
-    int seen_hash = 0, seen_array = 0, seen_percpu_hash = 0, seen_percpu_array = 0;
+    int seen[__MAX_BPF_MAP_TYPE] = { 0 };
     int first = 1;
 
     fprintf(stdlog, "        \"Map Types Used\" : [");
@@ -598,10 +674,7 @@ static void ebpf_write_object_map_types(struct bpf_object *obj)
             }
 #endif
 
-            if ((type == BPF_MAP_TYPE_HASH && seen_hash) ||
-                (type == BPF_MAP_TYPE_ARRAY && seen_array) ||
-                (type == BPF_MAP_TYPE_PERCPU_HASH && seen_percpu_hash) ||
-                (type == BPF_MAP_TYPE_PERCPU_ARRAY && seen_percpu_array))
+            if (type >= 0 && type < __MAX_BPF_MAP_TYPE && seen[type])
                 continue;
 
             if (!first)
@@ -610,14 +683,8 @@ static void ebpf_write_object_map_types(struct bpf_object *obj)
             fprintf(stdlog, "\"%s\"", ebpf_map_type_name(type));
             first = 0;
 
-            if (type == BPF_MAP_TYPE_HASH)
-                seen_hash = 1;
-            else if (type == BPF_MAP_TYPE_ARRAY)
-                seen_array = 1;
-            else if (type == BPF_MAP_TYPE_PERCPU_HASH)
-                seen_percpu_hash = 1;
-            else if (type == BPF_MAP_TYPE_PERCPU_ARRAY)
-                seen_percpu_array = 1;
+            if (type >= 0 && type < __MAX_BPF_MAP_TYPE)
+                seen[type] = 1;
         }
     }
 
@@ -1321,6 +1388,92 @@ static void ebpf_controller_json(ebpf_table_data_t *values, int fd)
             value + zero,  value, zero);
 }
 
+static void ebpf_test_ringbuf_map(const char *name, int fd, uint32_t type, uint32_t key_size, uint32_t value_size)
+{
+    char error_buffer[128];
+    const char *mode = ebpf_map_is_user_ringbuf(type) ? "user_ringbuf_producer" : "ringbuf_consumer";
+    struct ring_buffer *rb = NULL;
+    struct user_ring_buffer *urb = NULL;
+    ebpf_ringbuf_stats_t stats = { 0 };
+    ebpf_ringbuf_stats_t previous = { 0 };
+    int setup_error = 0;
+    int i;
+
+    fprintf(stdlog,
+            "        \"%s\" : {\n"
+            "            \"Info\" : { \"Length\" : { \"Key\" : %u, \"Value\" : %u},\n"
+            "                       \"Type\" : %u,\n"
+            "                       \"FD\" : %d,\n"
+            "                       \"Data\" : [\n",
+            name, key_size, value_size, type, fd);
+
+    if (type == BPF_MAP_TYPE_RINGBUF) {
+        rb = ring_buffer__new(fd, ebpf_ringbuf_sample_cb, &stats, NULL);
+        setup_error = (int)libbpf_get_error(rb);
+        if (setup_error)
+            rb = NULL;
+    } else {
+        urb = user_ring_buffer__new(fd, NULL);
+        setup_error = (int)libbpf_get_error(urb);
+        if (setup_error)
+            urb = NULL;
+    }
+
+    for (i = 0; i < end_iteration; i++) {
+        int op_error = setup_error;
+        int op_result = 0;
+        size_t iter_samples = 0;
+        size_t iter_bytes = 0;
+        size_t ring_size = 0;
+        size_t avail_data = 0;
+        const char *error_message;
+
+        sleep(5);
+
+        if (type == BPF_MAP_TYPE_RINGBUF && rb) {
+            struct ring *ring = ring_buffer__ring(rb, 0);
+
+            op_result = ring_buffer__poll(rb, 0);
+            if (op_result < 0)
+                op_error = op_result;
+
+            iter_samples = stats.samples - previous.samples;
+            iter_bytes = stats.bytes - previous.bytes;
+            previous = stats;
+
+            if (ring) {
+                ring_size = ring__size(ring);
+                avail_data = ring__avail_data_size(ring);
+            }
+        } else if (type == BPF_MAP_TYPE_USER_RINGBUF && urb) {
+            op_result = ebpf_user_ringbuf_submit_sample(urb, (uint64_t)(i + 1));
+            if (op_result < 0)
+                op_error = op_result;
+        }
+
+        error_message = ebpf_describe_error(op_error, error_buffer, sizeof(error_buffer));
+
+        if (i)
+            fprintf(stdlog, ",\n");
+
+        fprintf(stdlog,
+                "                                    "
+                "{ \"Iteration\" : %d, \"Mode\" : \"%s\", \"Setup\" : %d, "
+                "\"Operation Result\" : %d, \"Samples\" : %zu, \"Bytes\" : %zu, "
+                "\"Available\" : %zu, \"Ring Size\" : %zu, \"Error Code\" : %d, "
+                "\"Error Message\" : \"%s\" }",
+                i, mode, setup_error == 0, op_result, iter_samples, iter_bytes,
+                avail_data, ring_size, op_error, error_message);
+    }
+
+    fprintf(stdlog, "\n");
+
+    if (rb)
+        ring_buffer__free(rb);
+    if (urb)
+        user_ring_buffer__free(urb);
+}
+
 /**
  * Test Maps
  *
@@ -1352,6 +1505,15 @@ static void ebpf_test_maps(struct bpf_object *obj, char *ctrl)
         key_size = def->key_size;
         value_size = def->value_size;
 #endif
+        if (!ebpf_map_supports_key_value_io(type)) {
+            ebpf_test_ringbuf_map(name, fd, type, key_size, value_size);
+            fprintf(stdlog, "                                ]\n"
+                    "                      }\n"
+                    "        },\n");
+            tables++;
+            continue;
+        }
+
         values = ebpf_allocate_tables(name, type, key_size, value_size);
         if (values) {
             // Write header
@@ -1418,6 +1580,12 @@ static void ebpf_fill_ctrl(struct bpf_object *obj, char *ctrl)
         value_size = def->value_size;
         end = def->max_entries;
 #endif
+        if (!ebpf_map_supports_key_value_io(type)) {
+            fprintf(stdlog, "\"error\" : \"Control table %s uses unsupported map type %s.\",",
+                    name, ebpf_map_type_name(type));
+            continue;
+        }
+
         uint64_t values[NETDATA_CONTROLLER_END] = { 1, (uint64_t)map_level, 0, 0, 0, 0 };
         size_t value_length = ebpf_map_value_buffer_length(type, value_size);
         size_t value_stride = ebpf_map_value_stride(type, value_size);

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -112,6 +112,7 @@ ebpf_module_t ebpf_modules[] = {
 char *specific_ebpf = NULL;
 char *netdata_path = NULL;
 char *log_path = NULL;
+int buffer_mode = 0;
 #define NETDATA_DEFAULT_PROCESS_NUMBER 4096
 #define NETDATA_DNS_MAX_PORTS 32
 #define NETDATA_DNS_DEFAULT_PORT 53
@@ -442,7 +443,10 @@ static int ebpf_candidate_matches(const char *filename, const char *name, int is
     const char *rest;
     int has_rhf;
 
-    snprintf(prefix, sizeof(prefix), "%cnetdata_ebpf_%s.", (is_return) ? 'r' : 'p', name);
+    if (buffer_mode)
+        snprintf(prefix, sizeof(prefix), "%cnetdata_ebpf_%s_buffer.", (is_return) ? 'r' : 'p', name);
+    else
+        snprintf(prefix, sizeof(prefix), "%cnetdata_ebpf_%s.", (is_return) ? 'r' : 'p', name);
     prefix_len = strlen(prefix);
     if (filename_len <= prefix_len + 2)
         return 0;
@@ -955,17 +959,17 @@ static void ebpf_start_netdata_json(char *filename, int is_return)
 /**
  *  Mount Name
  *
- *  Mount name of eBPF program to be loaded. 
+ *  Mount name of eBPF program to be loaded.
  *
  *  Netdata eBPF programs has the following format:
- * 
+ *
  *      Tnetdata_ebpf_N.V.o
- *  
+ *
  *  where:
  *     T - Is the eBPF type. When starts with 'p', this means we are only adding probes,
- *         and when they start with 'r' we are using retprobes.     
+ *         and when they start with 'r' we are using retprobes.
  *     N - The eBPF program name.
- *     V - The kernel version in string format.    
+ *     V - The kernel version in string format.
  *
  *  @param out            the vector where the name will be stored
  *  @param len            the size of the out vector.
@@ -981,12 +985,20 @@ static void ebpf_mount_name(char *out, size_t len, uint32_t kver, char *name, in
     if (!path)
         path = ebpf_strdup_string(".");
 
-    snprintf(out, len, "%s/%cnetdata_ebpf_%s.%s%s.o", 
-            path,
-            (is_return) ? 'r' : 'p',
-            name,
-            version,
-            (rhf_version != -1) ? ".rhf" : "");
+    if (buffer_mode)
+        snprintf(out, len, "%s/%cnetdata_ebpf_%s_buffer.%s%s.o",
+                path,
+                (is_return) ? 'r' : 'p',
+                name,
+                version,
+                (rhf_version != -1) ? ".rhf" : "");
+    else
+        snprintf(out, len, "%s/%cnetdata_ebpf_%s.%s%s.o",
+                path,
+                (is_return) ? 'r' : 'p',
+                name,
+                version,
+                (rhf_version != -1) ? ".rhf" : "");
     free(path);
 }
 
@@ -1712,6 +1724,19 @@ static char *ebpf_tester(char *filename, ebpf_specify_name_t *names, uint32_t ma
  *  @param is_return     Load return or entry eBPF program
  *  @param flags         tests that software will run
  */
+static int ebpf_module_has_buffer(const char *name)
+{
+    static const char *buffer_modules[] = {
+        "cachestat", "dc", "fd", "oomkill", "process", "shm", "swap", "vfs", "dns", NULL
+    };
+    int i;
+    for (i = 0; buffer_modules[i]; i++) {
+        if (!strcmp(name, buffer_modules[i]))
+            return 1;
+    }
+    return 0;
+}
+
 static void ebpf_run_netdata_tests(int rhf_version, uint32_t kver, int is_return, uint64_t flags)
 {
     ebpf_map_support_t map_support;
@@ -1720,6 +1745,11 @@ static void ebpf_run_netdata_tests(int rhf_version, uint32_t kver, int is_return
 
     ebpf_detect_map_support(&map_support, rhf_version, kver);
     while (ebpf_modules[i].name) {
+        if (buffer_mode && !ebpf_module_has_buffer(ebpf_modules[i].name)) {
+            i++;
+            continue;
+        }
+
         if (flags & ebpf_modules[i].flags) {
             ebpf_candidate_list_t candidates;
             ebpf_candidate_list_t compatible = { 0 };
@@ -1823,7 +1853,8 @@ static void ebpf_help()
                     "                   software will use stderr.\n\n"
                     "--content          Test content stored inside hash tables.\n"
                     "--iteration        Number of iterations when content is read, default value is 1.\n"
-                    "--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, and 2 - All PID \n\n"
+                    "--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, and 2 - All PID \n"
+                    "--buffer           Test ring buffer versions of collectors (cachestat, dc, fd, oomkill, process, shm, swap, vfs, dns).\n\n"
                     "You can also specify an unique eBPF program developed by Netdata with the following\n"
                     "options:\n"
                     "--btrfs            Latency for btrfs.\n"
@@ -1917,6 +1948,7 @@ uint64_t ebpf_parse_arguments(int argc, char **argv, int kver)
         {"content",            no_argument,          0,  0 },
         {"iteration",          required_argument,    0,  0 },
         {"pid",                required_argument,    0,  0 },
+        {"buffer",             no_argument,          0,  0 },
 
         // this must be always the last option
         {0,                no_argument, 0, 0}
@@ -2111,7 +2143,17 @@ uint64_t ebpf_parse_arguments(int argc, char **argv, int kver)
                     map_level = value;
                     break;
                 }
+            case NETDATA_OPT_BUFFER:
+                {
+                    buffer_mode = 1;
+                    break;
+                }
         }
+    }
+
+    if (buffer_mode && kver < NETDATA_EBPF_KERNEL_5_8) {
+        fprintf(stdlog, "\"Error\" : \"Ring buffer support requires kernel >= 5.8, current version is not supported.\",\n");
+        exit(1);
     }
 
     // When user does not specify any flag, we will use common value

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -132,6 +132,7 @@ enum netdata_apps_level map_level = NETDATA_APPS_LEVEL_REAL_PARENT ;
 static uint16_t dns_ports[NETDATA_DNS_MAX_PORTS] = { NETDATA_DNS_DEFAULT_PORT };
 static size_t dns_port_count = 1;
 static int dns_ports_overridden = 0;
+static size_t tests_started = 0;
 
 typedef struct ebpf_map_support {
     int hash;
@@ -942,6 +943,7 @@ static uint32_t ebpf_select_index(uint32_t kernels, int rhf_version, uint32_t kv
  */
 static void ebpf_start_external_json(char *filename)
 {
+    tests_started++;
     fprintf(stdlog, "\n\"%s\" : {\n    \"Tables\" : {\n",
             filename);
 }
@@ -957,6 +959,7 @@ static void ebpf_start_external_json(char *filename)
 static void ebpf_start_netdata_json(char *filename, int is_return)
 {
     static int first = 1;
+    tests_started++;
     if (first) {
         first = 0;
         fprintf(stdlog, "\n");
@@ -2234,6 +2237,7 @@ int main(int argc, char **argv)
 {
     uint32_t my_kernel = ebpf_get_kernel_version();
     int rhf_version = ebpf_get_redhat_release();
+    int ret = 0;
     stdlog = stderr;
     nprocesses = sysconf(_SC_NPROCESSORS_ONLN);
     if (nprocesses < 0) {
@@ -2265,11 +2269,17 @@ int main(int argc, char **argv)
         }
     }
 
+    if (!tests_started) {
+        fprintf(stdlog,
+                "\"Error\" : \"No eBPF tests were started. Check selected options, binary name, and --netdata-path.\",\n");
+        ret = 1;
+    }
+
     // END JSON output
     fprintf(stdlog, "\"End\" : \"Good bye!!!\" }\n");
 
     if (log_path)
         fclose(stdlog);
 
-    return 0;
+    return ret;
 }

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -59,15 +59,17 @@ ebpf_module_t ebpf_modules[] = {
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_10 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_BTRFS, .name = "btrfs", .update_names = NULL, .ctrl_table = "btrfs_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_15 | NETDATA_V5_14 | NETDATA_V5_16,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_CACHESTAT, .name = "cachestat", .update_names = NULL, .ctrl_table = "cstat_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
-      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_DC, .name = "dc", .update_names = dc_optional_name, .ctrl_table = "dcstat_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_DISK, .name = "disk", .update_names = NULL, .ctrl_table = "disk_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_EXT4, .name = "ext4", .update_names = NULL, .ctrl_table = "ext4_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_11 | NETDATA_V5_14,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_FD, .name = "fd", .update_names = NULL, .ctrl_table = "fd_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SYNC, .name = "fdatasync", .update_names = NULL, .ctrl_table = NULL },
@@ -84,19 +86,20 @@ ebpf_module_t ebpf_modules[] = {
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SOCKET, .name = "socket", .update_names = NULL, .ctrl_table = "socket_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
-      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_DNS, .name = "dns", .update_names = NULL, .ctrl_table = NULL },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_NFS, .name = "nfs", .update_names = NULL, .ctrl_table = "nfs_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_NETWORK_VIEWER, .name = "network_viewer", .update_names = NULL, .ctrl_table = "nv_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
-      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_OOMKILL, .name = "oomkill", .update_names = NULL, .ctrl_table = NULL },
-    { .kernels =  NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V5_10,
+    { .kernels =  NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V5_10 | NETDATA_V6_12,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_PROCESS, .name = "process", .update_names = NULL, .ctrl_table = "process_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
-      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_SHM, .name = "shm", .update_names = NULL, .ctrl_table = "shm_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SOFTIRQ, .name = "softirq", .update_names = NULL, .ctrl_table = NULL },
@@ -106,9 +109,11 @@ ebpf_module_t ebpf_modules[] = {
       .flags = NETDATA_FLAG_SYNC, .name = "syncfs", .update_names = NULL, .ctrl_table = NULL },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SYNC, .name = "sync_file_range", .update_names = NULL, .ctrl_table = NULL },
-    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V6_8,
+    { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V6_8 | NETDATA_V6_12,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_SWAP, .name = "swap", .update_names = swap_optional_name, .ctrl_table = "swap_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8 | NETDATA_V6_12,
       .flags = NETDATA_FLAG_VFS, .name = "vfs", .update_names = NULL, .ctrl_table = "vfs_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_XFS, .name = "xfs", .update_names = NULL, .ctrl_table = "xfs_ctrl" },
@@ -133,6 +138,7 @@ static uint16_t dns_ports[NETDATA_DNS_MAX_PORTS] = { NETDATA_DNS_DEFAULT_PORT };
 static size_t dns_port_count = 1;
 static int dns_ports_overridden = 0;
 static size_t tests_started = 0;
+static char *ebpf_kernel_names[] = { "3.10", "4.14", "4.16", "4.18", "5.4", "5.10", "5.11", "5.14", "5.15", "5.16", "6.8", "6.12" };
 
 typedef struct ebpf_map_support {
     int hash;
@@ -478,12 +484,32 @@ static int ebpf_candidate_matches(const char *filename, const char *name, int is
     return !has_rhf;
 }
 
+static int ebpf_candidate_version_index(const char *filename, const char *name, int is_return,
+                                        int rhf_version, uint32_t kernels, uint32_t max_index)
+{
+    int idx;
+
+    if (rhf_version == -1)
+        kernels &= ~NETDATA_V5_14;
+
+    for (idx = (int)max_index; idx >= 0; idx--) {
+        if (!(kernels & (1U << idx)))
+            continue;
+
+        if (ebpf_candidate_matches(filename, name, is_return, ebpf_kernel_names[idx], rhf_version))
+            return idx;
+    }
+
+    return -1;
+}
+
 static void ebpf_discover_candidates(ebpf_candidate_list_t *list, const char *name, int is_return,
-                                     const char *version, int rhf_version)
+                                     uint32_t kernels, uint32_t max_index, int rhf_version)
 {
     char *path = ebpf_resolve_binary_directory();
     DIR *dir;
     struct dirent *entry;
+    int best_index = -1;
 
     memset(list, 0, sizeof(*list));
     if (!path)
@@ -497,12 +523,22 @@ static void ebpf_discover_candidates(ebpf_candidate_list_t *list, const char *na
 
     while ((entry = readdir(dir))) {
         char fullpath[PATH_MAX];
+        int candidate_index;
 
         if (entry->d_name[0] == '.')
             continue;
 
-        if (!ebpf_candidate_matches(entry->d_name, name, is_return, version, rhf_version))
+        candidate_index = ebpf_candidate_version_index(entry->d_name, name, is_return,
+                                                       rhf_version, kernels, max_index);
+        if (candidate_index < 0)
             continue;
+
+        if (candidate_index > best_index) {
+            ebpf_free_candidate_list(list);
+            best_index = candidate_index;
+        } else if (candidate_index < best_index) {
+            continue;
+        }
 
         snprintf(fullpath, sizeof(fullpath), "%s/%s", path, entry->d_name);
         if (ebpf_append_candidate(list, fullpath))
@@ -859,9 +895,7 @@ int ebpf_get_redhat_release()
  */
 static char *ebpf_select_kernel_name(uint32_t selector)
 {
-    static char *kernel_names[] = { "3.10", "4.14", "4.16", "4.18", "5.4", "5.10", "5.11", "5.14", "5.15", "5.16", "6.8" };
-
-    return kernel_names[selector];
+    return ebpf_kernel_names[selector];
 }
 
 /**
@@ -884,7 +918,9 @@ static int ebpf_select_max_index(int rhf_version, uint32_t kver)
         else if (kver >= NETDATA_EBPF_KERNEL_4_11)
             return 3;
     } else { // Kernels from kernel.org
-        if (kver >= NETDATA_EBPF_KERNEL_6_8)
+        if (kver >= NETDATA_EBPF_KERNEL_6_12)
+            return 11;
+        else if (kver >= NETDATA_EBPF_KERNEL_6_8)
             return 10;
 	else if (kver >= NETDATA_EBPF_KERNEL_5_16)
             return 9;
@@ -1770,10 +1806,11 @@ static void ebpf_run_netdata_tests(int rhf_version, uint32_t kver, int is_return
             size_t j;
             uint32_t kernels_to_use = (buffer_mode && ebpf_modules[i].buffer_kernels) ?
                                       ebpf_modules[i].buffer_kernels : ebpf_modules[i].kernels;
+            uint32_t max_idx = ebpf_select_max_index(rhf_version, kver);
             uint32_t idx = ebpf_select_index(kernels_to_use, rhf_version, kver);
-            char *version = ebpf_select_kernel_name(idx);
 
-            ebpf_discover_candidates(&candidates, ebpf_modules[i].name, is_return, version, rhf_version);
+            ebpf_discover_candidates(&candidates, ebpf_modules[i].name, is_return,
+                                     kernels_to_use, max_idx, rhf_version);
             for (j = 0; j < candidates.size; j++) {
                 struct bpf_object *obj = bpf_object__open_file(candidates.files[j], NULL);
                 if (libbpf_get_error(obj)) {
@@ -1907,7 +1944,7 @@ static void ebpf_help()
  */
 static uint64_t ebpf_set_common_flag()
 {
-    return NETDATA_FLAG_ALL &
+    return NETDATA_FLAG_COLLECTORS &
                              ~(NETDATA_FLAG_FS | NETDATA_FLAG_LOAD_BINARY | NETDATA_FLAG_MDFLUSH | NETDATA_FLAG_CONTENT);
 }
 
@@ -2093,7 +2130,7 @@ uint64_t ebpf_parse_arguments(int argc, char **argv, int kver)
                 }
             case NETDATA_OPT_ALL:
                 {
-                    flags |= NETDATA_FLAG_ALL;
+                    flags |= NETDATA_FLAG_COLLECTORS;
                     break;
                 }
             case NETDATA_OPT_COMMON:
@@ -2171,7 +2208,7 @@ uint64_t ebpf_parse_arguments(int argc, char **argv, int kver)
     }
 
     // When user does not specify any flag, we will use common value
-    if (!(flags & (NETDATA_FLAG_ALL & ~NETDATA_FLAG_CONTENT)))
+    if (!(flags & NETDATA_FLAG_COLLECTORS))
         flags |= ebpf_set_common_flag();
 
     // The necessary tracepoint was made in kernel 4.14, so we cannot

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -41,6 +41,11 @@ static ebpf_specify_name_t swap_optional_name[] = { {.program_name = "netdata_sw
                                                       .fallback_function_to_attach = "swap_writepage",
                                                       .optional = NULL,
                                                       .retprobe = 0},
+                                                     {.program_name = "netdata_swap_writepage_buffer",
+                                                      .function_to_attach = "__swap_writepage",
+                                                      .fallback_function_to_attach = "swap_writepage",
+                                                      .optional = NULL,
+                                                      .retprobe = 0},
                                                      {.program_name = NULL,
                                                       .function_to_attach = NULL,
                                                       .fallback_function_to_attach = NULL,
@@ -56,6 +61,7 @@ ebpf_module_t ebpf_modules[] = {
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_15 | NETDATA_V5_14 | NETDATA_V5_16,
       .flags = NETDATA_FLAG_CACHESTAT, .name = "cachestat", .update_names = NULL, .ctrl_table = "cstat_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
       .flags = NETDATA_FLAG_DC, .name = "dc", .update_names = dc_optional_name, .ctrl_table = "dcstat_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_DISK, .name = "disk", .update_names = NULL, .ctrl_table = "disk_ctrl" },
@@ -78,16 +84,19 @@ ebpf_module_t ebpf_modules[] = {
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SOCKET, .name = "socket", .update_names = NULL, .ctrl_table = "socket_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
       .flags = NETDATA_FLAG_DNS, .name = "dns", .update_names = NULL, .ctrl_table = NULL },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_NFS, .name = "nfs", .update_names = NULL, .ctrl_table = "nfs_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_NETWORK_VIEWER, .name = "network_viewer", .update_names = NULL, .ctrl_table = "nv_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
       .flags = NETDATA_FLAG_OOMKILL, .name = "oomkill", .update_names = NULL, .ctrl_table = NULL },
     { .kernels =  NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14 | NETDATA_V5_10,
       .flags = NETDATA_FLAG_PROCESS, .name = "process", .update_names = NULL, .ctrl_table = "process_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
+      .buffer_kernels = NETDATA_V5_10 | NETDATA_V5_11 | NETDATA_V5_14 | NETDATA_V5_15 | NETDATA_V5_16 | NETDATA_V6_8,
       .flags = NETDATA_FLAG_SHM, .name = "shm", .update_names = NULL, .ctrl_table = "shm_ctrl" },
     { .kernels =  NETDATA_V3_10 | NETDATA_V4_14 | NETDATA_V4_16 | NETDATA_V4_18 | NETDATA_V5_4 | NETDATA_V5_14,
       .flags = NETDATA_FLAG_SOFTIRQ, .name = "softirq", .update_names = NULL, .ctrl_table = NULL },
@@ -1756,7 +1765,9 @@ static void ebpf_run_netdata_tests(int rhf_version, uint32_t kver, int is_return
             char *first_incompatible = NULL;
             int unsupported_type = 0;
             size_t j;
-            uint32_t idx = ebpf_select_index(ebpf_modules[i].kernels, rhf_version, kver);
+            uint32_t kernels_to_use = (buffer_mode && ebpf_modules[i].buffer_kernels) ?
+                                      ebpf_modules[i].buffer_kernels : ebpf_modules[i].kernels;
+            uint32_t idx = ebpf_select_index(kernels_to_use, rhf_version, kver);
             char *version = ebpf_select_kernel_name(idx);
 
             ebpf_discover_candidates(&candidates, ebpf_modules[i].name, is_return, version, rhf_version);

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -1904,7 +1904,7 @@ static void ebpf_help()
                     "                   software will use stderr.\n\n"
                     "--content          Test content stored inside hash tables.\n"
                     "--iteration        Number of iterations when content is read, default value is 1.\n"
-                    "--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, and 2 - All PID \n"
+                    "--pid              Specify the number that identifies PID  that will be monitored: 0 - Real Parent PID (Default), 1 - Parent PID, 2 - All PID, and 3 - Ignore PID (ring buffer mode).\n"
                     "--buffer           Test ring buffer versions of collectors (cachestat, dc, fd, oomkill, process, shm, swap, vfs, dns).\n\n"
                     "You can also specify an unique eBPF program developed by Netdata with the following\n"
                     "options:\n"
@@ -2130,7 +2130,7 @@ uint64_t ebpf_parse_arguments(int argc, char **argv, int kver)
                 }
             case NETDATA_OPT_ALL:
                 {
-                    flags |= NETDATA_FLAG_COLLECTORS;
+                    flags |= NETDATA_FLAG_COLLECTORS | NETDATA_FLAG_CONTENT;
                     break;
                 }
             case NETDATA_OPT_COMMON:

--- a/tests/tester_user.c
+++ b/tests/tester_user.c
@@ -1488,7 +1488,7 @@ static void ebpf_test_ringbuf_map(const char *name, int fd, uint32_t type, uint3
         size_t avail_data = 0;
         const char *error_message;
 
-        sleep(5);
+        sleep(10);
 
         if (type == BPF_MAP_TYPE_RINGBUF && rb) {
             struct ring *ring = ring_buffer__ring(rb, 0);
@@ -2197,6 +2197,7 @@ uint64_t ebpf_parse_arguments(int argc, char **argv, int kver)
             case NETDATA_OPT_BUFFER:
                 {
                     buffer_mode = 1;
+                    flags |= NETDATA_FLAG_CONTENT;
                     break;
                 }
         }

--- a/tests/tester_user.h
+++ b/tests/tester_user.h
@@ -168,6 +168,7 @@ typedef struct ebpf_specify_name {
 
 typedef struct ebpf_module {
     uint32_t kernels;
+    uint32_t buffer_kernels; /* kernel bitmask for buffer mode; 0 = use kernels */
     uint64_t flags;
     char *name;
     ebpf_specify_name_t *update_names;

--- a/tests/tester_user.h
+++ b/tests/tester_user.h
@@ -46,6 +46,7 @@ enum netdata_ebpf_kernel_versions {
     NETDATA_EBPF_KERNEL_5_0  = 327680,  //  327680 = 5 * 65536 +  0 * 256
     NETDATA_EBPF_KERNEL_5_2  = 328192,  //  328192 = 5 * 65536 +  2 * 256
     NETDATA_EBPF_KERNEL_5_4  = 328704,  //  328704 = 5 * 65536 +  4 * 256
+    NETDATA_EBPF_KERNEL_5_8  = 329728,  //  329728 = 5 * 65536 +  8 * 256
     NETDATA_EBPF_KERNEL_5_10 = 330240,  //  330240 = 5 * 65536 + 10 * 256
     NETDATA_EBPF_KERNEL_5_11 = 330496,  //  330496 = 5 * 65536 + 11 * 256
     NETDATA_EBPF_KERNEL_5_14 = 331264,  //  331264 = 5 * 65536 + 14 * 256
@@ -153,7 +154,8 @@ enum netdata_thread_OPT {
     NETDATA_OPT_LOG_PATH,
     NETDATA_OPT_CONTENT,
     NETDATA_OPT_ITERATION,
-    NETDATA_OPT_PID
+    NETDATA_OPT_PID,
+    NETDATA_OPT_BUFFER
 };
 
 typedef struct ebpf_specify_name {

--- a/tests/tester_user.h
+++ b/tests/tester_user.h
@@ -52,7 +52,8 @@ enum netdata_ebpf_kernel_versions {
     NETDATA_EBPF_KERNEL_5_14 = 331264,  //  331264 = 5 * 65536 + 14 * 256
     NETDATA_EBPF_KERNEL_5_15 = 331520,  //  331520 = 5 * 65536 + 15 * 256
     NETDATA_EBPF_KERNEL_5_16 = 331776,  //  331776 = 5 * 65536 + 16 * 256
-    NETDATA_EBPF_KERNEL_6_8  = 395264   //  395264 = 6 * 65536 +  8 * 256
+    NETDATA_EBPF_KERNEL_6_8  = 395264,  //  395264 = 6 * 65536 +  8 * 256
+    NETDATA_EBPF_KERNEL_6_12 = 396288   //  396288 = 6 * 65536 + 12 * 256
 };
 
 /**
@@ -72,7 +73,8 @@ enum netdata_kernel_flag {
     NETDATA_V5_14 = 1 <<  7,
     NETDATA_V5_15 = 1 <<  8,
     NETDATA_V5_16 = 1 <<  9,
-    NETDATA_V6_8  = 1 << 10
+    NETDATA_V6_8  = 1 << 10,
+    NETDATA_V6_12 = 1 << 11
 };
 
 enum netdata_kernel_counter {
@@ -87,6 +89,7 @@ enum netdata_kernel_counter {
     NETDATA_5_15,
     NETDATA_5_16,
     NETDATA_6_8,
+    NETDATA_6_12,
 
     NETDATA_VERSION_END
 };
@@ -118,7 +121,13 @@ enum netdata_thread_flag {
     NETDATA_FLAG_DNS = 1 << 23,
 
     NETDATA_FLAG_FS =  (uint64_t)(NETDATA_FLAG_BTRFS | NETDATA_FLAG_EXT4 | NETDATA_FLAG_VFS | NETDATA_FLAG_NFS | NETDATA_FLAG_XFS | NETDATA_FLAG_ZFS),
-    NETDATA_FLAG_ALL = 0XFFFFFFFFFFFFFFFF
+    NETDATA_FLAG_COLLECTORS = (uint64_t)(NETDATA_FLAG_BTRFS | NETDATA_FLAG_CACHESTAT | NETDATA_FLAG_DC | NETDATA_FLAG_DISK |
+                                         NETDATA_FLAG_EXT4 | NETDATA_FLAG_FD | NETDATA_FLAG_SYNC | NETDATA_FLAG_HARDIRQ |
+                                         NETDATA_FLAG_MDFLUSH | NETDATA_FLAG_MOUNT | NETDATA_FLAG_NETWORK_VIEWER |
+                                         NETDATA_FLAG_OOMKILL | NETDATA_FLAG_PROCESS | NETDATA_FLAG_SHM | NETDATA_FLAG_SOCKET |
+                                         NETDATA_FLAG_SOFTIRQ | NETDATA_FLAG_SWAP | NETDATA_FLAG_VFS | NETDATA_FLAG_NFS |
+                                         NETDATA_FLAG_XFS | NETDATA_FLAG_ZFS | NETDATA_FLAG_DNS),
+    NETDATA_FLAG_ALL = NETDATA_FLAG_COLLECTORS
 };
 
 enum netdata_thread_OPT {


### PR DESCRIPTION
##### Summary
Bring new collection mode to codebase (Buffer Ring).

##### Test Plan
1. Get binaries according to your C library from [this](ADD ACTIONS LINK HERE) link and extract them inside a directory, for example: `../artifacts`.
You can also get everything for `glibc` [here](UPLOAD FILE WITH ALL BINARIES TO SIMPLIFY REVIEWERS).

2. Extract them running:
    ```sh
    $ for i in `ls *.zip`; do unzip $i; rm .gitkeep ; rm $i; done
    $ for i in `ls *.tar`; do tar -xf $i; rm $i* ; done
    ```

3. Compile branch an run the following shell script:

    ```sh
    #!/bin/bash
    rm *.log 2> /dev/null
   ./tests/legacy_test --pid 3 --all --iteration 1 --log-path c_all.log --netdata-path ../artifacts/ 2> err_all >out_alll
   ./tests/legacy_test --buffer --iteration 1 --log-path c_buffer.log --netdata-path ../artifacts/ 2> err_buffer >out_buffer

   ./gotests/go_tester --pid 3 --all --iteration 1 --log-path go_all.log --netdata-path ../artifacts/ 2>> err >>out
   ./gotests/go_tester --buffer --iteration 1 --log-path go_buffer.log --netdata-path ../artifacts/ 2>> err >>out
    ```

4. Verify logs do not have errors.

##### Additional information

This PR was tested on:

| Linux Distribution |   Environment  |Kernel Version | 
|--------------------|----------------|---------------|
| Slackware Current  | Bare metal  | 6.18..24      |
|Arch Linux | VM| 6.19.14-arch1-1 |
|Debian 13| VM| 6.12.74+deb13+1|
|Ubuntu 24.04 | VM| 6.0.8 |
|Alma 9| VM | 5.14.0-611|
|Alma 8| VM | 4.18.0-55.120.1.el8_10|